### PR TITLE
fix: express use() return type

### DIFF
--- a/packages/infra-adapters/_src/express.ts
+++ b/packages/infra-adapters/_src/express.ts
@@ -307,7 +307,7 @@ export function match(method: Methods): {
 
 export function defaultExitHandler(
   _req: Request,
-  _res: Response,
+  res: Response,
   _next: NextFunction
 ): (cause: Cause<never>) => Effect<never, never, void> {
   return cause =>
@@ -315,7 +315,7 @@ export function defaultExitHandler(
       if (cause.isDie()) {
         console.error(cause.pretty)
       }
-      _res.status(500).end()
+      res.status(500).end()
     })
 }
 
@@ -324,8 +324,8 @@ export function use<
 >(
   ...handlers: Handlers
 ): Effect<
-  & ExpressEnv
-  & _R<
+  | ExpressEnv
+  | _R<
     {
       [k in keyof Handlers]: [Handlers[k]] extends [
         EffectRequestHandler<infer R, any, any, any, any, any>
@@ -354,7 +354,7 @@ export function use<
   never,
   void
 >
-export function use(...args: any[]): Effect<ExpressEnv, never, void> {
+export function use(...args: any[]) {
   return withExpressApp(app => {
     if (typeof args[0] === "function") {
       return expressRuntime(


### PR DESCRIPTION
Fix wrong return type of `use` function in:
https://github.com/effect-ts-app/libs/blob/d807a8ec102d017930bfbed2c89139a0c49d048c/packages/infra-adapters/_src/express.ts#L327-L346

```ts
export function use<
  Handlers extends NonEmptyArguments<EffectRequestHandler<any, any, any, any, any, any>>
>(
  ...handlers: Handlers
): Effect<
  & ExpressEnv // #L327-328 should be a wrong type
  & _R<
    {
      [k in keyof Handlers]: [Handlers[k]] extends [
        EffectRequestHandler<infer R, any, any, any, any, any>
      ] ? Effect<R, never, void>
        : never
    }[number]
  >,
  never,
  void
>
export function use<
  Handlers extends NonEmptyArguments<EffectRequestHandler<any, any, any, any, any, any>>
>(
  path: PathParams,
  ...handlers: Handlers
): Effect<
  | ExpressEnv // #L345-346 should be the correct type
  | _R<
    {
      [k in keyof Handlers]: [Handlers[k]] extends [
        EffectRequestHandler<infer R, any, any, any, any, any>
      ] ? Effect<R, never, void>
        : never
    }[number]
  >,
  never,
  void
>
···