### PR TITLE
feat(infra): add SQL Store adapter, and namespace support to CosmosDB

### DIFF
--- a/.changeset/cosmos-namespace-support.md
+++ b/.changeset/cosmos-namespace-support.md
@@ -1,0 +1,5 @@
+---
+"@effect-app/infra": minor
+---
+
+Add storage namespace support to CosmosDB adapter via partition key prefixing. When `allowNamespace` is configured, the namespace from `storeId` is prepended to partition key values (e.g., `test-ns::primary`), isolating data per namespace within the same container.

--- a/.changeset/sql-namespace-support.md
+++ b/.changeset/sql-namespace-support.md
@@ -1,0 +1,5 @@
+---
+"@effect-app/infra": minor
+---
+
+Add storage namespace support to SQL adapters (SQLite and Postgres) via a `_namespace` column. When `allowNamespace` is configured, a `_namespace` column with composite primary key `(id, _namespace)` isolates data per namespace within the same table. New tables get the schema automatically; existing tables require manual migration.

--- a/.changeset/sql-store-adapter.md
+++ b/.changeset/sql-store-adapter.md
@@ -1,0 +1,5 @@
+---
+"@effect-app/infra": minor
+---
+
+Add SQL Store adapter for Effect SQL (SQLite + PostgreSQL). Table-per-repo with id/etag/data JSON columns, query DSL translation to SQL WHERE clauses, optimistic concurrency via etag.

--- a/.changeset/sql-transaction-middleware.md
+++ b/.changeset/sql-transaction-middleware.md
@@ -2,4 +2,4 @@
 "@effect-app/infra": minor
 ---
 
-Make `withSqlTransaction` in `setupRequest` configurable via `withTransaction` option (defaults to `true`). Add `requiresTransactionConfig` and `makeSqlTransactionMiddleware` for per-RPC transaction control as a dynamic middleware that requires `SqlClient` directly.
+Make `withSqlTransaction` in `setupRequest` configurable via `withTransaction` option (defaults to `false`). Add `requiresTransactionConfig` and `makeSqlTransactionMiddleware` for per-RPC transaction control as a dynamic middleware that requires `SqlClient` directly. Transactions are disabled by default; opt in with `withTransaction: true` or `requiresTransaction: true`.

--- a/.changeset/sql-transaction-middleware.md
+++ b/.changeset/sql-transaction-middleware.md
@@ -1,0 +1,5 @@
+---
+"@effect-app/infra": minor
+---
+
+Make `withSqlTransaction` in `setupRequest` configurable via `withTransaction` option (defaults to `true`). Add `requiresTransactionConfig` and `makeSqlTransactionMiddleware` for per-RPC transaction control as a dynamic middleware that requires `SqlClient` directly.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "private": true,
   "pnpm": {
+    "onlyBuiltDependencies": ["better-sqlite3"],
     "patchedDependencies": {
       "ts-plugin-sort-import-suggestions": "patches/ts-plugin-sort-import-suggestions.patch",
       "@tanstack/query-core": "patches/@tanstack__query-core.patch",

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -18,13 +18,16 @@
   "devDependencies": {
     "@azure/cosmos": "^4.9.2",
     "@azure/service-bus": "^7.9.5",
+    "@effect-app/eslint-shared-config": "workspace:*",
     "@sentry/node": "10.47.0",
     "@sentry/opentelemetry": "10.47.0",
+    "@types/better-sqlite3": "^7.6.13",
     "@types/express": "^5.0.6",
     "@types/node": "25.5.2",
     "@types/proper-lockfile": "^4.1.4",
     "@types/redis": "^2.8.32",
     "@types/redlock": "^4.0.8",
+    "better-sqlite3": "^12.9.0",
     "express": "^5.2.1",
     "jwks-rsa": "2.1.4",
     "jwt-decode": "^4.0.0",
@@ -33,8 +36,7 @@
     "redlock": "^4.2.0",
     "strip-ansi": "^7.2.0",
     "typescript": "~6.0.2",
-    "vitest": "^4.1.3",
-    "@effect-app/eslint-shared-config": "workspace:*"
+    "vitest": "^4.1.3"
   },
   "peerDependencies": {
     "@azure/cosmos": "^4.9.2",
@@ -44,11 +46,11 @@
     "@sendgrid/mail": "^8.1.6",
     "@sentry/node": "10.47.0",
     "@sentry/opentelemetry": "10.47.0",
+    "effect": "^4.0.0-beta.47",
+    "express": "^5.2.1",
     "jwt-decode": "^4.0.0",
     "redis": "^3.1.2",
-    "redlock": "^4.2.0",
-    "effect": "^4.0.0-beta.47",
-    "express": "^5.2.1"
+    "redlock": "^4.2.0"
   },
   "typesVersions": {
     "*": {
@@ -225,6 +227,18 @@
     "./Store/Memory": {
       "types": "./dist/Store/Memory.d.ts",
       "default": "./dist/Store/Memory.js"
+    },
+    "./Store/SQL": {
+      "types": "./dist/Store/SQL.d.ts",
+      "default": "./dist/Store/SQL.js"
+    },
+    "./Store/SQL/query": {
+      "types": "./dist/Store/SQL/query.d.ts",
+      "default": "./dist/Store/SQL/query.js"
+    },
+    "./Store/SQL/Pg": {
+      "types": "./dist/Store/SQL/Pg.d.ts",
+      "default": "./dist/Store/SQL/Pg.js"
     },
     "./Store/codeFilter": {
       "types": "./dist/Store/codeFilter.d.ts",

--- a/packages/infra/src/Store/Cosmos.ts
+++ b/packages/infra/src/Store/Cosmos.ts
@@ -9,6 +9,7 @@ import { InfraLogger } from "../logger.js"
 import type { FieldValues } from "../Model/filter/types.js"
 import { type RawQuery } from "../Model/query.js"
 import { buildWhereCosmosQuery3, logQuery } from "./Cosmos/query.js"
+import { storeId } from "./Memory.js"
 import { type FilterArgs, type PersistenceModelType, type StorageConfig, type Store, type StoreConfig, StoreMaker } from "./service.js"
 
 const makeMapId =
@@ -50,7 +51,21 @@ function makeCosmosStore({ prefix }: StorageConfig) {
             }))
           )
 
-          const mainPartitionKey = config?.partitionValue() ?? "primary"
+          const basePartitionKey = config?.partitionValue() ?? "primary"
+          const nsPrefix = (ns: string) => ns === "primary" ? "" : `${ns}::`
+          const nsPartitionValue = (ns: string, e?: Encoded) => {
+            const base = config?.partitionValue(e) ?? "primary"
+            return `${nsPrefix(ns)}${base}`
+          }
+          const resolveNamespace = !config?.allowNamespace
+            ? Effect.succeed("primary")
+            : storeId.asEffect().pipe(Effect.map((namespace) => {
+              if (namespace !== "primary" && !config.allowNamespace!(namespace)) {
+                throw new Error(`Namespace ${namespace} not allowed!`)
+              }
+              return namespace
+            }))
+          const resolvePartitionKey = Effect.map(resolveNamespace, (ns) => `${nsPrefix(ns)}${basePartitionKey}`)
 
           const defaultValues = config?.defaultValues ?? {}
           const container = db.container(containerId)
@@ -63,6 +78,7 @@ function makeCosmosStore({ prefix }: StorageConfig) {
           const bulkSet = (items: NonEmptyReadonlyArray<PM>) =>
             Effect
               .gen(function*() {
+                const ns = yield* resolveNamespace
                 // TODO: disable batching if need atomicity
                 // we delay and batch to keep low amount of RUs
                 const b = [...items]
@@ -77,7 +93,7 @@ function makeCosmosStore({ prefix }: StorageConfig) {
                               resourceBody: {
                                 ...Struct.omit(x, ["_etag", idKey]),
                                 id: x[idKey],
-                                _partitionKey: config?.partitionValue(x)
+                                _partitionKey: nsPartitionValue(ns, x)
                               }
                               // don't use this or we get an error that the request and some item partition key dont match - makese no sense
                               // partitionKey: config?.partitionValue(x)
@@ -89,7 +105,7 @@ function makeCosmosStore({ prefix }: StorageConfig) {
                               resourceBody: {
                                 ...Struct.omit(x, ["_etag", idKey]),
                                 id: x[idKey],
-                                _partitionKey: config?.partitionValue(x)
+                                _partitionKey: nsPartitionValue(ns, x)
                               },
                               ifMatch: eTag
                               // don't use this or we get an error that the request and some item partition key dont match - makese no sense
@@ -166,65 +182,68 @@ function makeCosmosStore({ prefix }: StorageConfig) {
               }, { captureStackTrace: false }))
 
           const batchSet = (items: NonEmptyReadonlyArray<PM>) => {
-            return Effect
-              .suspend(() => {
-                const batch = [...items].map(
-                  (x) =>
-                    [
-                      x,
-                      Option.match(Option.fromNullishOr(x._etag), {
-                        onNone: () => ({
-                          operationType: "Create" as const,
-                          resourceBody: {
-                            ...Struct.omit(x, ["_etag", idKey]),
-                            id: x[idKey],
-                            _partitionKey: config?.partitionValue(x)
-                          }
-                          // don't use this or we get an error that the request and some item partition key dont match - makese no sense
-                          // partitionKey: config?.partitionValue(x)
-                        }),
-                        onSome: (eTag) => ({
-                          operationType: "Replace" as const,
-                          id: x[idKey],
-                          resourceBody: {
-                            ...Struct.omit(x, ["_etag", idKey]),
-                            id: x[idKey],
-                            _partitionKey: config?.partitionValue(x)
-                          },
-                          // don't use this or we get an error that the request and some item partition key dont match - makese no sense
-                          // partitionKey: config?.partitionValue(x)
-                          ifMatch: eTag
-                        })
-                      })
-                    ] as const
-                )
-
-                const ex = batch.map(([, c]) => c)
-
-                return Effect
-                  .promise(() => execBatch(ex, ex[0]?.resourceBody._partitionKey))
-                  .pipe(Effect.flatMap(Effect.fnUntraced(function*(x) {
-                    const result = x.result ?? []
-                    const firstFailed = result.find(
-                      (x: any) => x.statusCode > 299 || x.statusCode < 200
+            return resolveNamespace
+              .pipe(Effect.flatMap((ns) =>
+                Effect
+                  .suspend(() => {
+                    const batch = [...items].map(
+                      (x) =>
+                        [
+                          x,
+                          Option.match(Option.fromNullishOr(x._etag), {
+                            onNone: () => ({
+                              operationType: "Create" as const,
+                              resourceBody: {
+                                ...Struct.omit(x, ["_etag", idKey]),
+                                id: x[idKey],
+                                _partitionKey: nsPartitionValue(ns, x)
+                              }
+                              // don't use this or we get an error that the request and some item partition key dont match - makese no sense
+                              // partitionKey: config?.partitionValue(x)
+                            }),
+                            onSome: (eTag) => ({
+                              operationType: "Replace" as const,
+                              id: x[idKey],
+                              resourceBody: {
+                                ...Struct.omit(x, ["_etag", idKey]),
+                                id: x[idKey],
+                                _partitionKey: nsPartitionValue(ns, x)
+                              },
+                              // don't use this or we get an error that the request and some item partition key dont match - makese no sense
+                              // partitionKey: config?.partitionValue(x)
+                              ifMatch: eTag
+                            })
+                          })
+                        ] as const
                     )
-                    if (firstFailed) {
-                      const code = firstFailed.statusCode ?? 0
-                      if (code === 412 || code === 404 || code === 409) {
-                        return yield* new OptimisticConcurrencyException({ type: name, id: "batch", code })
-                      }
 
-                      return yield* Effect.die(
-                        new CosmosDbOperationError("not able to update record: " + code)
-                      )
-                    }
+                    const ex = batch.map(([, c]) => c)
 
-                    return batch.map(([e], i) => ({
-                      ...e,
-                      _etag: result[i]?.eTag
-                    })) as unknown as NonEmptyReadonlyArray<Encoded>
-                  })))
-              })
+                    return Effect
+                      .promise(() => execBatch(ex, ex[0]?.resourceBody._partitionKey))
+                      .pipe(Effect.flatMap(Effect.fnUntraced(function*(x) {
+                        const result = x.result ?? []
+                        const firstFailed = result.find(
+                          (x: any) => x.statusCode > 299 || x.statusCode < 200
+                        )
+                        if (firstFailed) {
+                          const code = firstFailed.statusCode ?? 0
+                          if (code === 412 || code === 404 || code === 409) {
+                            return yield* new OptimisticConcurrencyException({ type: name, id: "batch", code })
+                          }
+
+                          return yield* Effect.die(
+                            new CosmosDbOperationError("not able to update record: " + code)
+                          )
+                        }
+
+                        return batch.map(([e], i) => ({
+                          ...e,
+                          _etag: result[i]?.eTag
+                        })) as unknown as NonEmptyReadonlyArray<Encoded>
+                      })))
+                  })
+              ))
               .pipe(Effect
                 .withSpan("Cosmos.batchSet [effect-app/infra/Store]", {
                   attributes: { "repository.container_id": containerId, "repository.model_name": name }
@@ -234,14 +253,14 @@ function makeCosmosStore({ prefix }: StorageConfig) {
           const s: Store<IdKey, Encoded> = {
             queryRaw: <Out>(query: RawQuery<Encoded, Out>) =>
               Effect
-                .sync(() => query.cosmos({ name }))
+                .all({ q: Effect.sync(() => query.cosmos({ name })), pk: resolvePartitionKey })
                 .pipe(
-                  Effect.tap((q) => logQuery(q)),
-                  Effect.flatMap((q) =>
+                  Effect.tap(({ q }) => logQuery(q)),
+                  Effect.flatMap(({ pk, q }) =>
                     Effect.promise(() =>
                       container
                         .items
-                        .query<Out>(q, { partitionKey: mainPartitionKey })
+                        .query<Out>(q, { partitionKey: pk })
                         .fetchAll()
                         .then(({ resources }) =>
                           resources.map(
@@ -256,31 +275,36 @@ function makeCosmosStore({ prefix }: StorageConfig) {
                     }, { captureStackTrace: false })
                 ),
             batchRemove: (ids, partitionKey?: string) =>
-              Effect.promise(() =>
-                execBatch(
-                  mutable(ids.map((id) =>
-                    dropUndefinedT({
-                      operationType: "Delete" as const,
-                      id
-                      // don't use this or we get an error that the request and some item partition key dont match - makese no sense
-                      // partitionKey: config?.partitionValue({ [idKey]: id } as Encoded)
-                    })
-                  )),
-                  partitionKey ?? mainPartitionKey
+              resolvePartitionKey.pipe(Effect.flatMap((pk) =>
+                Effect.promise(() =>
+                  execBatch(
+                    mutable(ids.map((id) =>
+                      dropUndefinedT({
+                        operationType: "Delete" as const,
+                        id
+                        // don't use this or we get an error that the request and some item partition key dont match - makese no sense
+                        // partitionKey: config?.partitionValue({ [idKey]: id } as Encoded)
+                      })
+                    )),
+                    partitionKey ?? pk
+                  )
                 )
-              ),
+              )),
             all: Effect
-              .sync(() => ({
-                query: `SELECT * FROM ${name}`,
-                parameters: []
-              }))
+              .all({
+                q: Effect.sync(() => ({
+                  query: `SELECT * FROM ${name}`,
+                  parameters: []
+                })),
+                pk: resolvePartitionKey
+              })
               .pipe(
-                Effect.tap((q) => logQuery(q)),
-                Effect.flatMap((q) =>
+                Effect.tap(({ q }) => logQuery(q)),
+                Effect.flatMap(({ pk, q }) =>
                   Effect.promise(() =>
                     container
                       .items
-                      .query<PMCosmos>(q, { partitionKey: mainPartitionKey })
+                      .query<PMCosmos>(q, { partitionKey: pk })
                       .fetchAll()
                       .then(({ resources }) =>
                         resources.map(
@@ -305,27 +329,32 @@ function makeCosmosStore({ prefix }: StorageConfig) {
               const filter = f.filter
               type M = U extends undefined ? Encoded : Pick<Encoded, U>
               return Effect
-                .sync(() =>
-                  buildWhereCosmosQuery3(
-                    idKey,
-                    filter ? [{ t: "where-scope", result: filter, relation: "some" }] : [],
-                    name,
-                    defaultValues,
-                    f.select as NonEmptyReadonlyArray<string | { key: string; subKeys: readonly string[] }> | undefined,
-                    f.order as NonEmptyReadonlyArray<{ key: string; direction: "ASC" | "DESC" }> | undefined,
-                    skip,
-                    limit
-                  )
-                )
+                .all({
+                  q: Effect.sync(() =>
+                    buildWhereCosmosQuery3(
+                      idKey,
+                      filter ? [{ t: "where-scope", result: filter, relation: "some" }] : [],
+                      name,
+                      defaultValues,
+                      f.select as
+                        | NonEmptyReadonlyArray<string | { key: string; subKeys: readonly string[] }>
+                        | undefined,
+                      f.order as NonEmptyReadonlyArray<{ key: string; direction: "ASC" | "DESC" }> | undefined,
+                      skip,
+                      limit
+                    )
+                  ),
+                  pk: resolvePartitionKey
+                })
                 .pipe(
-                  Effect.tap((q) => logQuery(q)),
+                  Effect.tap(({ q }) => logQuery(q)),
                   Effect
-                    .flatMap((q) =>
+                    .flatMap(({ pk, q }) =>
                       Effect.promise(() =>
                         f.select
                           ? container
                             .items
-                            .query<M>(q, { partitionKey: mainPartitionKey })
+                            .query<M>(q, { partitionKey: pk })
                             .fetchAll()
                             .then(({ resources }) =>
                               resources.map((_) => ({
@@ -338,7 +367,7 @@ function makeCosmosStore({ prefix }: StorageConfig) {
                             )
                           : container
                             .items
-                            .query<{ f: M }>(q, { partitionKey: mainPartitionKey })
+                            .query<{ f: M }>(q, { partitionKey: pk })
                             .fetchAll()
                             .then(({ resources }) =>
                               resources.map(({ f }) => ({ ...defaultValues, ...mapReverseId(f as any) }) as any)
@@ -353,80 +382,86 @@ function makeCosmosStore({ prefix }: StorageConfig) {
                 )
             },
             find: (id) =>
-              Effect
-                .promise(() =>
-                  container
-                    .item(id, config?.partitionValue({ [idKey]: id } as Encoded))
-                    .read<Encoded>()
-                    .then(({ resource }) =>
-                      Option.fromNullishOr(resource).pipe(Option.map((_) => ({ ...defaultValues, ...mapReverseId(_) })))
-                    )
-                )
-                .pipe(Effect
-                  .withSpan("Cosmos.find [effect-app/infra/Store]", {
-                    attributes: {
-                      "repository.container_id": containerId,
-                      "repository.model_name": name,
-                      partitionValue: config?.partitionValue({ [idKey]: id } as Encoded),
-                      id
-                    }
-                  }, { captureStackTrace: false })),
-            set: (e) =>
-              Option
-                .match(
-                  Option
-                    .fromNullishOr(e._etag),
-                  {
-                    onNone: () =>
-                      Effect.promise(() =>
-                        container.items.create({
-                          ...mapId(e),
-                          _partitionKey: config?.partitionValue(e)
-                        })
-                      ),
-                    onSome: (eTag) =>
-                      Effect.promise(() =>
-                        container.item(e[idKey], config?.partitionValue(e)).replace(
-                          { ...mapId(e), _partitionKey: config?.partitionValue(e) },
-                          {
-                            accessCondition: {
-                              type: "IfMatch",
-                              condition: eTag
-                            }
-                          }
+              resolveNamespace.pipe(Effect.flatMap((ns) =>
+                Effect
+                  .promise(() =>
+                    container
+                      .item(id, nsPartitionValue(ns, { [idKey]: id } as Encoded))
+                      .read<Encoded>()
+                      .then(({ resource }) =>
+                        Option.fromNullishOr(resource).pipe(
+                          Option.map((_) => ({ ...defaultValues, ...mapReverseId(_) }))
                         )
                       )
-                  }
-                )
-                .pipe(
-                  Effect
-                    .flatMap((x) => {
-                      if (x.statusCode === 412 || x.statusCode === 404 || x.statusCode === 409) {
-                        return Effect.fail(
-                          new OptimisticConcurrencyException({ type: name, id: e[idKey], code: x.statusCode })
-                        )
-                      }
-                      if (x.statusCode > 299 || x.statusCode < 200) {
-                        return Effect.die(
-                          new CosmosDbOperationError(
-                            "not able to update record: " + x.statusCode
-                          )
-                        )
-                      }
-                      return Effect.sync(() => ({
-                        ...e,
-                        _etag: x.etag
-                      }))
-                    }),
-                  Effect
-                    .withSpan("Cosmos.set [effect-app/infra/Store]", {
+                  )
+                  .pipe(Effect
+                    .withSpan("Cosmos.find [effect-app/infra/Store]", {
                       attributes: {
                         "repository.container_id": containerId,
                         "repository.model_name": name,
-                        id: e[idKey]
+                        partitionValue: nsPartitionValue(ns, { [idKey]: id } as Encoded),
+                        id
                       }
-                    }, { captureStackTrace: false })
-                ),
+                    }, { captureStackTrace: false }))
+              )),
+            set: (e) =>
+              resolveNamespace.pipe(Effect.flatMap((ns) =>
+                Option
+                  .match(
+                    Option
+                      .fromNullishOr(e._etag),
+                    {
+                      onNone: () =>
+                        Effect.promise(() =>
+                          container.items.create({
+                            ...mapId(e),
+                            _partitionKey: nsPartitionValue(ns, e)
+                          })
+                        ),
+                      onSome: (eTag) =>
+                        Effect.promise(() =>
+                          container.item(e[idKey], nsPartitionValue(ns, e)).replace(
+                            { ...mapId(e), _partitionKey: nsPartitionValue(ns, e) },
+                            {
+                              accessCondition: {
+                                type: "IfMatch",
+                                condition: eTag
+                              }
+                            }
+                          )
+                        )
+                    }
+                  )
+                  .pipe(
+                    Effect
+                      .flatMap((x) => {
+                        if (x.statusCode === 412 || x.statusCode === 404 || x.statusCode === 409) {
+                          return Effect.fail(
+                            new OptimisticConcurrencyException({ type: name, id: e[idKey], code: x.statusCode })
+                          )
+                        }
+                        if (x.statusCode > 299 || x.statusCode < 200) {
+                          return Effect.die(
+                            new CosmosDbOperationError(
+                              "not able to update record: " + x.statusCode
+                            )
+                          )
+                        }
+                        return Effect.sync(() => ({
+                          ...e,
+                          _etag: x.etag
+                        }))
+                      }),
+                    Effect
+                      .withSpan("Cosmos.set [effect-app/infra/Store]", {
+                        attributes: {
+                          "repository.container_id": containerId,
+                          "repository.model_name": name,
+                          id: e[idKey]
+                        }
+                      }, { captureStackTrace: false })
+                  )
+              )),
             batchSet,
             bulkSet
           }

--- a/packages/infra/src/Store/SQL.ts
+++ b/packages/infra/src/Store/SQL.ts
@@ -147,17 +147,33 @@ function makeSQLStoreInt(dialect: SQLDialect, jsonColumnType: string) {
                                 .params
                                 .length + 1
                             )
-                          const hasWhere = q.sql.includes("WHERE")
+                          const hasWhere = q
+                            .sql
+                            .includes("WHERE")
                           const nsSql = hasWhere
-                            ? q.sql.replace("WHERE", `WHERE _namespace = ${nsPlaceholder} AND`)
-                            : q.sql.replace(
-                              `FROM "${tableName}"`,
-                              `FROM "${tableName}" WHERE _namespace = ${nsPlaceholder}`
-                            )
-                          return { sql: nsSql, params: [...q.params, ns] }
+                            ? q
+                              .sql
+                              .replace("WHERE", `WHERE _namespace = ${nsPlaceholder} AND`)
+                            : q
+                              .sql
+                              .replace(
+                                `FROM "${tableName}"`,
+                                `FROM "${tableName}" WHERE _namespace = ${nsPlaceholder}`
+                              )
+                          return {
+                            sql: nsSql,
+                            params: [
+                              ...q
+                                .params,
+                              ns
+                            ]
+                          }
                         })
                         .pipe(
-                          Effect.tap((q) => logQuery(q)),
+                          Effect
+                            .tap((q) =>
+                              logQuery(q)
+                            ),
                           Effect.flatMap((q) =>
                             exec(q.sql, q.params).pipe(
                               Effect.map((rows) => {

--- a/packages/infra/src/Store/SQL.ts
+++ b/packages/infra/src/Store/SQL.ts
@@ -6,6 +6,7 @@ import { SqlClient } from "effect/unstable/sql"
 import { OptimisticConcurrencyException } from "../errors.js"
 import { InfraLogger } from "../logger.js"
 import type { FieldValues } from "../Model/filter/types.js"
+import { storeId } from "./Memory.js"
 import { type FilterArgs, type PersistenceModelType, type StorageConfig, type Store, type StoreConfig, StoreMaker } from "./service.js"
 import { buildWhereSQLQuery, logQuery, type SQLDialect, sqliteDialect } from "./SQL/query.js"
 import { makeETag } from "./utils.js"
@@ -57,9 +58,18 @@ function makeSQLStoreInt(dialect: SQLDialect, jsonColumnType: string) {
             const tableName = `${prefix}${name}`
             const defaultValues = config?.defaultValues ?? {}
 
+            const resolveNamespace = !config?.allowNamespace
+              ? Effect.succeed("primary")
+              : storeId.asEffect().pipe(Effect.map((namespace) => {
+                if (namespace !== "primary" && !config.allowNamespace!(namespace)) {
+                  throw new Error(`Namespace ${namespace} not allowed!`)
+                }
+                return namespace
+              }))
+
             yield* sql
               .unsafe(
-                `CREATE TABLE IF NOT EXISTS "${tableName}" (id TEXT PRIMARY KEY, _etag TEXT, data ${jsonColumnType} NOT NULL)`
+                `CREATE TABLE IF NOT EXISTS "${tableName}" (id TEXT NOT NULL, _namespace TEXT NOT NULL DEFAULT 'primary', _etag TEXT, data ${jsonColumnType} NOT NULL, PRIMARY KEY (id, _namespace))`
               )
               .pipe(Effect.orDie)
 
@@ -74,119 +84,153 @@ function makeSQLStoreInt(dialect: SQLDialect, jsonColumnType: string) {
               sql.unsafe(query, params as any).pipe(Effect.orDie)
 
             const s: Store<IdKey, Encoded> = {
-              all: exec(`SELECT id, _etag, data FROM "${tableName}"`)
-                .pipe(
-                  Effect.map((rows) => (rows as any[]).map((r) => parseRow<Encoded>(r, defaultValues))),
-                  Effect.withSpan("SQL.all [effect-app/infra/Store]", {
-                    attributes: { "repository.table_name": tableName, "repository.model_name": name }
-                  }, { captureStackTrace: false })
-                ),
+              all: resolveNamespace.pipe(Effect.flatMap((ns) =>
+                exec(`SELECT id, _etag, data FROM "${tableName}" WHERE _namespace = ?`, [ns])
+                  .pipe(
+                    Effect.map((rows) => (rows as any[]).map((r) => parseRow<Encoded>(r, defaultValues))),
+                    Effect.withSpan("SQL.all [effect-app/infra/Store]", {
+                      attributes: {
+                        "repository.table_name": tableName,
+                        "repository.model_name": name,
+                        "repository.namespace": ns
+                      }
+                    }, { captureStackTrace: false })
+                  )
+              )),
 
               find: (id) =>
-                exec(`SELECT id, _etag, data FROM "${tableName}" WHERE id = ?`, [id])
-                  .pipe(
-                    Effect.map((rows) => {
-                      const row = (rows as any[])[0]
-                      return row
-                        ? Option.some(parseRow<Encoded>(row, defaultValues))
-                        : Option.none()
-                    }),
-                    Effect.withSpan("SQL.find [effect-app/infra/Store]", {
-                      attributes: { "repository.table_name": tableName, "repository.model_name": name, id }
-                    }, { captureStackTrace: false })
-                  ),
+                resolveNamespace.pipe(Effect.flatMap((ns) =>
+                  exec(`SELECT id, _etag, data FROM "${tableName}" WHERE id = ? AND _namespace = ?`, [id, ns])
+                    .pipe(
+                      Effect.map((rows) => {
+                        const row = (rows as any[])[0]
+                        return row
+                          ? Option.some(parseRow<Encoded>(row, defaultValues))
+                          : Option.none()
+                      }),
+                      Effect.withSpan("SQL.find [effect-app/infra/Store]", {
+                        attributes: { "repository.table_name": tableName, "repository.model_name": name, id }
+                      }, { captureStackTrace: false })
+                    )
+                )),
 
               filter: <U extends keyof Encoded = never>(f: FilterArgs<Encoded, U>) => {
-                const filter = f.filter
-                type M = U extends undefined ? Encoded : Pick<Encoded, U>
-                return Effect
-                  .sync(() =>
-                    buildWhereSQLQuery(
-                      dialect,
-                      idKey,
-                      filter ? [{ t: "where-scope", result: filter, relation: "some" }] : [],
-                      tableName,
-                      defaultValues,
-                      f.select as
-                        | NonEmptyReadonlyArray<string | { key: string; subKeys: readonly string[] }>
-                        | undefined,
-                      f.order as NonEmptyReadonlyArray<{ key: string; direction: "ASC" | "DESC" }> | undefined,
-                      f.skip,
-                      f.limit
-                    )
-                  )
-                  .pipe(
-                    Effect.tap((q) => logQuery(q)),
-                    Effect.flatMap((q) =>
-                      exec(q.sql, q.params).pipe(
-                        Effect.map((rows) => {
-                          if (f.select) {
-                            return (rows as any[]).map((r) => {
-                              const selected = parseSelectRow(r, idKey, {})
-                              return {
-                                ...Struct.pick(
-                                  defaultValues as any,
-                                  f.select!.filter((_) => typeof _ === "string") as never[]
-                                ),
-                                ...selected
-                              } as M
-                            })
-                          }
-                          return (rows as any[]).map((r) => parseRow<Encoded>(r, defaultValues) as any as M)
+                const filter = f
+                  .filter
+                type M = U extends undefined ? Encoded
+                  : Pick<Encoded, U>
+                return resolveNamespace
+                  .pipe(Effect
+                    .flatMap((ns) =>
+                      Effect
+                        .sync(() => {
+                          const q = buildWhereSQLQuery(
+                            dialect,
+                            idKey,
+                            filter ? [{ t: "where-scope", result: filter, relation: "some" }] : [],
+                            tableName,
+                            defaultValues,
+                            f
+                              .select as
+                                | NonEmptyReadonlyArray<string | { key: string; subKeys: readonly string[] }>
+                                | undefined,
+                            f
+                              .order as NonEmptyReadonlyArray<{ key: string; direction: "ASC" | "DESC" }> | undefined,
+                            f
+                              .skip,
+                            f
+                              .limit
+                          )
+                          const nsPlaceholder = dialect
+                            .placeholder(
+                              q
+                                .params
+                                .length + 1
+                            )
+                          const hasWhere = q.sql.includes("WHERE")
+                          const nsSql = hasWhere
+                            ? q.sql.replace("WHERE", `WHERE _namespace = ${nsPlaceholder} AND`)
+                            : q.sql.replace(
+                              `FROM "${tableName}"`,
+                              `FROM "${tableName}" WHERE _namespace = ${nsPlaceholder}`
+                            )
+                          return { sql: nsSql, params: [...q.params, ns] }
                         })
-                      )
-                    ),
-                    Effect.withSpan("SQL.filter [effect-app/infra/Store]", {
-                      attributes: { "repository.table_name": tableName, "repository.model_name": name }
-                    }, { captureStackTrace: false })
-                  )
+                        .pipe(
+                          Effect.tap((q) => logQuery(q)),
+                          Effect.flatMap((q) =>
+                            exec(q.sql, q.params).pipe(
+                              Effect.map((rows) => {
+                                if (f.select) {
+                                  return (rows as any[]).map((r) => {
+                                    const selected = parseSelectRow(r, idKey, {})
+                                    return {
+                                      ...Struct.pick(
+                                        defaultValues as any,
+                                        f.select!.filter((_) => typeof _ === "string") as never[]
+                                      ),
+                                      ...selected
+                                    } as M
+                                  })
+                                }
+                                return (rows as any[]).map((r) => parseRow<Encoded>(r, defaultValues) as any as M)
+                              })
+                            )
+                          ),
+                          Effect.withSpan("SQL.filter [effect-app/infra/Store]", {
+                            attributes: { "repository.table_name": tableName, "repository.model_name": name }
+                          }, { captureStackTrace: false })
+                        )
+                    ))
               },
 
               set: (e) =>
-                Effect
-                  .gen(function*() {
-                    const row = toRow(e)
-                    if (e._etag) {
-                      yield* exec(
-                        `UPDATE "${tableName}" SET _etag = ?, data = ? WHERE id = ? AND _etag = ?`,
-                        [row._etag, row.data, row.id, e._etag]
-                      )
-                      const existing = yield* exec(
-                        `SELECT _etag FROM "${tableName}" WHERE id = ?`,
-                        [row.id]
-                      )
-                      const current = (existing as any[])[0]
-                      if (!current || current._etag !== row._etag) {
-                        if (current) {
+                resolveNamespace.pipe(Effect.flatMap((ns) =>
+                  Effect
+                    .gen(function*() {
+                      const row = toRow(e)
+                      if (e._etag) {
+                        yield* exec(
+                          `UPDATE "${tableName}" SET _etag = ?, data = ? WHERE id = ? AND _etag = ? AND _namespace = ?`,
+                          [row._etag, row.data, row.id, e._etag, ns]
+                        )
+                        const existing = yield* exec(
+                          `SELECT _etag FROM "${tableName}" WHERE id = ? AND _namespace = ?`,
+                          [row.id, ns]
+                        )
+                        const current = (existing as any[])[0]
+                        if (!current || current._etag !== row._etag) {
+                          if (current) {
+                            return yield* new OptimisticConcurrencyException({
+                              type: name,
+                              id: row.id,
+                              current: current._etag,
+                              found: e._etag,
+                              code: 412
+                            })
+                          }
                           return yield* new OptimisticConcurrencyException({
                             type: name,
                             id: row.id,
-                            current: current._etag,
+                            current: "",
                             found: e._etag,
-                            code: 412
+                            code: 404
                           })
                         }
-                        return yield* new OptimisticConcurrencyException({
-                          type: name,
-                          id: row.id,
-                          current: "",
-                          found: e._etag,
-                          code: 404
-                        })
+                      } else {
+                        yield* exec(
+                          `INSERT INTO "${tableName}" (id, _namespace, _etag, data) VALUES (?, ?, ?, ?)`,
+                          [row.id, ns, row._etag, row.data]
+                        )
                       }
-                    } else {
-                      yield* exec(
-                        `INSERT INTO "${tableName}" (id, _etag, data) VALUES (?, ?, ?)`,
-                        [row.id, row._etag, row.data]
-                      )
-                    }
-                    return row.item
-                  })
-                  .pipe(
-                    Effect.withSpan("SQL.set [effect-app/infra/Store]", {
-                      attributes: { "repository.table_name": tableName, "repository.model_name": name, id: e[idKey] }
-                    }, { captureStackTrace: false })
-                  ),
+                      return row.item
+                    })
+                    .pipe(
+                      Effect.withSpan("SQL.set [effect-app/infra/Store]", {
+                        attributes: { "repository.table_name": tableName, "repository.model_name": name, id: e[idKey] }
+                      }, { captureStackTrace: false })
+                    )
+                )),
 
               batchSet: (items) =>
                 sql
@@ -216,16 +260,18 @@ function makeSQLStoreInt(dialect: SQLDialect, jsonColumnType: string) {
 
               batchRemove: (ids) => {
                 const placeholders = ids.map(() => "?").join(", ")
-                return exec(
-                  `DELETE FROM "${tableName}" WHERE id IN (${placeholders})`,
-                  [...ids]
-                )
-                  .pipe(
-                    Effect.asVoid,
-                    Effect.withSpan("SQL.batchRemove [effect-app/infra/Store]", {
-                      attributes: { "repository.table_name": tableName, "repository.model_name": name }
-                    }, { captureStackTrace: false })
+                return resolveNamespace.pipe(Effect.flatMap((ns) =>
+                  exec(
+                    `DELETE FROM "${tableName}" WHERE id IN (${placeholders}) AND _namespace = ?`,
+                    [...ids, ns]
                   )
+                    .pipe(
+                      Effect.asVoid,
+                      Effect.withSpan("SQL.batchRemove [effect-app/infra/Store]", {
+                        attributes: { "repository.table_name": tableName, "repository.model_name": name }
+                      }, { captureStackTrace: false })
+                    )
+                ))
               },
 
               queryRaw: (query) =>
@@ -238,7 +284,10 @@ function makeSQLStoreInt(dialect: SQLDialect, jsonColumnType: string) {
             }
 
             if (seed) {
-              const existing = yield* exec(`SELECT COUNT(*) as cnt FROM "${tableName}"`)
+              const existing = yield* exec(
+                `SELECT COUNT(*) as cnt FROM "${tableName}" WHERE _namespace = ?`,
+                ["primary"]
+              )
               const count = (existing as any[])[0]?.cnt ?? 0
               if (count === 0) {
                 yield* InfraLogger.logInfo("Seeding data for " + name)

--- a/packages/infra/src/Store/SQL.ts
+++ b/packages/infra/src/Store/SQL.ts
@@ -1,0 +1,262 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { Effect, type NonEmptyReadonlyArray, Option, Struct } from "effect-app"
+import { toNonEmptyArray } from "effect-app/Array"
+import { SqlClient } from "effect/unstable/sql"
+import { OptimisticConcurrencyException } from "../errors.js"
+import { InfraLogger } from "../logger.js"
+import type { FieldValues } from "../Model/filter/types.js"
+import { type FilterArgs, type PersistenceModelType, type StorageConfig, type Store, type StoreConfig, StoreMaker } from "./service.js"
+import { buildWhereSQLQuery, logQuery, type SQLDialect, sqliteDialect } from "./SQL/query.js"
+import { makeETag } from "./utils.js"
+
+const parseRow = <Encoded extends FieldValues>(
+  row: { id: string; _etag: string | null; data: string },
+  defaultValues: Partial<Encoded>
+): PersistenceModelType<Encoded> => {
+  const data = (typeof row.data === "string" ? JSON.parse(row.data) : row.data) as object
+  return { ...defaultValues, ...data, _etag: row._etag ?? undefined } as PersistenceModelType<Encoded>
+}
+
+const parseSelectRow = <Encoded extends FieldValues>(
+  row: Record<string, unknown>,
+  idKey: PropertyKey,
+  defaultValues: Partial<Encoded>
+): any => {
+  const result: Record<string, unknown> = { ...defaultValues }
+  for (const [key, value] of Object.entries(row)) {
+    if (key === "id") {
+      result[idKey as string] = value
+      result["id"] = value
+    } else if (typeof value === "string") {
+      try {
+        result[key] = JSON.parse(value)
+      } catch {
+        result[key] = value
+      }
+    } else {
+      result[key] = value
+    }
+  }
+  return result
+}
+
+function makeSQLStoreInt(dialect: SQLDialect, jsonColumnType: string) {
+  return ({ prefix }: StorageConfig) =>
+    Effect.gen(function*() {
+      const sql = yield* SqlClient.SqlClient
+      return {
+        make: <IdKey extends keyof Encoded, Encoded extends FieldValues, R = never, E = never>(
+          name: string,
+          idKey: IdKey,
+          seed?: Effect.Effect<Iterable<Encoded>, E, R>,
+          config?: StoreConfig<Encoded>
+        ) =>
+          Effect.gen(function*() {
+            type PM = PersistenceModelType<Encoded>
+            const tableName = `${prefix}${name}`
+            const defaultValues = config?.defaultValues ?? {}
+
+            yield* sql
+              .unsafe(
+                `CREATE TABLE IF NOT EXISTS "${tableName}" (id TEXT PRIMARY KEY, _etag TEXT, data ${jsonColumnType} NOT NULL)`
+              )
+              .pipe(Effect.orDie)
+
+            const toRow = (e: PM) => {
+              const newE = makeETag(e)
+              const id = newE[idKey] as string
+              const data = JSON.stringify(newE)
+              return { id, _etag: newE._etag!, data, item: newE }
+            }
+
+            const exec = (query: string, params?: readonly unknown[]) =>
+              sql.unsafe(query, params as any).pipe(Effect.orDie)
+
+            const s: Store<IdKey, Encoded> = {
+              all: exec(`SELECT id, _etag, data FROM "${tableName}"`)
+                .pipe(
+                  Effect.map((rows) => (rows as any[]).map((r) => parseRow<Encoded>(r, defaultValues))),
+                  Effect.withSpan("SQL.all [effect-app/infra/Store]", {
+                    attributes: { "repository.table_name": tableName, "repository.model_name": name }
+                  }, { captureStackTrace: false })
+                ),
+
+              find: (id) =>
+                exec(`SELECT id, _etag, data FROM "${tableName}" WHERE id = ?`, [id])
+                  .pipe(
+                    Effect.map((rows) => {
+                      const row = (rows as any[])[0]
+                      return row
+                        ? Option.some(parseRow<Encoded>(row, defaultValues))
+                        : Option.none()
+                    }),
+                    Effect.withSpan("SQL.find [effect-app/infra/Store]", {
+                      attributes: { "repository.table_name": tableName, "repository.model_name": name, id }
+                    }, { captureStackTrace: false })
+                  ),
+
+              filter: <U extends keyof Encoded = never>(f: FilterArgs<Encoded, U>) => {
+                const filter = f.filter
+                type M = U extends undefined ? Encoded : Pick<Encoded, U>
+                return Effect
+                  .sync(() =>
+                    buildWhereSQLQuery(
+                      dialect,
+                      idKey,
+                      filter ? [{ t: "where-scope", result: filter, relation: "some" }] : [],
+                      tableName,
+                      defaultValues,
+                      f.select as
+                        | NonEmptyReadonlyArray<string | { key: string; subKeys: readonly string[] }>
+                        | undefined,
+                      f.order as NonEmptyReadonlyArray<{ key: string; direction: "ASC" | "DESC" }> | undefined,
+                      f.skip,
+                      f.limit
+                    )
+                  )
+                  .pipe(
+                    Effect.tap((q) => logQuery(q)),
+                    Effect.flatMap((q) =>
+                      exec(q.sql, q.params).pipe(
+                        Effect.map((rows) => {
+                          if (f.select) {
+                            return (rows as any[]).map((r) => {
+                              const selected = parseSelectRow(r, idKey, {})
+                              return {
+                                ...Struct.pick(
+                                  defaultValues as any,
+                                  f.select!.filter((_) => typeof _ === "string") as never[]
+                                ),
+                                ...selected
+                              } as M
+                            })
+                          }
+                          return (rows as any[]).map((r) => parseRow<Encoded>(r, defaultValues) as any as M)
+                        })
+                      )
+                    ),
+                    Effect.withSpan("SQL.filter [effect-app/infra/Store]", {
+                      attributes: { "repository.table_name": tableName, "repository.model_name": name }
+                    }, { captureStackTrace: false })
+                  )
+              },
+
+              set: (e) =>
+                Effect
+                  .gen(function*() {
+                    const row = toRow(e)
+                    if (e._etag) {
+                      yield* exec(
+                        `UPDATE "${tableName}" SET _etag = ?, data = ? WHERE id = ? AND _etag = ?`,
+                        [row._etag, row.data, row.id, e._etag]
+                      )
+                      const existing = yield* exec(
+                        `SELECT _etag FROM "${tableName}" WHERE id = ?`,
+                        [row.id]
+                      )
+                      const current = (existing as any[])[0]
+                      if (!current || current._etag !== row._etag) {
+                        if (current) {
+                          return yield* new OptimisticConcurrencyException({
+                            type: name,
+                            id: row.id,
+                            current: current._etag,
+                            found: e._etag,
+                            code: 412
+                          })
+                        }
+                        return yield* new OptimisticConcurrencyException({
+                          type: name,
+                          id: row.id,
+                          current: "",
+                          found: e._etag,
+                          code: 404
+                        })
+                      }
+                    } else {
+                      yield* exec(
+                        `INSERT INTO "${tableName}" (id, _etag, data) VALUES (?, ?, ?)`,
+                        [row.id, row._etag, row.data]
+                      )
+                    }
+                    return row.item
+                  })
+                  .pipe(
+                    Effect.withSpan("SQL.set [effect-app/infra/Store]", {
+                      attributes: { "repository.table_name": tableName, "repository.model_name": name, id: e[idKey] }
+                    }, { captureStackTrace: false })
+                  ),
+
+              batchSet: (items) =>
+                sql
+                  .withTransaction(
+                    Effect.forEach(items, (e) => s.set(e))
+                  )
+                  .pipe(
+                    Effect.orDie,
+                    Effect.map((_) => _ as unknown as NonEmptyReadonlyArray<PM>),
+                    Effect.withSpan("SQL.batchSet [effect-app/infra/Store]", {
+                      attributes: { "repository.table_name": tableName, "repository.model_name": name }
+                    }, { captureStackTrace: false })
+                  ),
+
+              bulkSet: (items) =>
+                sql
+                  .withTransaction(
+                    Effect.forEach(items, (e) => s.set(e))
+                  )
+                  .pipe(
+                    Effect.orDie,
+                    Effect.map((_) => _ as unknown as NonEmptyReadonlyArray<PM>),
+                    Effect.withSpan("SQL.bulkSet [effect-app/infra/Store]", {
+                      attributes: { "repository.table_name": tableName, "repository.model_name": name }
+                    }, { captureStackTrace: false })
+                  ),
+
+              batchRemove: (ids) => {
+                const placeholders = ids.map(() => "?").join(", ")
+                return exec(
+                  `DELETE FROM "${tableName}" WHERE id IN (${placeholders})`,
+                  [...ids]
+                )
+                  .pipe(
+                    Effect.asVoid,
+                    Effect.withSpan("SQL.batchRemove [effect-app/infra/Store]", {
+                      attributes: { "repository.table_name": tableName, "repository.model_name": name }
+                    }, { captureStackTrace: false })
+                  )
+              },
+
+              queryRaw: (query) =>
+                s.all.pipe(
+                  Effect.map(query.memory),
+                  Effect.withSpan("SQL.queryRaw [effect-app/infra/Store]", {
+                    attributes: { "repository.table_name": tableName, "repository.model_name": name }
+                  }, { captureStackTrace: false })
+                )
+            }
+
+            if (seed) {
+              const existing = yield* exec(`SELECT COUNT(*) as cnt FROM "${tableName}"`)
+              const count = (existing as any[])[0]?.cnt ?? 0
+              if (count === 0) {
+                yield* InfraLogger.logInfo("Seeding data for " + name)
+                const items = yield* seed
+                yield* Effect.flatMapOption(
+                  Effect.succeed(toNonEmptyArray([...items])),
+                  (a) => s.bulkSet(a).pipe(Effect.orDie)
+                )
+              }
+            }
+
+            return s
+          })
+      }
+    })
+}
+
+export function SQLiteStoreLayer(cfg: StorageConfig) {
+  return StoreMaker
+    .toLayer(makeSQLStoreInt(sqliteDialect, "JSON")(cfg))
+}

--- a/packages/infra/src/Store/SQL/Pg.ts
+++ b/packages/infra/src/Store/SQL/Pg.ts
@@ -1,0 +1,253 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { Effect, type NonEmptyReadonlyArray, Option, Struct } from "effect-app"
+import { toNonEmptyArray } from "effect-app/Array"
+import { SqlClient } from "effect/unstable/sql"
+import { OptimisticConcurrencyException } from "../../errors.js"
+import { InfraLogger } from "../../logger.js"
+import type { FieldValues } from "../../Model/filter/types.js"
+import { type FilterArgs, type PersistenceModelType, type StorageConfig, type Store, type StoreConfig, StoreMaker } from "../service.js"
+import { makeETag } from "../utils.js"
+import { buildWhereSQLQuery, logQuery, pgDialect } from "./query.js"
+
+const parseRow = <Encoded extends FieldValues>(
+  row: { id: string; _etag: string | null; data: unknown },
+  defaultValues: Partial<Encoded>
+): PersistenceModelType<Encoded> => {
+  const data = (typeof row.data === "string" ? JSON.parse(row.data) : row.data) as object
+  return { ...defaultValues, ...data, _etag: row._etag ?? undefined } as PersistenceModelType<Encoded>
+}
+
+const parseSelectRow = (
+  row: Record<string, unknown>,
+  idKey: PropertyKey,
+  defaultValues: Record<string, unknown>
+): any => {
+  const result: Record<string, unknown> = { ...defaultValues }
+  for (const [key, value] of Object.entries(row)) {
+    if (key === "id") {
+      result[idKey as string] = value
+      result["id"] = value
+    } else {
+      result[key] = value
+    }
+  }
+  return result
+}
+
+function makePgStore({ prefix }: StorageConfig) {
+  return Effect.gen(function*() {
+    const sql = yield* SqlClient.SqlClient
+    return {
+      make: <IdKey extends keyof Encoded, Encoded extends FieldValues, R = never, E = never>(
+        name: string,
+        idKey: IdKey,
+        seed?: Effect.Effect<Iterable<Encoded>, E, R>,
+        config?: StoreConfig<Encoded>
+      ) =>
+        Effect.gen(function*() {
+          type PM = PersistenceModelType<Encoded>
+          const tableName = `${prefix}${name}`
+          const defaultValues = config?.defaultValues ?? {}
+
+          yield* sql
+            .unsafe(
+              `CREATE TABLE IF NOT EXISTS "${tableName}" (id TEXT PRIMARY KEY, _etag TEXT, data JSONB NOT NULL)`
+            )
+            .pipe(Effect.orDie)
+
+          const toRow = (e: PM) => {
+            const newE = makeETag(e)
+            const id = newE[idKey] as string
+            const data = JSON.stringify(newE)
+            return { id, _etag: newE._etag!, data, item: newE }
+          }
+
+          const exec = (query: string, params?: readonly unknown[]) =>
+            sql.unsafe(query, params as any).pipe(Effect.orDie)
+
+          const s: Store<IdKey, Encoded> = {
+            all: exec(`SELECT id, _etag, data FROM "${tableName}"`)
+              .pipe(
+                Effect.map((rows) => (rows as any[]).map((r) => parseRow<Encoded>(r, defaultValues))),
+                Effect.withSpan("PgSQL.all [effect-app/infra/Store]", {
+                  attributes: { "repository.table_name": tableName, "repository.model_name": name }
+                }, { captureStackTrace: false })
+              ),
+
+            find: (id) =>
+              exec(`SELECT id, _etag, data FROM "${tableName}" WHERE id = $1`, [id])
+                .pipe(
+                  Effect.map((rows) => {
+                    const row = (rows as any[])[0]
+                    return row
+                      ? Option.some(parseRow<Encoded>(row, defaultValues))
+                      : Option.none()
+                  }),
+                  Effect.withSpan("PgSQL.find [effect-app/infra/Store]", {
+                    attributes: { "repository.table_name": tableName, "repository.model_name": name, id }
+                  }, { captureStackTrace: false })
+                ),
+
+            filter: <U extends keyof Encoded = never>(f: FilterArgs<Encoded, U>) => {
+              const filter = f.filter
+              type M = U extends undefined ? Encoded : Pick<Encoded, U>
+              return Effect
+                .sync(() =>
+                  buildWhereSQLQuery(
+                    pgDialect,
+                    idKey,
+                    filter ? [{ t: "where-scope", result: filter, relation: "some" }] : [],
+                    tableName,
+                    defaultValues,
+                    f.select as NonEmptyReadonlyArray<string | { key: string; subKeys: readonly string[] }> | undefined,
+                    f.order as NonEmptyReadonlyArray<{ key: string; direction: "ASC" | "DESC" }> | undefined,
+                    f.skip,
+                    f.limit
+                  )
+                )
+                .pipe(
+                  Effect.tap((q) => logQuery(q)),
+                  Effect.flatMap((q) =>
+                    exec(q.sql, q.params).pipe(
+                      Effect.map((rows) => {
+                        if (f.select) {
+                          return (rows as any[]).map((r) => {
+                            const selected = parseSelectRow(r, idKey, {})
+                            return {
+                              ...Struct.pick(
+                                defaultValues as any,
+                                f.select!.filter((_) => typeof _ === "string") as never[]
+                              ),
+                              ...selected
+                            } as M
+                          })
+                        }
+                        return (rows as any[]).map((r) => parseRow<Encoded>(r, defaultValues) as any as M)
+                      })
+                    )
+                  ),
+                  Effect.withSpan("PgSQL.filter [effect-app/infra/Store]", {
+                    attributes: { "repository.table_name": tableName, "repository.model_name": name }
+                  }, { captureStackTrace: false })
+                )
+            },
+
+            set: (e) =>
+              Effect
+                .gen(function*() {
+                  const row = toRow(e)
+                  if (e._etag) {
+                    yield* exec(
+                      `UPDATE "${tableName}" SET _etag = $1, data = $2 WHERE id = $3 AND _etag = $4`,
+                      [row._etag, row.data, row.id, e._etag]
+                    )
+                    const existing = yield* exec(
+                      `SELECT _etag FROM "${tableName}" WHERE id = $1`,
+                      [row.id]
+                    )
+                    const current = (existing as any[])[0]
+                    if (!current || current._etag !== row._etag) {
+                      if (current) {
+                        return yield* new OptimisticConcurrencyException({
+                          type: name,
+                          id: row.id,
+                          current: current._etag,
+                          found: e._etag,
+                          code: 412
+                        })
+                      }
+                      return yield* new OptimisticConcurrencyException({
+                        type: name,
+                        id: row.id,
+                        current: "",
+                        found: e._etag,
+                        code: 404
+                      })
+                    }
+                  } else {
+                    yield* exec(
+                      `INSERT INTO "${tableName}" (id, _etag, data) VALUES ($1, $2, $3)`,
+                      [row.id, row._etag, row.data]
+                    )
+                  }
+                  return row.item
+                })
+                .pipe(
+                  Effect.withSpan("PgSQL.set [effect-app/infra/Store]", {
+                    attributes: { "repository.table_name": tableName, "repository.model_name": name, id: e[idKey] }
+                  }, { captureStackTrace: false })
+                ),
+
+            batchSet: (items) =>
+              sql
+                .withTransaction(
+                  Effect.forEach(items, (e) => s.set(e))
+                )
+                .pipe(
+                  Effect.orDie,
+                  Effect.map((_) => _ as unknown as NonEmptyReadonlyArray<PM>),
+                  Effect.withSpan("PgSQL.batchSet [effect-app/infra/Store]", {
+                    attributes: { "repository.table_name": tableName, "repository.model_name": name }
+                  }, { captureStackTrace: false })
+                ),
+
+            bulkSet: (items) =>
+              sql
+                .withTransaction(
+                  Effect.forEach(items, (e) => s.set(e))
+                )
+                .pipe(
+                  Effect.orDie,
+                  Effect.map((_) => _ as unknown as NonEmptyReadonlyArray<PM>),
+                  Effect.withSpan("PgSQL.bulkSet [effect-app/infra/Store]", {
+                    attributes: { "repository.table_name": tableName, "repository.model_name": name }
+                  }, { captureStackTrace: false })
+                ),
+
+            batchRemove: (ids) => {
+              const placeholders = ids.map((_, i) => `$${i + 1}`).join(", ")
+              return exec(
+                `DELETE FROM "${tableName}" WHERE id IN (${placeholders})`,
+                [...ids]
+              )
+                .pipe(
+                  Effect.asVoid,
+                  Effect.withSpan("PgSQL.batchRemove [effect-app/infra/Store]", {
+                    attributes: { "repository.table_name": tableName, "repository.model_name": name }
+                  }, { captureStackTrace: false })
+                )
+            },
+
+            queryRaw: (query) =>
+              s.all.pipe(
+                Effect.map(query.memory),
+                Effect.withSpan("PgSQL.queryRaw [effect-app/infra/Store]", {
+                  attributes: { "repository.table_name": tableName, "repository.model_name": name }
+                }, { captureStackTrace: false })
+              )
+          }
+
+          if (seed) {
+            const existing = yield* exec(`SELECT COUNT(*) as cnt FROM "${tableName}"`)
+            const count = Number((existing as any[])[0]?.cnt ?? 0)
+            if (count === 0) {
+              yield* InfraLogger.logInfo("Seeding data for " + name)
+              const items = yield* seed
+              yield* Effect.flatMapOption(
+                Effect.succeed(toNonEmptyArray([...items])),
+                (a) => s.bulkSet(a).pipe(Effect.orDie)
+              )
+            }
+          }
+
+          return s
+        })
+    }
+  })
+}
+
+export function PgStoreLayer(cfg: StorageConfig) {
+  return StoreMaker
+    .toLayer(makePgStore(cfg))
+}

--- a/packages/infra/src/Store/SQL/Pg.ts
+++ b/packages/infra/src/Store/SQL/Pg.ts
@@ -6,6 +6,7 @@ import { SqlClient } from "effect/unstable/sql"
 import { OptimisticConcurrencyException } from "../../errors.js"
 import { InfraLogger } from "../../logger.js"
 import type { FieldValues } from "../../Model/filter/types.js"
+import { storeId } from "../Memory.js"
 import { type FilterArgs, type PersistenceModelType, type StorageConfig, type Store, type StoreConfig, StoreMaker } from "../service.js"
 import { makeETag } from "../utils.js"
 import { buildWhereSQLQuery, logQuery, pgDialect } from "./query.js"
@@ -50,9 +51,18 @@ function makePgStore({ prefix }: StorageConfig) {
           const tableName = `${prefix}${name}`
           const defaultValues = config?.defaultValues ?? {}
 
+          const resolveNamespace = !config?.allowNamespace
+            ? Effect.succeed("primary")
+            : storeId.asEffect().pipe(Effect.map((namespace) => {
+              if (namespace !== "primary" && !config.allowNamespace!(namespace)) {
+                throw new Error(`Namespace ${namespace} not allowed!`)
+              }
+              return namespace
+            }))
+
           yield* sql
             .unsafe(
-              `CREATE TABLE IF NOT EXISTS "${tableName}" (id TEXT PRIMARY KEY, _etag TEXT, data JSONB NOT NULL)`
+              `CREATE TABLE IF NOT EXISTS "${tableName}" (id TEXT NOT NULL, _namespace TEXT NOT NULL DEFAULT 'primary', _etag TEXT, data JSONB NOT NULL, PRIMARY KEY (id, _namespace))`
             )
             .pipe(Effect.orDie)
 
@@ -67,117 +77,142 @@ function makePgStore({ prefix }: StorageConfig) {
             sql.unsafe(query, params as any).pipe(Effect.orDie)
 
           const s: Store<IdKey, Encoded> = {
-            all: exec(`SELECT id, _etag, data FROM "${tableName}"`)
-              .pipe(
-                Effect.map((rows) => (rows as any[]).map((r) => parseRow<Encoded>(r, defaultValues))),
-                Effect.withSpan("PgSQL.all [effect-app/infra/Store]", {
-                  attributes: { "repository.table_name": tableName, "repository.model_name": name }
-                }, { captureStackTrace: false })
-              ),
+            all: resolveNamespace.pipe(Effect.flatMap((ns) =>
+              exec(`SELECT id, _etag, data FROM "${tableName}" WHERE _namespace = $1`, [ns])
+                .pipe(
+                  Effect.map((rows) => (rows as any[]).map((r) => parseRow<Encoded>(r, defaultValues))),
+                  Effect.withSpan("PgSQL.all [effect-app/infra/Store]", {
+                    attributes: {
+                      "repository.table_name": tableName,
+                      "repository.model_name": name,
+                      "repository.namespace": ns
+                    }
+                  }, { captureStackTrace: false })
+                )
+            )),
 
             find: (id) =>
-              exec(`SELECT id, _etag, data FROM "${tableName}" WHERE id = $1`, [id])
-                .pipe(
-                  Effect.map((rows) => {
-                    const row = (rows as any[])[0]
-                    return row
-                      ? Option.some(parseRow<Encoded>(row, defaultValues))
-                      : Option.none()
-                  }),
-                  Effect.withSpan("PgSQL.find [effect-app/infra/Store]", {
-                    attributes: { "repository.table_name": tableName, "repository.model_name": name, id }
-                  }, { captureStackTrace: false })
-                ),
+              resolveNamespace.pipe(Effect
+                .flatMap((ns) =>
+                  exec(`SELECT id, _etag, data FROM "${tableName}" WHERE id = $1 AND _namespace = $2`, [id, ns])
+                    .pipe(
+                      Effect.map((rows) => {
+                        const row = (rows as any[])[0]
+                        return row
+                          ? Option.some(parseRow<Encoded>(row, defaultValues))
+                          : Option.none()
+                      }),
+                      Effect.withSpan("PgSQL.find [effect-app/infra/Store]", {
+                        attributes: { "repository.table_name": tableName, "repository.model_name": name, id }
+                      }, { captureStackTrace: false })
+                    )
+                )),
 
             filter: <U extends keyof Encoded = never>(f: FilterArgs<Encoded, U>) => {
-              const filter = f.filter
+              const filter = f
+                .filter
               type M = U extends undefined ? Encoded : Pick<Encoded, U>
-              return Effect
-                .sync(() =>
-                  buildWhereSQLQuery(
-                    pgDialect,
-                    idKey,
-                    filter ? [{ t: "where-scope", result: filter, relation: "some" }] : [],
-                    tableName,
-                    defaultValues,
-                    f.select as NonEmptyReadonlyArray<string | { key: string; subKeys: readonly string[] }> | undefined,
-                    f.order as NonEmptyReadonlyArray<{ key: string; direction: "ASC" | "DESC" }> | undefined,
-                    f.skip,
-                    f.limit
-                  )
-                )
-                .pipe(
-                  Effect.tap((q) => logQuery(q)),
-                  Effect.flatMap((q) =>
-                    exec(q.sql, q.params).pipe(
-                      Effect.map((rows) => {
-                        if (f.select) {
-                          return (rows as any[]).map((r) => {
-                            const selected = parseSelectRow(r, idKey, {})
-                            return {
-                              ...Struct.pick(
-                                defaultValues as any,
-                                f.select!.filter((_) => typeof _ === "string") as never[]
-                              ),
-                              ...selected
-                            } as M
-                          })
-                        }
-                        return (rows as any[]).map((r) => parseRow<Encoded>(r, defaultValues) as any as M)
-                      })
+              return resolveNamespace.pipe(Effect.flatMap((ns) =>
+                Effect
+                  .sync(() => {
+                    const q = buildWhereSQLQuery(
+                      pgDialect,
+                      idKey,
+                      filter ? [{ t: "where-scope", result: filter, relation: "some" }] : [],
+                      tableName,
+                      defaultValues,
+                      f.select as
+                        | NonEmptyReadonlyArray<string | { key: string; subKeys: readonly string[] }>
+                        | undefined,
+                      f.order as NonEmptyReadonlyArray<{ key: string; direction: "ASC" | "DESC" }> | undefined,
+                      f.skip,
+                      f.limit
                     )
-                  ),
-                  Effect.withSpan("PgSQL.filter [effect-app/infra/Store]", {
-                    attributes: { "repository.table_name": tableName, "repository.model_name": name }
-                  }, { captureStackTrace: false })
-                )
+                    const nsPlaceholder = pgDialect.placeholder(q.params.length + 1)
+                    const hasWhere = q.sql.includes("WHERE")
+                    const nsSql = hasWhere
+                      ? q.sql.replace("WHERE", `WHERE _namespace = ${nsPlaceholder} AND`)
+                      : q.sql.replace(
+                        `FROM "${tableName}"`,
+                        `FROM "${tableName}" WHERE _namespace = ${nsPlaceholder}`
+                      )
+                    return { sql: nsSql, params: [...q.params, ns] }
+                  })
+                  .pipe(
+                    Effect.tap((q) => logQuery(q)),
+                    Effect.flatMap((q) =>
+                      exec(q.sql, q.params).pipe(
+                        Effect.map((rows) => {
+                          if (f.select) {
+                            return (rows as any[]).map((r) => {
+                              const selected = parseSelectRow(r, idKey, {})
+                              return {
+                                ...Struct.pick(
+                                  defaultValues as any,
+                                  f.select!.filter((_) => typeof _ === "string") as never[]
+                                ),
+                                ...selected
+                              } as M
+                            })
+                          }
+                          return (rows as any[]).map((r) => parseRow<Encoded>(r, defaultValues) as any as M)
+                        })
+                      )
+                    ),
+                    Effect.withSpan("PgSQL.filter [effect-app/infra/Store]", {
+                      attributes: { "repository.table_name": tableName, "repository.model_name": name }
+                    }, { captureStackTrace: false })
+                  )
+              ))
             },
 
             set: (e) =>
-              Effect
-                .gen(function*() {
-                  const row = toRow(e)
-                  if (e._etag) {
-                    yield* exec(
-                      `UPDATE "${tableName}" SET _etag = $1, data = $2 WHERE id = $3 AND _etag = $4`,
-                      [row._etag, row.data, row.id, e._etag]
-                    )
-                    const existing = yield* exec(
-                      `SELECT _etag FROM "${tableName}" WHERE id = $1`,
-                      [row.id]
-                    )
-                    const current = (existing as any[])[0]
-                    if (!current || current._etag !== row._etag) {
-                      if (current) {
+              resolveNamespace.pipe(Effect.flatMap((ns) =>
+                Effect
+                  .gen(function*() {
+                    const row = toRow(e)
+                    if (e._etag) {
+                      yield* exec(
+                        `UPDATE "${tableName}" SET _etag = $1, data = $2 WHERE id = $3 AND _etag = $4 AND _namespace = $5`,
+                        [row._etag, row.data, row.id, e._etag, ns]
+                      )
+                      const existing = yield* exec(
+                        `SELECT _etag FROM "${tableName}" WHERE id = $1 AND _namespace = $2`,
+                        [row.id, ns]
+                      )
+                      const current = (existing as any[])[0]
+                      if (!current || current._etag !== row._etag) {
+                        if (current) {
+                          return yield* new OptimisticConcurrencyException({
+                            type: name,
+                            id: row.id,
+                            current: current._etag,
+                            found: e._etag,
+                            code: 412
+                          })
+                        }
                         return yield* new OptimisticConcurrencyException({
                           type: name,
                           id: row.id,
-                          current: current._etag,
+                          current: "",
                           found: e._etag,
-                          code: 412
+                          code: 404
                         })
                       }
-                      return yield* new OptimisticConcurrencyException({
-                        type: name,
-                        id: row.id,
-                        current: "",
-                        found: e._etag,
-                        code: 404
-                      })
+                    } else {
+                      yield* exec(
+                        `INSERT INTO "${tableName}" (id, _namespace, _etag, data) VALUES ($1, $2, $3, $4)`,
+                        [row.id, ns, row._etag, row.data]
+                      )
                     }
-                  } else {
-                    yield* exec(
-                      `INSERT INTO "${tableName}" (id, _etag, data) VALUES ($1, $2, $3)`,
-                      [row.id, row._etag, row.data]
-                    )
-                  }
-                  return row.item
-                })
-                .pipe(
-                  Effect.withSpan("PgSQL.set [effect-app/infra/Store]", {
-                    attributes: { "repository.table_name": tableName, "repository.model_name": name, id: e[idKey] }
-                  }, { captureStackTrace: false })
-                ),
+                    return row.item
+                  })
+                  .pipe(
+                    Effect.withSpan("PgSQL.set [effect-app/infra/Store]", {
+                      attributes: { "repository.table_name": tableName, "repository.model_name": name, id: e[idKey] }
+                    }, { captureStackTrace: false })
+                  )
+              )),
 
             batchSet: (items) =>
               sql
@@ -207,16 +242,19 @@ function makePgStore({ prefix }: StorageConfig) {
 
             batchRemove: (ids) => {
               const placeholders = ids.map((_, i) => `$${i + 1}`).join(", ")
-              return exec(
-                `DELETE FROM "${tableName}" WHERE id IN (${placeholders})`,
-                [...ids]
-              )
-                .pipe(
-                  Effect.asVoid,
-                  Effect.withSpan("PgSQL.batchRemove [effect-app/infra/Store]", {
-                    attributes: { "repository.table_name": tableName, "repository.model_name": name }
-                  }, { captureStackTrace: false })
+              const nsPlaceholder = `$${ids.length + 1}`
+              return resolveNamespace.pipe(Effect.flatMap((ns) =>
+                exec(
+                  `DELETE FROM "${tableName}" WHERE id IN (${placeholders}) AND _namespace = ${nsPlaceholder}`,
+                  [...ids, ns]
                 )
+                  .pipe(
+                    Effect.asVoid,
+                    Effect.withSpan("PgSQL.batchRemove [effect-app/infra/Store]", {
+                      attributes: { "repository.table_name": tableName, "repository.model_name": name }
+                    }, { captureStackTrace: false })
+                  )
+              ))
             },
 
             queryRaw: (query) =>
@@ -229,7 +267,10 @@ function makePgStore({ prefix }: StorageConfig) {
           }
 
           if (seed) {
-            const existing = yield* exec(`SELECT COUNT(*) as cnt FROM "${tableName}"`)
+            const existing = yield* exec(
+              `SELECT COUNT(*) as cnt FROM "${tableName}" WHERE _namespace = $1`,
+              ["primary"]
+            )
             const count = Number((existing as any[])[0]?.cnt ?? 0)
             if (count === 0) {
               yield* InfraLogger.logInfo("Seeding data for " + name)

--- a/packages/infra/src/Store/SQL/query.ts
+++ b/packages/infra/src/Store/SQL/query.ts
@@ -1,0 +1,372 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { Effect, type NonEmptyReadonlyArray } from "effect-app"
+import { assertUnreachable } from "effect-app/utils"
+import { InfraLogger } from "../../logger.js"
+import type { FilterR, FilterResult, Ops } from "../../Model/filter/filterApi.js"
+import { isRelationCheck } from "../codeFilter.js"
+
+export interface SQLDialect {
+  readonly jsonExtract: (path: string) => string
+  readonly jsonExtractJson: (path: string) => string
+  readonly placeholder: (index: number) => string
+  readonly jsonArrayContains: (arrPath: string, valPlaceholder: string) => string
+  readonly jsonArrayNotContains: (arrPath: string, valPlaceholder: string) => string
+  readonly jsonArrayContainsAny: (arrPath: string, valPlaceholders: readonly string[]) => string
+  readonly jsonArrayNotContainsAny: (arrPath: string, valPlaceholders: readonly string[]) => string
+  readonly jsonArrayContainsAll: (arrPath: string, valPlaceholders: readonly string[]) => string
+  readonly jsonArrayNotContainsAll: (arrPath: string, valPlaceholders: readonly string[]) => string
+  readonly caseInsensitiveLike: (expr: string, valPlaceholder: string) => string
+  readonly caseInsensitiveNotLike: (expr: string, valPlaceholder: string) => string
+  readonly jsonColumnType: "JSON" | "JSONB"
+  readonly arrayLength: (path: string) => string
+}
+
+export const sqliteDialect: SQLDialect = {
+  jsonExtract: (path) => `json_extract(data, '$.${path}')`,
+  jsonExtractJson: (path) => `json_extract(data, '$.${path}')`,
+  placeholder: (_index) => "?",
+  jsonArrayContains: (arrPath, val) => `EXISTS(SELECT 1 FROM json_each(data, '$.${arrPath}') WHERE value = ${val})`,
+  jsonArrayNotContains: (arrPath, val) =>
+    `NOT EXISTS(SELECT 1 FROM json_each(data, '$.${arrPath}') WHERE value = ${val})`,
+  jsonArrayContainsAny: (arrPath, vals) =>
+    `EXISTS(SELECT 1 FROM json_each(data, '$.${arrPath}') WHERE value IN (${vals.join(", ")}))`,
+  jsonArrayNotContainsAny: (arrPath, vals) =>
+    `NOT EXISTS(SELECT 1 FROM json_each(data, '$.${arrPath}') WHERE value IN (${vals.join(", ")}))`,
+  jsonArrayContainsAll: (arrPath, vals) =>
+    vals.map((v) => `EXISTS(SELECT 1 FROM json_each(data, '$.${arrPath}') WHERE value = ${v})`).join(" AND "),
+  jsonArrayNotContainsAll: (arrPath, vals) =>
+    `NOT (${
+      vals.map((v) => `EXISTS(SELECT 1 FROM json_each(data, '$.${arrPath}') WHERE value = ${v})`).join(" AND ")
+    })`,
+  caseInsensitiveLike: (expr, val) => `LOWER(${expr}) LIKE LOWER(${val})`,
+  caseInsensitiveNotLike: (expr, val) => `LOWER(${expr}) NOT LIKE LOWER(${val})`,
+  jsonColumnType: "JSON",
+  arrayLength: (path) => `json_array_length(data, '$.${path}')`
+}
+
+export const pgDialect: SQLDialect = {
+  jsonExtract: (path) => {
+    const parts = path.split(".")
+    if (parts.length === 1) return `data->>'${parts[0]}'`
+    const last = parts.pop()!
+    return `data${parts.map((p) => `->'${p}'`).join("")}->>'${last}'`
+  },
+  jsonExtractJson: (path) => {
+    const parts = path.split(".")
+    if (parts.length === 1) return `data->'${parts[0]}'`
+    return `data${parts.map((p) => `->'${p}'`).join("")}`
+  },
+  placeholder: (index) => `$${index}`,
+  jsonArrayContains: (arrPath, val) => {
+    const parts = arrPath.split(".")
+    const jsonPath = parts.length === 1
+      ? `data->'${parts[0]}'`
+      : `data${parts.map((p) => `->'${p}'`).join("")}`
+    return `${jsonPath} @> ${val}::jsonb`
+  },
+  jsonArrayNotContains: (arrPath, val) => {
+    const parts = arrPath.split(".")
+    const jsonPath = parts.length === 1
+      ? `data->'${parts[0]}'`
+      : `data${parts.map((p) => `->'${p}'`).join("")}`
+    return `NOT (${jsonPath} @> ${val}::jsonb)`
+  },
+  jsonArrayContainsAny: (arrPath, vals) => {
+    const parts = arrPath.split(".")
+    const jsonPath = parts.length === 1
+      ? `data->'${parts[0]}'`
+      : `data${parts.map((p) => `->'${p}'`).join("")}`
+    return `(${vals.map((v) => `${jsonPath} @> ${v}::jsonb`).join(" OR ")})`
+  },
+  jsonArrayNotContainsAny: (arrPath, vals) => {
+    const parts = arrPath.split(".")
+    const jsonPath = parts.length === 1
+      ? `data->'${parts[0]}'`
+      : `data${parts.map((p) => `->'${p}'`).join("")}`
+    return `NOT (${vals.map((v) => `${jsonPath} @> ${v}::jsonb`).join(" OR ")})`
+  },
+  jsonArrayContainsAll: (arrPath, vals) => {
+    const parts = arrPath.split(".")
+    const jsonPath = parts.length === 1
+      ? `data->'${parts[0]}'`
+      : `data${parts.map((p) => `->'${p}'`).join("")}`
+    return vals.map((v) => `${jsonPath} @> ${v}::jsonb`).join(" AND ")
+  },
+  jsonArrayNotContainsAll: (arrPath, vals) => {
+    const parts = arrPath.split(".")
+    const jsonPath = parts.length === 1
+      ? `data->'${parts[0]}'`
+      : `data${parts.map((p) => `->'${p}'`).join("")}`
+    return `NOT (${vals.map((v) => `${jsonPath} @> ${v}::jsonb`).join(" AND ")})`
+  },
+  caseInsensitiveLike: (expr, val) => `${expr} ILIKE ${val}`,
+  caseInsensitiveNotLike: (expr, val) => `${expr} NOT ILIKE ${val}`,
+  jsonColumnType: "JSONB",
+  arrayLength: (path) => `jsonb_array_length(data->'${path}')`
+}
+
+export function logQuery(q: { sql: string; params: unknown[] }) {
+  return InfraLogger
+    .logDebug("sql query")
+    .pipe(Effect.annotateLogs({
+      query: q.sql,
+      parameters: JSON.stringify(q.params, undefined, 2)
+    }))
+}
+
+const dottedToJsonPath = (path: string) =>
+  path
+    .split(".")
+    .filter((p) => p !== "-1")
+    .join(".")
+
+export function buildWhereSQLQuery(
+  dialect: SQLDialect,
+  idKey: PropertyKey,
+  filter: readonly FilterResult[],
+  tableName: string,
+  _defaultValues: Record<string, unknown>,
+  select?: NonEmptyReadonlyArray<string | { key: string; subKeys: readonly string[] }>,
+  order?: NonEmptyReadonlyArray<{ key: string; direction: "ASC" | "DESC" }>,
+  skip?: number,
+  limit?: number
+) {
+  const params: unknown[] = []
+  let paramIndex = 1
+
+  const addParam = (value: unknown): string => {
+    params.push(value)
+    return dialect.placeholder(paramIndex++)
+  }
+
+  const fieldExpr = (path: string): string => {
+    if (path === idKey || path === "id") return "id"
+    if (path.endsWith(".length")) {
+      const arrPath = dottedToJsonPath(path.slice(0, -".length".length))
+      return dialect.arrayLength(arrPath)
+    }
+    const jsonPath = dottedToJsonPath(path)
+    return dialect.jsonExtract(jsonPath)
+  }
+
+  const statement = (x: FilterR): string => {
+    const resolvedPath = x.path === idKey ? "id" : x.path
+    const k = fieldExpr(resolvedPath)
+
+    switch (x.op) {
+      case "in": {
+        const vals = x.value as unknown as readonly unknown[]
+        const placeholders = vals.map((v) => addParam(v))
+        return `${k} IN (${placeholders.join(", ")})`
+      }
+      case "notIn": {
+        const vals = x.value as unknown as readonly unknown[]
+        const placeholders = vals.map((v) => addParam(v))
+        return `${k} NOT IN (${placeholders.join(", ")})`
+      }
+
+      case "includes": {
+        const arrPath = dottedToJsonPath(resolvedPath)
+        const v = addParam(x.value)
+        return dialect.jsonArrayContains(arrPath, v)
+      }
+      case "notIncludes": {
+        const arrPath = dottedToJsonPath(resolvedPath)
+        const v = addParam(x.value)
+        return dialect.jsonArrayNotContains(arrPath, v)
+      }
+
+      case "includes-any": {
+        const arrPath = dottedToJsonPath(resolvedPath)
+        const vals = x.value as unknown as readonly unknown[]
+        const placeholders = vals.map((v) => addParam(JSON.stringify(v)))
+        return dialect.jsonArrayContainsAny(arrPath, placeholders)
+      }
+      case "notIncludes-any": {
+        const arrPath = dottedToJsonPath(resolvedPath)
+        const vals = x.value as unknown as readonly unknown[]
+        const placeholders = vals.map((v) => addParam(JSON.stringify(v)))
+        return dialect.jsonArrayNotContainsAny(arrPath, placeholders)
+      }
+
+      case "includes-all": {
+        const arrPath = dottedToJsonPath(resolvedPath)
+        const vals = x.value as unknown as readonly unknown[]
+        const placeholders = vals.map((v) => addParam(JSON.stringify(v)))
+        return dialect.jsonArrayContainsAll(arrPath, placeholders)
+      }
+      case "notIncludes-all": {
+        const arrPath = dottedToJsonPath(resolvedPath)
+        const vals = x.value as unknown as readonly unknown[]
+        const placeholders = vals.map((v) => addParam(JSON.stringify(v)))
+        return dialect.jsonArrayNotContainsAll(arrPath, placeholders)
+      }
+
+      case "contains": {
+        const v = addParam(`%${x.value}%`)
+        return dialect.caseInsensitiveLike(k, v)
+      }
+      case "notContains": {
+        const v = addParam(`%${x.value}%`)
+        return dialect.caseInsensitiveNotLike(k, v)
+      }
+      case "startsWith": {
+        const v = addParam(`${x.value}%`)
+        return dialect.caseInsensitiveLike(k, v)
+      }
+      case "notStartsWith": {
+        const v = addParam(`${x.value}%`)
+        return dialect.caseInsensitiveNotLike(k, v)
+      }
+      case "endsWith": {
+        const v = addParam(`%${x.value}`)
+        return dialect.caseInsensitiveLike(k, v)
+      }
+      case "notEndsWith": {
+        const v = addParam(`%${x.value}`)
+        return dialect.caseInsensitiveNotLike(k, v)
+      }
+
+      case "lt": {
+        const v = addParam(x.value)
+        return `${k} < ${v}`
+      }
+      case "lte": {
+        const v = addParam(x.value)
+        return `${k} <= ${v}`
+      }
+      case "gt": {
+        const v = addParam(x.value)
+        return `${k} > ${v}`
+      }
+      case "gte": {
+        const v = addParam(x.value)
+        return `${k} >= ${v}`
+      }
+      case "neq": {
+        if (x.value === null) return `${k} IS NOT NULL`
+        const v = addParam(x.value)
+        return `${k} <> ${v}`
+      }
+      case undefined:
+      case "eq": {
+        if (x.value === null) return `${k} IS NULL`
+        const v = addParam(x.value)
+        return `${k} = ${v}`
+      }
+      default:
+        return assertUnreachable(x.op)
+    }
+  }
+
+  const flipOps = {
+    gt: "lt",
+    lt: "gt",
+    gte: "lte",
+    lte: "gte",
+    contains: "notContains",
+    notContains: "contains",
+    startsWith: "notStartsWith",
+    notStartsWith: "startsWith",
+    endsWith: "notEndsWith",
+    notEndsWith: "endsWith",
+    eq: "neq",
+    neq: "eq",
+    includes: "notIncludes",
+    notIncludes: "includes",
+    "includes-any": "notIncludes-any",
+    "notIncludes-any": "includes-any",
+    "includes-all": "notIncludes-all",
+    "notIncludes-all": "includes-all",
+    in: "notIn",
+    notIn: "in"
+  } satisfies Record<Ops, Ops>
+
+  const flippies = {
+    and: "or",
+    or: "and"
+  } satisfies Record<"and" | "or", "and" | "or">
+
+  const flip = (every: boolean) => (_: FilterResult): FilterResult =>
+    every
+      ? _.t === "where" || _.t === "or" || _.t === "and"
+        ? { ..._, t: _.t === "where" ? _.t : flippies[_.t], op: flipOps[_.op] }
+        : _
+      : _
+
+  const print = (state: readonly FilterResult[], isRelation: string | null, every: boolean): string => {
+    let s = ""
+    for (const e of state) {
+      switch (e.t) {
+        case "where":
+          s += statement(e)
+          break
+        case "or":
+          s += ` OR ${statement(e)}`
+          break
+        case "and":
+          s += ` AND ${statement(e)}`
+          break
+        case "or-scope": {
+          if (!every) every = e.relation === "every"
+          const rel = isRelationCheck(e.result, isRelation)
+          if (rel) {
+            s += ` OR (${print(e.result.map(flip(every)), rel, every)})`
+          } else {
+            s += ` OR (${print(e.result, null, every)})`
+          }
+          break
+        }
+        case "and-scope": {
+          if (!every) every = e.relation === "every"
+          const rel = isRelationCheck(e.result, isRelation)
+          if (rel) {
+            s += ` AND (${print(e.result.map(flip(every)), rel, every)})`
+          } else {
+            s += ` AND (${print(e.result, null, every)})`
+          }
+          break
+        }
+        case "where-scope": {
+          if (!every) every = e.relation === "every"
+          const rel = isRelationCheck(e.result, isRelation)
+          if (rel) {
+            s += `(${print(e.result.map(flip(every)), rel, every)})`
+          } else {
+            s += `(${print(e.result, null, every)})`
+          }
+          break
+        }
+      }
+    }
+    return s
+  }
+
+  const getSelectExpr = (): string => {
+    if (!select) return "id, _etag, data"
+    const fields = select.map((s) => {
+      if (typeof s === "string") {
+        if (s === idKey || s === "id") return `id`
+        return `${dialect.jsonExtract(s)} AS "${s}"`
+      }
+      return `${dialect.jsonExtractJson(s.key)} AS "${s.key}"`
+    })
+    return fields.join(", ")
+  }
+
+  const whereClause = filter.length
+    ? `WHERE ${print([{ t: "where-scope", result: filter, relation: "some" }], null, false)}`
+    : ""
+
+  const orderClause = order
+    ? `ORDER BY ${order.map((_) => `${fieldExpr(_.key)} ${_.direction}`).join(", ")}`
+    : ""
+
+  const limitClause = limit !== undefined || skip !== undefined
+    ? `LIMIT ${addParam(limit ?? 999999)} OFFSET ${addParam(skip ?? 0)}`
+    : ""
+
+  const sql = `SELECT ${getSelectExpr()} FROM "${tableName}" ${whereClause} ${orderClause} ${limitClause}`.trim()
+
+  return { sql, params }
+}

--- a/packages/infra/src/Store/index.ts
+++ b/packages/infra/src/Store/index.ts
@@ -21,7 +21,7 @@ export function StoreMakerLayer(cfg: StorageConfig) {
         console.log("Using disk store at " + dir)
         return DiskStoreLayer(cfg, dir)
       }
-      if (storageUrl.startsWith("sql://")) {
+      if (storageUrl.startsWith("sqlite://")) {
         console.log("Using SQLite store")
         return SQLiteStoreLayer(cfg)
       }

--- a/packages/infra/src/Store/index.ts
+++ b/packages/infra/src/Store/index.ts
@@ -5,6 +5,8 @@ import { DiskStoreLayer } from "./Disk.js"
 import { MemoryStoreLive } from "./Memory.js"
 // import { RedisStoreLayer } from "./Redis.js"
 import type { StorageConfig } from "./service.js"
+import { SQLiteStoreLayer } from "./SQL.js"
+import { PgStoreLayer } from "./SQL/Pg.js"
 
 export function StoreMakerLayer(cfg: StorageConfig) {
   return Effect
@@ -18,6 +20,14 @@ export function StoreMakerLayer(cfg: StorageConfig) {
         const dir = storageUrl.replace("disk://", "")
         console.log("Using disk store at " + dir)
         return DiskStoreLayer(cfg, dir)
+      }
+      if (storageUrl.startsWith("sql://")) {
+        console.log("Using SQLite store")
+        return SQLiteStoreLayer(cfg)
+      }
+      if (storageUrl.startsWith("pg://")) {
+        console.log("Using PostgreSQL store")
+        return PgStoreLayer(cfg)
       }
       // if (storageUrl.startsWith("redis://")) {
       //   console.log("Using Redis store")

--- a/packages/infra/src/Store/service.ts
+++ b/packages/infra/src/Store/service.ts
@@ -11,7 +11,7 @@ export interface StoreConfig<E> {
   partitionValue: (e?: E) => string
   /**
    * Primarily used for testing, creating namespaces in the database to separate data e.g to run multiple tests in isolation within the same database.
-   * Memory/Disk use separate store instances per namespace. CosmosDB uses namespace-prefixed partition keys.
+   * Memory/Disk use separate store instances per namespace. CosmosDB uses namespace-prefixed partition keys. SQL uses a `_namespace` column.
    */
   allowNamespace?: (namespace: string) => boolean
   /**

--- a/packages/infra/src/Store/service.ts
+++ b/packages/infra/src/Store/service.ts
@@ -10,8 +10,8 @@ import { type RawQuery } from "../Model/query.js"
 export interface StoreConfig<E> {
   partitionValue: (e?: E) => string
   /**
-   * Primarily used for testing, creating namespaces in the database to separate data e.g to run multiple tests in isolation within the same database
-   * currently only supported in disk/memory. CosmosDB is TODO.
+   * Primarily used for testing, creating namespaces in the database to separate data e.g to run multiple tests in isolation within the same database.
+   * Memory/Disk use separate store instances per namespace. CosmosDB uses namespace-prefixed partition keys.
    */
   allowNamespace?: (namespace: string) => boolean
   /**

--- a/packages/infra/src/api/routing/middleware/middleware.ts
+++ b/packages/infra/src/api/routing/middleware/middleware.ts
@@ -1,7 +1,9 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Cause, Config, Effect, Layer, Schema } from "effect"
 import { ConfigureInterruptibilityMiddleware, DevMode, DevModeMiddleware, LoggerMiddleware, RequestCacheMiddleware } from "effect-app/middleware"
+import { RpcContextMap } from "effect-app/rpc"
 import { pretty } from "effect-app/utils"
+import { SqlClient } from "effect/unstable/sql"
 import { logError, reportError } from "../../../errorReporter.js"
 import { InfraLogger } from "../../../logger.js"
 import { determineMethod, isCommand } from "../utils.js"
@@ -126,3 +128,42 @@ export const DefaultGenericMiddlewaresLive = Layer.mergeAll(
   LoggerMiddlewareLive,
   DevModeMiddlewareLive
 )
+
+/**
+ * Config entry for `RequestContextMap` that controls per-RPC transaction wrapping.
+ * Defaults to `true` (transaction applied). Set `requiresTransaction: false` on a route to skip.
+ *
+ * @example
+ * ```ts
+ * class RequestContextMap extends RpcContextMap.makeMap({
+ *   requiresTransaction: requiresTransactionConfig,
+ *   // ...
+ * }) {}
+ * ```
+ */
+export const requiresTransactionConfig = RpcContextMap.makeCustom()(Schema.Never, true as boolean)
+
+/**
+ * Creates the middleware Effect for SQL transaction wrapping.
+ * Requires `SqlClient` directly (not via serviceOption).
+ * Reads `requiresTransaction` from the RPC config; defaults to `true`.
+ *
+ * @example
+ * ```ts
+ * const SqlTransactionMiddlewareLive = Layer.effect(
+ *   SqlTransactionMiddleware,
+ *   makeSqlTransactionMiddleware(RequestContextMap)
+ * )
+ * ```
+ */
+export const makeSqlTransactionMiddleware = (
+  rcm: { getConfig: (rpc: any) => Record<string, any> }
+) =>
+  Effect.gen(function*() {
+    const sql = yield* SqlClient.SqlClient
+    return (effect: Effect.Effect<any, any, any>, { rpc }: { rpc: any }) => {
+      const config = rcm.getConfig(rpc)
+      if (config["requiresTransaction"] === false) return effect
+      return sql.withTransaction(effect).pipe(Effect.orDie)
+    }
+  })

--- a/packages/infra/src/api/routing/middleware/middleware.ts
+++ b/packages/infra/src/api/routing/middleware/middleware.ts
@@ -1,8 +1,9 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Cause, Config, Effect, Layer, Schema } from "effect"
 import { ConfigureInterruptibilityMiddleware, DevMode, DevModeMiddleware, LoggerMiddleware, RequestCacheMiddleware } from "effect-app/middleware"
-import { RpcContextMap } from "effect-app/rpc"
+import { RpcContextMap, type RpcMiddleware } from "effect-app/rpc"
 import { pretty } from "effect-app/utils"
+import { type Rpc } from "effect/unstable/rpc"
 import { SqlClient } from "effect/unstable/sql"
 import { logError, reportError } from "../../../errorReporter.js"
 import { InfraLogger } from "../../../logger.js"
@@ -131,7 +132,7 @@ export const DefaultGenericMiddlewaresLive = Layer.mergeAll(
 
 /**
  * Config entry for `RequestContextMap` that controls per-RPC transaction wrapping.
- * Defaults to `true` (transaction applied). Set `requiresTransaction: false` on a route to skip.
+ * Defaults to `false` (no transaction). Set `requiresTransaction: true` on a route to enable.
  *
  * @example
  * ```ts
@@ -141,12 +142,12 @@ export const DefaultGenericMiddlewaresLive = Layer.mergeAll(
  * }) {}
  * ```
  */
-export const requiresTransactionConfig = RpcContextMap.makeCustom()(Schema.Never, true as boolean)
+export const requiresTransactionConfig = RpcContextMap.makeCustom()(Schema.Never, false as boolean)
 
 /**
  * Creates the middleware Effect for SQL transaction wrapping.
  * Requires `SqlClient` directly (not via serviceOption).
- * Reads `requiresTransaction` from the RPC config; defaults to `true`.
+ * Reads `requiresTransaction` from the RPC config; defaults to `false`.
  *
  * @example
  * ```ts
@@ -157,13 +158,14 @@ export const requiresTransactionConfig = RpcContextMap.makeCustom()(Schema.Never
  * ```
  */
 export const makeSqlTransactionMiddleware = (
-  rcm: { getConfig: (rpc: any) => Record<string, any> }
+  rcm: { getConfig: (rpc: Rpc.AnyWithProps) => { readonly requiresTransaction?: boolean } }
 ) =>
   Effect.gen(function*() {
     const sql = yield* SqlClient.SqlClient
-    return (effect: Effect.Effect<any, any, any>, { rpc }: { rpc: any }) => {
-      const config = rcm.getConfig(rpc)
-      if (config["requiresTransaction"] === false) return effect
+    const mw: RpcMiddleware.RpcMiddlewareV4<never, never, never> = (effect, { rpc }) => {
+      const { requiresTransaction } = rcm.getConfig(rpc)
+      if (requiresTransaction !== true) return effect
       return sql.withTransaction(effect).pipe(Effect.orDie)
     }
+    return mw
   })

--- a/packages/infra/src/api/setupRequest.ts
+++ b/packages/infra/src/api/setupRequest.ts
@@ -60,7 +60,7 @@ export const setupRequestContextFromCurrent =
   (name = "request", options?: Tracer.SpanOptions & SetupRequestOptions) => <R, E, A>(self: Effect.Effect<A, E, R>) =>
     self
       .pipe(
-        options?.withTransaction !== false ? withSqlTransaction : (_) => _,
+        options?.withTransaction === true ? withSqlTransaction : (_) => _,
         withRequestSpan(name, options),
         Effect.provide(ContextMapContainer.layer, { local: true })
       )
@@ -78,7 +78,7 @@ export function setupRequestContext<R, E, A>(
   )
   return self
     .pipe(
-      options?.withTransaction !== false ? withSqlTransaction : (_) => _,
+      options?.withTransaction === true ? withSqlTransaction : (_) => _,
       withRequestSpan(requestContext.name),
       Effect.provide(layer, { local: true })
     )
@@ -97,7 +97,7 @@ export function setupRequestContextWithCustomSpan<R, E, A>(
   )
   return self
     .pipe(
-      options?.withTransaction !== false ? withSqlTransaction : (_) => _,
+      options?.withTransaction === true ? withSqlTransaction : (_) => _,
       withRequestSpan(name, options),
       Effect.provide(layer, { local: true })
     )

--- a/packages/infra/src/api/setupRequest.ts
+++ b/packages/infra/src/api/setupRequest.ts
@@ -1,8 +1,17 @@
-import { Effect, Layer, Tracer } from "effect-app"
+import { Effect, Layer, Option, Tracer } from "effect-app"
 import { NonEmptyString255 } from "effect-app/Schema"
+import { SqlClient } from "effect/unstable/sql"
 import { LocaleRef, RequestContext, spanAttributes } from "../RequestContext.js"
 import { ContextMapContainer } from "../Store/ContextMapContainer.js"
 import { storeId } from "../Store/Memory.js"
+
+const withSqlTransaction = <R, E, A>(self: Effect.Effect<A, E, R>): Effect.Effect<A, E, R> =>
+  Effect.serviceOption(SqlClient.SqlClient).pipe(
+    Effect.flatMap(Option.match({
+      onNone: () => self,
+      onSome: (sql) => sql.withTransaction(self).pipe(Effect.orDie)
+    }))
+  )
 
 export const getRequestContext = Effect
   .all({
@@ -47,6 +56,7 @@ export const setupRequestContextFromCurrent =
   (name = "request", options?: Tracer.SpanOptions) => <R, E, A>(self: Effect.Effect<A, E, R>) =>
     self
       .pipe(
+        withSqlTransaction,
         withRequestSpan(name, options),
         Effect.provide(ContextMapContainer.layer, { local: true })
       )
@@ -60,6 +70,7 @@ export function setupRequestContext<R, E, A>(self: Effect.Effect<A, E, R>, reque
   )
   return self
     .pipe(
+      withSqlTransaction,
       withRequestSpan(requestContext.name),
       Effect.provide(layer, { local: true })
     )
@@ -78,6 +89,7 @@ export function setupRequestContextWithCustomSpan<R, E, A>(
   )
   return self
     .pipe(
+      withSqlTransaction,
       withRequestSpan(name, options),
       Effect.provide(layer, { local: true })
     )

--- a/packages/infra/src/api/setupRequest.ts
+++ b/packages/infra/src/api/setupRequest.ts
@@ -52,17 +52,25 @@ const withRequestSpan = (name = "request", options?: Tracer.SpanOptions) => <R, 
       )
   )
 
+export interface SetupRequestOptions {
+  readonly withTransaction?: boolean
+}
+
 export const setupRequestContextFromCurrent =
-  (name = "request", options?: Tracer.SpanOptions) => <R, E, A>(self: Effect.Effect<A, E, R>) =>
+  (name = "request", options?: Tracer.SpanOptions & SetupRequestOptions) => <R, E, A>(self: Effect.Effect<A, E, R>) =>
     self
       .pipe(
-        withSqlTransaction,
+        options?.withTransaction !== false ? withSqlTransaction : (_) => _,
         withRequestSpan(name, options),
         Effect.provide(ContextMapContainer.layer, { local: true })
       )
 
 // TODO: consider integrating Effect.withParentSpan
-export function setupRequestContext<R, E, A>(self: Effect.Effect<A, E, R>, requestContext: RequestContext) {
+export function setupRequestContext<R, E, A>(
+  self: Effect.Effect<A, E, R>,
+  requestContext: RequestContext,
+  options?: SetupRequestOptions
+) {
   const layer = Layer.mergeAll(
     ContextMapContainer.layer,
     Layer.succeed(LocaleRef, requestContext.locale),
@@ -70,7 +78,7 @@ export function setupRequestContext<R, E, A>(self: Effect.Effect<A, E, R>, reque
   )
   return self
     .pipe(
-      withSqlTransaction,
+      options?.withTransaction !== false ? withSqlTransaction : (_) => _,
       withRequestSpan(requestContext.name),
       Effect.provide(layer, { local: true })
     )
@@ -80,7 +88,7 @@ export function setupRequestContextWithCustomSpan<R, E, A>(
   self: Effect.Effect<A, E, R>,
   requestContext: RequestContext,
   name: string,
-  options?: Tracer.SpanOptions
+  options?: Tracer.SpanOptions & SetupRequestOptions
 ) {
   const layer = Layer.mergeAll(
     ContextMapContainer.layer,
@@ -89,7 +97,7 @@ export function setupRequestContextWithCustomSpan<R, E, A>(
   )
   return self
     .pipe(
-      withSqlTransaction,
+      options?.withTransaction !== false ? withSqlTransaction : (_) => _,
       withRequestSpan(name, options),
       Effect.provide(layer, { local: true })
     )

--- a/packages/infra/test/sql-store.test.ts
+++ b/packages/infra/test/sql-store.test.ts
@@ -1,0 +1,444 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import type Sqlite from "better-sqlite3"
+import BetterSqlite from "better-sqlite3"
+import { describe, expect, it } from "vitest"
+import { buildWhereSQLQuery, pgDialect, sqliteDialect } from "../src/Store/SQL/query.js"
+
+const query = (db: Sqlite.Database, sql: string, params: unknown[] = []) =>
+  db.prepare(sql).all(...params as any[]) as any[]
+
+// --- Query builder unit tests ---
+
+describe("SQL query builder (SQLite dialect)", () => {
+  it("where eq string", () => {
+    const result = buildWhereSQLQuery(
+      sqliteDialect,
+      "id",
+      [{ t: "where", path: "name", op: "eq", value: "John" }],
+      "users",
+      {}
+    )
+    expect(result.sql).toContain("json_extract(data, '$.name') = ?")
+    expect(result.params).toContain("John")
+  })
+
+  it("where eq number", () => {
+    const result = buildWhereSQLQuery(
+      sqliteDialect,
+      "id",
+      [{ t: "where", path: "age", op: "eq", value: 25 as any }],
+      "users",
+      {}
+    )
+    expect(result.sql).toContain("json_extract(data, '$.age') = ?")
+    expect(result.params).toContain(25)
+  })
+
+  it("where gt", () => {
+    const result = buildWhereSQLQuery(
+      sqliteDialect,
+      "id",
+      [{ t: "where", path: "age", op: "gt", value: 18 as any }],
+      "users",
+      {}
+    )
+    expect(result.sql).toContain("json_extract(data, '$.age') > ?")
+    expect(result.params).toContain(18)
+  })
+
+  it("where or", () => {
+    const result = buildWhereSQLQuery(
+      sqliteDialect,
+      "id",
+      [
+        { t: "where", path: "name", op: "eq", value: "Alice" },
+        { t: "or", path: "name", op: "eq", value: "Bob" }
+      ],
+      "users",
+      {}
+    )
+    expect(result.sql).toContain("= ?")
+    expect(result.sql).toContain("OR")
+    expect(result.params).toEqual(expect.arrayContaining(["Alice", "Bob"]))
+  })
+
+  it("where and", () => {
+    const result = buildWhereSQLQuery(
+      sqliteDialect,
+      "id",
+      [
+        { t: "where", path: "name", op: "eq", value: "Alice" },
+        { t: "and", path: "age", op: "gt", value: 18 as any }
+      ],
+      "users",
+      {}
+    )
+    expect(result.sql).toContain("AND")
+    expect(result.params).toEqual(expect.arrayContaining(["Alice", 18]))
+  })
+
+  it("where in", () => {
+    const result = buildWhereSQLQuery(
+      sqliteDialect,
+      "id",
+      [{ t: "where", path: "id", op: "in", value: ["a", "b", "c"] as any }],
+      "users",
+      {}
+    )
+    expect(result.sql).toContain("id IN (?, ?, ?)")
+    expect(result.params).toEqual(expect.arrayContaining(["a", "b", "c"]))
+  })
+
+  it("where null", () => {
+    const result = buildWhereSQLQuery(
+      sqliteDialect,
+      "id",
+      [{ t: "where", path: "status", op: "eq", value: null as any }],
+      "users",
+      {}
+    )
+    expect(result.sql).toContain("IS NULL")
+  })
+
+  it("where neq null", () => {
+    const result = buildWhereSQLQuery(
+      sqliteDialect,
+      "id",
+      [{ t: "where", path: "status", op: "neq", value: null as any }],
+      "users",
+      {}
+    )
+    expect(result.sql).toContain("IS NOT NULL")
+  })
+
+  it("where contains", () => {
+    const result = buildWhereSQLQuery(
+      sqliteDialect,
+      "id",
+      [{ t: "where", path: "name", op: "contains", value: "oh" }],
+      "users",
+      {}
+    )
+    expect(result.sql).toContain("LIKE")
+    expect(result.sql).toContain("LOWER")
+    expect(result.params).toContain("%oh%")
+  })
+
+  it("where startsWith", () => {
+    const result = buildWhereSQLQuery(
+      sqliteDialect,
+      "id",
+      [{ t: "where", path: "name", op: "startsWith", value: "Jo" }],
+      "users",
+      {}
+    )
+    expect(result.sql).toContain("LIKE")
+    expect(result.params).toContain("Jo%")
+  })
+
+  it("where endsWith", () => {
+    const result = buildWhereSQLQuery(
+      sqliteDialect,
+      "id",
+      [{ t: "where", path: "name", op: "endsWith", value: "hn" }],
+      "users",
+      {}
+    )
+    expect(result.sql).toContain("LIKE")
+    expect(result.params).toContain("%hn")
+  })
+
+  it("where includes (array contains)", () => {
+    const result = buildWhereSQLQuery(
+      sqliteDialect,
+      "id",
+      [{ t: "where", path: "tags", op: "includes", value: "admin" }],
+      "users",
+      {}
+    )
+    expect(result.sql).toContain("json_each")
+    expect(result.sql).toContain("value = ?")
+    expect(result.params).toContain("admin")
+  })
+
+  it("where includes-any (array contains any)", () => {
+    const result = buildWhereSQLQuery(
+      sqliteDialect,
+      "id",
+      [{ t: "where", path: "tags", op: "includes-any", value: ["admin", "user"] as any }],
+      "users",
+      {}
+    )
+    expect(result.sql).toContain("json_each")
+    expect(result.sql).toContain("IN")
+  })
+
+  it("nested scopes", () => {
+    const result = buildWhereSQLQuery(
+      sqliteDialect,
+      "id",
+      [
+        { t: "where", path: "a", op: "eq", value: "1" },
+        {
+          t: "or-scope",
+          result: [
+            { t: "where", path: "b", op: "eq", value: "2" },
+            { t: "and", path: "c", op: "eq", value: "3" }
+          ],
+          relation: "some" as const
+        }
+      ],
+      "test",
+      {}
+    )
+    expect(result.sql).toContain("OR (")
+    expect(result.sql).toContain("AND")
+    expect(result.params).toEqual(expect.arrayContaining(["1", "2", "3"]))
+  })
+
+  it("id key maps to id column", () => {
+    const result = buildWhereSQLQuery(
+      sqliteDialect,
+      "myId",
+      [{ t: "where", path: "myId", op: "eq", value: "123" }],
+      "users",
+      {}
+    )
+    expect(result.sql).toContain("id = ?")
+    expect(result.sql).not.toContain("json_extract")
+    expect(result.params).toContain("123")
+  })
+
+  it("order + limit + skip", () => {
+    const result = buildWhereSQLQuery(
+      sqliteDialect,
+      "id",
+      [],
+      "users",
+      {},
+      undefined,
+      [{ key: "name", direction: "ASC" }] as any,
+      5,
+      10
+    )
+    expect(result.sql).toContain("ORDER BY")
+    expect(result.sql).toContain("ASC")
+    expect(result.sql).toContain("LIMIT")
+    expect(result.sql).toContain("OFFSET")
+  })
+})
+
+describe("SQL query builder (PostgreSQL dialect)", () => {
+  it("where eq string uses ->> operator", () => {
+    const result = buildWhereSQLQuery(
+      pgDialect,
+      "id",
+      [{ t: "where", path: "name", op: "eq", value: "John" }],
+      "users",
+      {}
+    )
+    expect(result.sql).toContain("data->>'name'")
+    expect(result.sql).toContain("$1")
+    expect(result.params).toContain("John")
+  })
+
+  it("where contains uses ILIKE", () => {
+    const result = buildWhereSQLQuery(
+      pgDialect,
+      "id",
+      [{ t: "where", path: "name", op: "contains", value: "oh" }],
+      "users",
+      {}
+    )
+    expect(result.sql).toContain("ILIKE")
+    expect(result.params).toContain("%oh%")
+  })
+
+  it("where in uses $N placeholders", () => {
+    const result = buildWhereSQLQuery(
+      pgDialect,
+      "id",
+      [{ t: "where", path: "status", op: "in", value: ["active", "pending"] as any }],
+      "users",
+      {}
+    )
+    expect(result.sql).toContain("$1")
+    expect(result.sql).toContain("$2")
+    expect(result.params).toEqual(expect.arrayContaining(["active", "pending"]))
+  })
+
+  it("where includes uses @> jsonb operator", () => {
+    const result = buildWhereSQLQuery(
+      pgDialect,
+      "id",
+      [{ t: "where", path: "tags", op: "includes", value: "admin" }],
+      "users",
+      {}
+    )
+    expect(result.sql).toContain("@>")
+    expect(result.sql).toContain("jsonb")
+  })
+
+  it("nested path uses chained -> operators", () => {
+    const result = buildWhereSQLQuery(
+      pgDialect,
+      "id",
+      [{ t: "where", path: "address.city", op: "eq", value: "NYC" }],
+      "users",
+      {}
+    )
+    expect(result.sql).toContain("data->'address'->>'city'")
+  })
+})
+
+// --- Integration tests with in-memory SQLite (direct, no Effect SQL client) ---
+
+describe("SQL Store (SQLite integration)", () => {
+  const withDb = (fn: (db: Sqlite.Database) => void) => {
+    const db = new BetterSqlite(":memory:")
+    db.pragma("journal_mode = WAL")
+    try {
+      fn(db)
+    } finally {
+      db.close()
+    }
+  }
+
+  it("creates table and seeds data", () =>
+    withDb((db) => {
+      db.exec(
+        `CREATE TABLE IF NOT EXISTS "test_items" (id TEXT PRIMARY KEY, _etag TEXT, data JSON NOT NULL)`
+      )
+      db.prepare(`INSERT INTO "test_items" (id, _etag, data) VALUES (?, ?, ?)`)
+        .run("1", "etag1", JSON.stringify({ id: "1", name: "Alice", age: 30 }))
+
+      const rows = db.prepare(`SELECT * FROM "test_items"`).all()
+      expect(rows.length).toBe(1)
+      expect((rows[0] as any).id).toBe("1")
+    }))
+
+  it("query builder generates valid SQL for SQLite", () =>
+    withDb((db) => {
+      db.exec(
+        `CREATE TABLE IF NOT EXISTS "test_people" (id TEXT PRIMARY KEY, _etag TEXT, data JSON NOT NULL)`
+      )
+
+      const people = [
+        { id: "1", name: "Alice", age: 30, tags: ["admin", "user"] },
+        { id: "2", name: "Bob", age: 25, tags: ["user"] },
+        { id: "3", name: "Charlie", age: 35, tags: ["admin"] },
+        { id: "4", name: "Diana", age: 28, tags: ["user", "editor"] }
+      ]
+
+      const insert = db.prepare(
+        `INSERT INTO "test_people" (id, _etag, data) VALUES (?, ?, ?)`
+      )
+      for (const p of people) {
+        insert.run(p.id, `etag_${p.id}`, JSON.stringify(p))
+      }
+
+      // Test eq
+      const q1 = buildWhereSQLQuery(
+        sqliteDialect, "id",
+        [{ t: "where", path: "name", op: "eq", value: "Alice" }],
+        "test_people", {}
+      )
+      expect(query(db, q1.sql, q1.params).length).toBe(1)
+      expect((JSON.parse((query(db, q1.sql, q1.params)[0] as any).data) as any).name).toBe("Alice")
+
+      // Test gt
+      const q2 = buildWhereSQLQuery(
+        sqliteDialect, "id",
+        [{ t: "where", path: "age", op: "gt", value: 28 as any }],
+        "test_people", {}
+      )
+      expect(query(db, q2.sql, q2.params).length).toBe(2)
+
+      // Test OR
+      const q3 = buildWhereSQLQuery(
+        sqliteDialect, "id",
+        [
+          { t: "where", path: "name", op: "eq", value: "Alice" },
+          { t: "or", path: "name", op: "eq", value: "Bob" }
+        ],
+        "test_people", {}
+      )
+      expect(query(db, q3.sql, q3.params).length).toBe(2)
+
+      // Test AND
+      const q4 = buildWhereSQLQuery(
+        sqliteDialect, "id",
+        [
+          { t: "where", path: "name", op: "eq", value: "Alice" },
+          { t: "and", path: "age", op: "gt", value: 25 as any }
+        ],
+        "test_people", {}
+      )
+      const r4 = query(db, q4.sql, q4.params)
+      expect(r4.length).toBe(1)
+      expect((JSON.parse((r4[0] as any).data) as any).name).toBe("Alice")
+
+      // Test IN
+      const q5 = buildWhereSQLQuery(
+        sqliteDialect, "id",
+        [{ t: "where", path: "id", op: "in", value: ["1", "3"] as any }],
+        "test_people", {}
+      )
+      expect(query(db, q5.sql, q5.params).length).toBe(2)
+
+      // Test contains (string)
+      const q6 = buildWhereSQLQuery(
+        sqliteDialect, "id",
+        [{ t: "where", path: "name", op: "contains", value: "li" }],
+        "test_people", {}
+      )
+      expect(query(db, q6.sql, q6.params).length).toBe(2) // Alice, Charlie
+
+      // Test startsWith
+      const q7 = buildWhereSQLQuery(
+        sqliteDialect, "id",
+        [{ t: "where", path: "name", op: "startsWith", value: "Al" }],
+        "test_people", {}
+      )
+      const r7 = query(db, q7.sql, q7.params)
+      expect(r7.length).toBe(1)
+      expect((JSON.parse((r7[0] as any).data) as any).name).toBe("Alice")
+
+      // Test includes (array)
+      const q8 = buildWhereSQLQuery(
+        sqliteDialect, "id",
+        [{ t: "where", path: "tags", op: "includes", value: "admin" }],
+        "test_people", {}
+      )
+      expect(query(db, q8.sql, q8.params).length).toBe(2) // Alice, Charlie
+
+      // Test nested scope: where name = Alice OR (age > 30 AND name contains 'ar')
+      const q9 = buildWhereSQLQuery(
+        sqliteDialect, "id",
+        [
+          { t: "where", path: "name", op: "eq", value: "Alice" },
+          {
+            t: "or-scope",
+            result: [
+              { t: "where", path: "age", op: "gt", value: 30 as any },
+              { t: "and", path: "name", op: "contains", value: "ar" }
+            ],
+            relation: "some"
+          }
+        ],
+        "test_people", {}
+      )
+      expect(query(db, q9.sql, q9.params).length).toBe(2) // Alice + Charlie
+
+      // Test order + limit
+      const q10 = buildWhereSQLQuery(
+        sqliteDialect, "id", [], "test_people", {},
+        undefined,
+        [{ key: "age", direction: "DESC" }] as any,
+        undefined, 2
+      )
+      const r10 = query(db, q10.sql, q10.params)
+      expect(r10.length).toBe(2)
+      expect((JSON.parse((r10[0] as any).data) as any).name).toBe("Charlie") // oldest first
+    }))
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -449,6 +449,9 @@ importers:
       '@sentry/opentelemetry':
         specifier: 10.47.0
         version: 10.47.0(@opentelemetry/api@1.9.1)(@opentelemetry/context-async-hooks@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)
+      '@types/better-sqlite3':
+        specifier: ^7.6.13
+        version: 7.6.13
       '@types/express':
         specifier: ^5.0.6
         version: 5.0.6
@@ -464,6 +467,9 @@ importers:
       '@types/redlock':
         specifier: ^4.0.8
         version: 4.0.8
+      better-sqlite3:
+        specifier: ^12.9.0
+        version: 12.9.0
       express:
         specifier: ^5.2.1
         version: 5.2.1
@@ -1088,36 +1094,43 @@ packages:
     resolution: {integrity: sha512-K0aj5bLtPlSsTDAtLwEjwDGPIVpc8lgmvpLzf6IdASJn1kMkowPoZSCNUvmUUJTTmANscMugLsi9XGVbBzkE6Q==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@dprint/linux-arm64-musl@0.53.2':
     resolution: {integrity: sha512-209yb6BGMiohPuB12wgnodULEs3JC1epLaHyN5s2XpDU7rWi6WqWkzeSuuN2TTAbDz4Z51tqe5KJSRsF0yi+Dg==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@dprint/linux-loong64-glibc@0.53.2':
     resolution: {integrity: sha512-IngXJ6c7n/DYd2j1CssLHqxtGILMv0BEQZplx8kIYedGyVbzLSxJu7XpqgThnCuLQjh4elfRkT67Q8g7l//m0Q==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@dprint/linux-loong64-musl@0.53.2':
     resolution: {integrity: sha512-ExtcNOjSbXgpoWw5efAO00xYTOlEsEyz58v/HPJzEV5tfn9J7vozSVxTdXLDkTgg+USEQLaZ9qTnXxc1kbraiQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@dprint/linux-riscv64-glibc@0.53.2':
     resolution: {integrity: sha512-2UTqXMkIhyK7rYdpBY7tE3x1R36msWjX3lU3MdYM9HauldnsHJx2EhZofIYzHBICH8eziw/W7aY8HWo4oLdJ/A==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@dprint/linux-x64-glibc@0.53.2':
     resolution: {integrity: sha512-hO4O7d20IALUCFbFG2H7kvP5Di3/G8fqrMXzX9Fdps4ccM4Kg3Cr9LZ/G+mif4Q9WwwUnkOJ0oXBxeqJ8S65ng==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@dprint/linux-x64-musl@0.53.2':
     resolution: {integrity: sha512-XHqYE5nFz1s5Z2J1E9j8JYHE4ISp5KCfaYT7fs4lW14G2B8U/CtutUGWzvP5aYRGfLc6CYGrWgKAQppn846vUQ==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@dprint/typescript@0.95.15':
     resolution: {integrity: sha512-PQGYicsjlv7Eq+5BzpI04Ow2N9xeHkjr9O1TG3lDebK2B48IvXFQz0RwO4OhkKj22o7YLcjVIFM6WL7zVuM2ng==}
@@ -1943,36 +1956,42 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.4':
     resolution: {integrity: sha512-kGO8RPvVrcAotV4QcWh8kZuHr9bXi9a3bSZw7kFarYR0+fGliU7hd/zevhjw8fnvIKG3J9EO5G6sXNGCSNMYPQ==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.4':
     resolution: {integrity: sha512-KU75aooXhqGFY2W5/p8DYYHt4hrjHZod8AhcGAmhzPn/etTa+lYCDB2b1sJy3sWJ8ahFVTdy+EbqSBvMx3iFlw==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.4':
     resolution: {integrity: sha512-Qx8uNiIekVutnzbVdrgSanM+cbpDD3boB1f8vMtnuG5Zau4/bdDbXyKwIn0ToqFhIuob73bcxV9NwRm04/hzHQ==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.4':
     resolution: {integrity: sha512-UYBQvhYmgAv61LNUn24qGQdjtycFBKSK3EXr72DbJqX9aaLbtCOO8+1SkKhD/GNiJ97ExgcHBrukcYhVjrnogA==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.4':
     resolution: {integrity: sha512-YoRWCVgxv8akZrMhdyVi6/TyoeeMkQ0PGGOf2E4omODrvd1wxniXP+DBynKoHryStks7l+fDAMUBRzqNHrVOpg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.5.4':
     resolution: {integrity: sha512-iby+D/YNXWkiQNYcIhg8P5hSjzXEHaQrk2SLrWOUD7VeC4Ohu0WQvmV+HDJokZVJ2UjJ4AGXW3bx7Lls9Ln4TQ==}
@@ -2061,36 +2080,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.13':
     resolution: {integrity: sha512-bmRg3O6Z0gq9yodKKWCIpnlH051sEfdVwt+6m5UDffAQMUUqU0xjnQqqAUm+Gu7ofAAly9DqiQDtKu2nPDEABA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.13':
     resolution: {integrity: sha512-8Wtnbw4k7pMYN9B/mOEAsQ8HOiq7AZ31Ig4M9BKn2So4xRaFEhtCSa4ZJaOutOWq50zpgR4N5+L/opnlaCx8wQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.13':
     resolution: {integrity: sha512-D/0Nlo8mQuxSMohNJUF2lDXWRsFDsHldfRRgD9bRgktj+EndGPj4DOV37LqDKPYS+osdyhZEH7fTakTAEcW7qg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.13':
     resolution: {integrity: sha512-eRrPvat2YaVQcwwKi/JzOP6MKf1WRnOCr+VaI3cTWz3ZoLcP/654z90lVCJ4dAuMEpPdke0n+qyAqXDZdIC4rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.13':
     resolution: {integrity: sha512-PsdONiFRp8hR8KgVjTWjZ9s7uA3uueWL0t74/cKHfM4dR5zXYv4AjB8BvA+QDToqxAFg4ZkcVEqeu5F7inoz5w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.13':
     resolution: {integrity: sha512-hCNXgC5dI3TVOLrPT++PKFNZ+1EtS0mLQwfXXXSUD/+rGlB65gZDwN/IDuxLpQP4x8RYYHqGomlUXzpO8aVI2w==}
@@ -2155,66 +2180,79 @@ packages:
     resolution: {integrity: sha512-Rn3n+FUk2J5VWx+ywrG/HGPTD9jXNbicRtTM11e/uorplArnXZYsVifnPPqNNP5BsO3roI4n8332ukpY/zN7rQ==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.55.1':
     resolution: {integrity: sha512-grPNWydeKtc1aEdrJDWk4opD7nFtQbMmV7769hiAaYyUKCT1faPRm2av8CX1YJsZ4TLAZcg9gTR1KvEzoLjXkg==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.55.1':
     resolution: {integrity: sha512-a59mwd1k6x8tXKcUxSyISiquLwB5pX+fJW9TkWU46lCqD/GRDe9uDN31jrMmVP3feI3mhAdvcCClhV8V5MhJFQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.55.1':
     resolution: {integrity: sha512-puS1MEgWX5GsHSoiAsF0TYrpomdvkaXm0CofIMG5uVkP6IBV+ZO9xhC5YEN49nsgYo1DuuMquF9+7EDBVYu4uA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.55.1':
     resolution: {integrity: sha512-r3Wv40in+lTsULSb6nnoudVbARdOwb2u5fpeoOAZjFLznp6tDU8kd+GTHmJoqZ9lt6/Sys33KdIHUaQihFcu7g==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.55.1':
     resolution: {integrity: sha512-MR8c0+UxAlB22Fq4R+aQSPBayvYa3+9DrwG/i1TKQXFYEaoW3B5b/rkSRIypcZDdWjWnpcvxbNaAJDcSbJU3Lw==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.55.1':
     resolution: {integrity: sha512-3KhoECe1BRlSYpMTeVrD4sh2Pw2xgt4jzNSZIIPLFEsnQn9gAnZagW9+VqDqAHgm1Xc77LzJOo2LdigS5qZ+gw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.55.1':
     resolution: {integrity: sha512-ziR1OuZx0vdYZZ30vueNZTg73alF59DicYrPViG0NEgDVN8/Jl87zkAPu4u6VjZST2llgEUjaiNl9JM6HH1Vdw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.55.1':
     resolution: {integrity: sha512-uW0Y12ih2XJRERZ4jAfKamTyIHVMPQnTZcQjme2HMVDAHY4amf5u414OqNYC+x+LzRdRcnIG1YodLrrtA8xsxw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.55.1':
     resolution: {integrity: sha512-u9yZ0jUkOED1BFrqu3BwMQoixvGHGZ+JhJNkNKY/hyoEgOwlqKb62qu+7UjbPSHYjiVy8kKJHvXKv5coH4wDeg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.55.1':
     resolution: {integrity: sha512-/0PenBCmqM4ZUd0190j7J0UsQ/1nsi735iPRakO8iPciE7BQ495Y6msPzaOmvx0/pn+eJVVlZrNrSh4WSYLxNg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.55.1':
     resolution: {integrity: sha512-a8G4wiQxQG2BAvo+gU6XrReRRqj+pLS2NGXKm8io19goR+K8lw269eTrPkSdDTALwMmJp4th2Uh0D8J9bEV1vg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.55.1':
     resolution: {integrity: sha512-bD+zjpFrMpP/hqkfEcnjXWHMw5BIghGisOKPj+2NaNDuVT+8Ds4mPf3XcPHuat1tz89WRL+1wbcxKY3WSbiT7w==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.55.1':
     resolution: {integrity: sha512-eLXw0dOiqE4QmvikfQ6yjgkg/xDM+MdU9YJuP4ySTibXU0oAvnEWXt7UDJmD4UkYialMfOGFPJnIHSe/kdzPxg==}
@@ -2489,6 +2527,9 @@ packages:
 
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
+  '@types/better-sqlite3@7.6.13':
+    resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
 
   '@types/bluebird@3.5.42':
     resolution: {integrity: sha512-Jhy+MWRlro6UjVi578V/4ZGNfeCOcNCp0YaFNIUGFKlImowqwb1O/22wDVk3FDGMLqxdpOV3qQHD5fPEH4hK6A==}
@@ -2782,41 +2823,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -3319,12 +3368,19 @@ packages:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
 
+  better-sqlite3@12.9.0:
+    resolution: {integrity: sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ==}
+    engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x}
+
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
+
+  bindings@1.5.0:
+    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
 
   birpc@2.9.0:
     resolution: {integrity: sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==}
@@ -3446,6 +3502,9 @@ packages:
   chokidar@5.0.0:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
     engines: {node: '>= 20.19.0'}
+
+  chownr@1.1.4:
+    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
   chrome-trace-event@1.0.4:
     resolution: {integrity: sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==}
@@ -3621,6 +3680,10 @@ packages:
   decode-uri-component@0.4.1:
     resolution: {integrity: sha512-+8VxcR21HhTy8nOt6jf20w0c9CADrw1O8d+VZ/YzzCt4bJ3uBjw+D1q2osAB8RnpwwaeYBxy0HyKQxD5JBMuuQ==}
     engines: {node: '>=14.16'}
+
+  decompress-response@6.0.0:
+    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
+    engines: {node: '>=10'}
 
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
@@ -3813,6 +3876,9 @@ packages:
   encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
+
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
   enhanced-resolve@0.9.1:
     resolution: {integrity: sha512-kxpoMgrdtkXZ5h0SeraBS1iRntpTpQ3R8ussdb38+UAFnMGX5DDyJXePm+OCHOcoXvHDw7mc2erbJBpDnl7TPw==}
@@ -4101,6 +4167,10 @@ packages:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
 
+  expand-template@2.0.3:
+    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
+    engines: {node: '>=6'}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
@@ -4162,6 +4232,9 @@ packages:
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
+
+  file-uri-to-path@1.0.0:
+    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
 
   filing-cabinet@5.0.3:
     resolution: {integrity: sha512-PlPcMwVWg60NQkhvfoxZs4wEHjhlOO/y7OAm4sKM60o1Z9nttRY4mcdQxp/iZ+kg/Vv6Hw1OAaTbYVM9DA9pYg==}
@@ -4242,6 +4315,9 @@ packages:
   from@0.1.7:
     resolution: {integrity: sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g==}
 
+  fs-constants@1.0.0:
+    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
+
   fs-extra@7.0.1:
     resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
     engines: {node: '>=6 <7 || >=8'}
@@ -4305,6 +4381,9 @@ packages:
 
   get-tsconfig@4.13.0:
     resolution: {integrity: sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==}
+
+  github-from-package@0.0.0:
+    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -4898,24 +4977,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -5126,6 +5209,10 @@ packages:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
 
+  mimic-response@3.1.0:
+    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
+    engines: {node: '>=10'}
+
   min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
@@ -5161,6 +5248,9 @@ packages:
 
   mitt@3.0.1:
     resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
+
+  mkdirp-classic@0.5.3:
+    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
 
   mlly@1.8.0:
     resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
@@ -5242,6 +5332,9 @@ packages:
     engines: {node: ^18 || >=20}
     hasBin: true
 
+  napi-build-utils@2.0.0:
+    resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
+
   napi-postinstall@0.3.4:
     resolution: {integrity: sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
@@ -5259,6 +5352,10 @@ packages:
 
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
+
+  node-abi@3.89.0:
+    resolution: {integrity: sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==}
+    engines: {node: '>=10'}
 
   node-addon-api@7.1.1:
     resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
@@ -5569,6 +5666,12 @@ packages:
   preact@10.28.2:
     resolution: {integrity: sha512-lbteaWGzGHdlIuiJ0l2Jq454m6kcpI1zNje6d8MlGAFlYvP2GO4ibnat7P74Esfz4sPTdM6UxtTwh/d3pwM9JA==}
 
+  prebuild-install@7.1.3:
+    resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
+    engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
+    hasBin: true
+
   precinct@12.2.0:
     resolution: {integrity: sha512-NFBMuwIfaJ4SocE9YXPU/n4AcNSoFMVFjP72nvl3cx69j/ke61/hPOWFREVxLkFhhEGnA8ZuVfTqJBa+PK3b5w==}
     engines: {node: '>=18'}
@@ -5674,6 +5777,9 @@ packages:
 
   pug@3.0.3:
     resolution: {integrity: sha512-uBi6kmc9f3SZ3PXxqcHiUZLmIXgfgWooKWXcwSGwQd2Zi5Rb0bT14+8CJjJgI8AB+nndLaNgHGrcc6bPIB665g==}
+
+  pump@3.0.4:
+    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -6032,6 +6138,12 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
+  simple-concat@1.0.1:
+    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
+
+  simple-get@4.0.1:
+    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
+
   simple-update-notifier@2.0.0:
     resolution: {integrity: sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==}
     engines: {node: '>=10'}
@@ -6253,6 +6365,13 @@ packages:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
     engines: {node: '>=6'}
 
+  tar-fs@2.1.4:
+    resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
+
+  tar-stream@2.2.0:
+    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
+    engines: {node: '>=6'}
+
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
     engines: {node: '>=8'}
@@ -6407,6 +6526,9 @@ packages:
     resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
     engines: {node: '>=18.0.0'}
     hasBin: true
+
+  tunnel-agent@0.6.0:
+    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -8893,6 +9015,10 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
+  '@types/better-sqlite3@7.6.13':
+    dependencies:
+      '@types/node': 25.5.2
+
   '@types/bluebird@3.5.42': {}
 
   '@types/body-parser@1.19.6':
@@ -9876,11 +10002,20 @@ snapshots:
     dependencies:
       is-windows: 1.0.2
 
+  better-sqlite3@12.9.0:
+    dependencies:
+      bindings: 1.5.0
+      prebuild-install: 7.1.3
+
   bidi-js@1.0.3:
     dependencies:
       require-from-string: 2.0.2
 
   binary-extensions@2.3.0: {}
+
+  bindings@1.5.0:
+    dependencies:
+      file-uri-to-path: 1.0.0
 
   birpc@2.9.0: {}
 
@@ -10024,6 +10159,8 @@ snapshots:
   chokidar@5.0.0:
     dependencies:
       readdirp: 5.0.0
+
+  chownr@1.1.4: {}
 
   chrome-trace-event@1.0.4: {}
 
@@ -10176,6 +10313,10 @@ snapshots:
   decimal.js@10.6.0: {}
 
   decode-uri-component@0.4.1: {}
+
+  decompress-response@6.0.0:
+    dependencies:
+      mimic-response: 3.1.0
 
   deep-eql@5.0.2: {}
 
@@ -10372,6 +10513,10 @@ snapshots:
   emoji-regex@9.2.2: {}
 
   encodeurl@2.0.0: {}
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
 
   enhanced-resolve@0.9.1:
     dependencies:
@@ -10831,6 +10976,8 @@ snapshots:
       signal-exit: 3.0.7
       strip-final-newline: 2.0.0
 
+  expand-template@2.0.3: {}
+
   expect-type@1.3.0: {}
 
   expect@26.6.2:
@@ -10919,6 +11066,8 @@ snapshots:
     dependencies:
       flat-cache: 4.0.1
 
+  file-uri-to-path@1.0.0: {}
+
   filing-cabinet@5.0.3:
     dependencies:
       app-module-path: 2.2.0
@@ -11004,6 +11153,8 @@ snapshots:
 
   from@0.1.7: {}
 
+  fs-constants@1.0.0: {}
+
   fs-extra@7.0.1:
     dependencies:
       graceful-fs: 4.2.11
@@ -11076,6 +11227,8 @@ snapshots:
   get-tsconfig@4.13.0:
     dependencies:
       resolve-pkg-maps: 1.0.0
+
+  github-from-package@0.0.0: {}
 
   glob-parent@5.1.2:
     dependencies:
@@ -11886,6 +12039,8 @@ snapshots:
 
   mimic-fn@2.1.0: {}
 
+  mimic-response@3.1.0: {}
+
   min-indent@1.0.1: {}
 
   minimatch@10.2.4:
@@ -11915,6 +12070,8 @@ snapshots:
   minisearch@7.2.0: {}
 
   mitt@3.0.1: {}
+
+  mkdirp-classic@0.5.3: {}
 
   mlly@1.8.0:
     dependencies:
@@ -11978,6 +12135,8 @@ snapshots:
 
   nanoid@5.1.7: {}
 
+  napi-build-utils@2.0.0: {}
+
   napi-postinstall@0.3.4: {}
 
   natural-compare-lite@1.4.0: {}
@@ -11987,6 +12146,10 @@ snapshots:
   negotiator@1.0.0: {}
 
   neo-async@2.6.2: {}
+
+  node-abi@3.89.0:
+    dependencies:
+      semver: 7.7.3
 
   node-addon-api@7.1.1:
     optional: true
@@ -12307,6 +12470,21 @@ snapshots:
 
   preact@10.28.2: {}
 
+  prebuild-install@7.1.3:
+    dependencies:
+      detect-libc: 2.1.2
+      expand-template: 2.0.3
+      github-from-package: 0.0.0
+      minimist: 1.2.8
+      mkdirp-classic: 0.5.3
+      napi-build-utils: 2.0.0
+      node-abi: 3.89.0
+      pump: 3.0.4
+      rc: 1.2.8
+      simple-get: 4.0.1
+      tar-fs: 2.1.4
+      tunnel-agent: 0.6.0
+
   precinct@12.2.0:
     dependencies:
       '@dependents/detective-less': 5.0.1
@@ -12459,6 +12637,11 @@ snapshots:
       pug-parser: 6.0.0
       pug-runtime: 3.0.1
       pug-strip-comments: 2.0.0
+
+  pump@3.0.4:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
 
   punycode@2.3.1: {}
 
@@ -12926,6 +13109,14 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
+  simple-concat@1.0.1: {}
+
+  simple-get@4.0.1:
+    dependencies:
+      decompress-response: 6.0.0
+      once: 1.4.0
+      simple-concat: 1.0.1
+
   simple-update-notifier@2.0.0:
     dependencies:
       semver: 7.7.3
@@ -13160,6 +13351,21 @@ snapshots:
 
   tapable@2.3.0: {}
 
+  tar-fs@2.1.4:
+    dependencies:
+      chownr: 1.1.4
+      mkdirp-classic: 0.5.3
+      pump: 3.0.4
+      tar-stream: 2.2.0
+
+  tar-stream@2.2.0:
+    dependencies:
+      bl: 4.1.0
+      end-of-stream: 1.4.5
+      fs-constants: 1.0.0
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
   term-size@2.2.1: {}
 
   terser-webpack-plugin@5.3.16(esbuild@0.27.2)(webpack@5.104.1(esbuild@0.27.2)):
@@ -13293,6 +13499,10 @@ snapshots:
       get-tsconfig: 4.13.0
     optionalDependencies:
       fsevents: 2.3.3
+
+  tunnel-agent@0.6.0:
+    dependencies:
+      safe-buffer: 5.2.1
 
   type-check@0.4.0:
     dependencies:


### PR DESCRIPTION
## feat(infra): add SQL Store adapter and namespace support

### Summary

Adds a SQL-backed Store adapter for Effect SQL (SQLite + PostgreSQL), namespace isolation for both SQL and CosmosDB adapters, and configurable SQL transaction support in the request pipeline.

### Changes

#### SQL Store adapter
- New `Store/SQL.ts` and `Store/SQL/Pg.ts` — table-per-repo with `id`/`_etag`/`data` JSON columns
- Query DSL translation to SQL `WHERE` clauses via `Store/SQL/query.ts`
- Optimistic concurrency via etag comparison on set/batchSet
- SQLite dialect (default) and Postgres dialect with `jsonb` support
- Comprehensive test suite (`sql-store.test.ts`, 444 lines)

#### Namespace support
- **SQL adapters**: `_namespace` column with composite primary key `(id, _namespace)` isolates data per namespace within the same table
- **CosmosDB adapter**: partition key prefixing (e.g., `test-ns::primary`) isolates data per namespace within the same container
- Controlled via `allowNamespace` in `StoreConfig`

#### Configurable SQL transactions
- `setupRequest` gains a `withTransaction` option (defaults to `false`)
- New `requiresTransactionConfig` and `makeSqlTransactionMiddleware` for per-RPC transaction control
- Transactions are opt-in: set `withTransaction: true` or `requiresTransaction: true`

### Changesets

4× minor bumps to `@effect-app/infra`