### PR TITLE
fix(infra): preserve R inference in OneDSL update/modify callbacks

### DIFF
--- a/.changeset/fix-onedsl-r-inference.md
+++ b/.changeset/fix-onedsl-r-inference.md
@@ -1,0 +1,5 @@
+---
+"@effect-app/infra": patch
+---
+
+Fix `R` inference in `OneDSL`, `OneDSLExt.modify` and `OneDSLExt.update`. The callback's effect type was annotated as `Effect<…, E, FixEnv<R, Evt, S1, S2>>`, which deadlocked inference of `R` (TS6 fell back to `never`, tsgo to `unknown`, leaking `unknown` into yielded effects in generator handlers). Now matches the existing `AllDSLExt` pattern: bare `R` in the callback, `FixEnv<R, …>` only in the return type.

--- a/packages/infra/src/Model/dsl.ts
+++ b/packages/infra/src/Model/dsl.ts
@@ -42,16 +42,16 @@ export function makeAllDSL<T, Evt>() {
 
 export type OneDSL<T, Evt> =
   & (<R, A, E, S1 extends T, S2 extends T>(
-    pure: (dsl: PureDSL<S1, S2, Evt>) => Effect.Effect<A, E, FixEnv<R, Evt, S1, S2>>
+    pure: (dsl: PureDSL<S1, S2, Evt>) => Effect.Effect<A, E, R>
   ) => Effect.Effect<A, E, FixEnv<R, Evt, S1, S2>>)
   & OneDSLExt<T, Evt>
 
 export interface OneDSLExt<T, Evt> {
   modify: <R, E, A, S1 extends T, S2 extends T>(
-    pure: (items: S1, dsl: PureDSL<S1, S2, Evt>) => Effect.Effect<A, E, FixEnv<R, Evt, S1, S2>>
+    pure: (items: S1, dsl: PureDSL<S1, S2, Evt>) => Effect.Effect<A, E, R>
   ) => Effect.Effect<A, E, FixEnv<R, Evt, S1, S2> | PureEnvEnv<Evt, S1, S1>>
   update: <R, E, S1 extends T, S2 extends T>(
-    pure: (items: S1, log: (...evt: Evt[]) => PureLogT<Evt>) => Effect.Effect<S2, E, FixEnv<R, Evt, S1, S2>>
+    pure: (items: S1, log: (...evt: Evt[]) => PureLogT<Evt>) => Effect.Effect<S2, E, R>
   ) => Effect.Effect<S2, E, FixEnv<R, Evt, S1, S2>>
   updateWith: <S1 extends T, S2 extends T>(
     upd: (item: S1) => S2

--- a/packages/infra/test/router-generator.test.ts
+++ b/packages/infra/test/router-generator.test.ts
@@ -1,0 +1,188 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { type MakeContext, type MakeErrors, makeRouter } from "@effect-app/infra/api/routing"
+import { makeAllDSL, makeOneDSL } from "@effect-app/infra/Model"
+import { expectTypeOf, it } from "@effect/vitest"
+import { Context, Effect, Layer, RpcX, S } from "effect-app"
+import { InvalidStateError, makeRpcClient, UnauthorizedError } from "effect-app/client"
+import { DefaultGenericMiddlewares } from "effect-app/middleware"
+import { type FixEnv } from "effect-app/Pure"
+import { MiddlewareMaker } from "effect-app/rpc"
+import { TypeTestId } from "effect-app/TypeTest"
+import { DefaultGenericMiddlewaresLive, DevModeMiddlewareLive } from "../src/api/routing/middleware.js"
+import {
+  AllowAnonymous,
+  AllowAnonymousLive,
+  RequestContextMap,
+  RequireRoles,
+  RequireRolesLive,
+  Some,
+  SomeElse,
+  SomeService,
+  Test,
+  TestLive
+} from "./fixtures.js"
+
+// Inline minimal context provider (provides `Some`)
+class CtxProvider extends RpcX.RpcMiddleware.Tag<CtxProvider, { provides: Some }>()("CtxProvider") {
+  static Default = Layer.make(this, {
+    *make() {
+      return Effect.fnUntraced(function*(effect) {
+        return yield* Effect.provideService(effect, Some, Some.of({ a: 1 }))
+      })
+    }
+  })
+}
+
+// Provides `SomeElse` so AllowAnonymous's requirement is met.
+class SomeElseProvider
+  extends RpcX.RpcMiddleware.Tag<SomeElseProvider, { provides: SomeElse }>()("SomeElseProvider")
+{
+  static Default = Layer.make(this, {
+    *make() {
+      return Effect.fnUntraced(function*(effect) {
+        return yield* Effect.provideService(effect, SomeElse, SomeElse.of({ b: 2 }))
+      })
+    }
+  })
+}
+
+class mw extends MiddlewareMaker
+  .Tag<mw>()("mw", RequestContextMap)
+  .middleware(RequireRoles, Test)
+  .middleware(AllowAnonymous)
+  .middleware(CtxProvider)
+  .middleware(...DefaultGenericMiddlewares, SomeElseProvider)
+{
+  static Default = this.layer.pipe(
+    Layer.provide([
+      RequireRolesLive,
+      TestLive,
+      AllowAnonymousLive,
+      CtxProvider.Default,
+      SomeElseProvider.Default,
+      DefaultGenericMiddlewaresLive,
+      DevModeMiddlewareLive,
+      SomeService.Default
+    ])
+  )
+}
+
+const { TaggedRequestFor } = makeRpcClient(RequestContextMap)
+const Req = TaggedRequestFor("GenRouter")
+
+class GetThing extends Req.Query<GetThing>()("GetThing", { id: S.String }, { success: S.String }) {}
+class DoThing extends Req.Command<DoThing>()("DoThing", { id: S.String }, { success: S.Void }) {}
+
+const Resource = { GetThing, DoThing }
+
+const { Router, matchAll } = makeRouter(mw)
+
+class ThingRepo extends Context.Service<ThingRepo>()("ThingRepo", {
+  make: Effect.succeed({ get: (id: string) => Effect.succeed(id + "!") })
+}) {
+  static Default = Layer.effect(this, this.make)
+}
+
+// Case under test:
+// `match({})` is given handlers as **shorthand generator methods** (`*GetThing(req) { ... }`).
+// tsgo (>= 7 dev) infers `TNext = unknown` for these shorthand generators while TS6 infers `never`.
+// `HandlerWithInputGen` in routing.ts must accept both — see the structural fix.
+const router = Router(Resource)({
+  dependencies: [ThingRepo.Default],
+  *effect(match) {
+    const repo = yield* ThingRepo
+
+    if (Math.random() > 0.5) return yield* new InvalidStateError("nope")
+
+    return match({
+      *GetThing(req) {
+        const some = yield* Some
+        if (req.id === "boom") {
+          return yield* Effect.fail(new UnauthorizedError())
+        }
+        return yield* repo.get(req.id + String(some.a))
+      },
+      *DoThing(_req) {
+        yield* Effect.succeed(1)
+      }
+    })
+  }
+})
+
+// Same scenario but using the `raw:` variant — exercises the `raw` path of `HandlerWithInputGen`.
+const routerRaw = Router({ GetThing })({
+  *effect(match) {
+    return match({
+      GetThing: {
+        *raw(req) {
+          const some = yield* Some
+          return yield* Effect.succeed(req.id + String(some.a))
+        }
+      }
+    })
+  }
+})
+
+it("router with generator-method handlers compiles", () => {
+  expectTypeOf(router).toMatchTypeOf<Layer.Layer<never, any, any>>()
+  expectTypeOf(routerRaw).toMatchTypeOf<Layer.Layer<never, any, any>>()
+})
+
+// Type-level assertions: verify generator yields propagate to MakeErrors / MakeContext
+type Errors = MakeErrors<typeof router[TypeTestId]>
+type Ctx = MakeContext<typeof router[TypeTestId]>
+expectTypeOf<Errors>().toEqualTypeOf<InvalidStateError>()
+expectTypeOf<Ctx>().toEqualTypeOf<ThingRepo>()
+
+const matched = matchAll({ router })
+expectTypeOf(matched).toMatchTypeOf<Layer.Layer<never, any, any>>()
+
+// ---------------------------------------------------------------------------
+// DSL R-inference regression
+// ---------------------------------------------------------------------------
+// `OneDSL`/`OneDSLExt.update`/`.modify` previously annotated the callback's
+// effect R as `FixEnv<R, Evt, S1, S2>`. That deadlocked inference of `R`
+// (TS6 → `never`, tsgo → `unknown`), causing yielded effects to leak
+// `unknown` in the R slot when consumed by generator handlers.
+// The fix uses bare `R` in the callback and `FixEnv<R, …>` only on the return.
+class Item extends S.Class<Item>("Item")({ id: S.String, label: S.String }) {}
+class Dep extends Context.Service<Dep>()("Dep", { make: Effect.succeed({ tag: "dep" as const }) }) {}
+
+type Evt = { _tag: "Updated"; id: string }
+
+const Items$ = makeAllDSL<Item, Evt>()
+const Item$ = makeOneDSL<Item, Evt>()
+
+// Callback body uses generator syntax (TNext = unknown under tsgo) and yields
+// a service-dependent effect — R must be inferred as `Dep` (plus the
+// canonical PureEnvEnv contributed by FixEnv on the return).
+const oneUpdate = Item$.update((item) =>
+  Effect.gen(function*() {
+    const dep = yield* Dep
+    return new Item({ id: item.id, label: item.label + dep.tag })
+  })
+)
+
+const allUpdate = Items$.update((items) =>
+  Effect.gen(function*() {
+    const dep = yield* Dep
+    return items.map((_) => new Item({ id: _.id, label: _.label + dep.tag }))
+  })
+)
+
+const oneModify = Item$.modify((item, _dsl) =>
+  Effect.gen(function*() {
+    const dep = yield* Dep
+    return { ...item, tag: dep.tag }
+  })
+)
+
+// `R` should be `FixEnv<Dep, Evt, …>` — never collapsed to `unknown`/`never`.
+// The regression manifested as `unknown` here, breaking `Dep` assignability.
+expectTypeOf(oneUpdate).toMatchTypeOf<Effect.Effect<Item, never, FixEnv<Dep, Evt, Item, Item>>>();
+expectTypeOf(allUpdate).toMatchTypeOf<
+  Effect.Effect<readonly Item[], never, FixEnv<Dep, Evt, readonly Item[], readonly Item[]>>
+>();
+expectTypeOf(oneModify).toMatchTypeOf<
+  Effect.Effect<{ tag: "dep"; id: string; label: string }, never, FixEnv<Dep, Evt, Item, Item>>
+>()

--- a/packages/infra/test/router-generator.test.ts
+++ b/packages/infra/test/router-generator.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { type MakeContext, type MakeErrors, makeRouter } from "@effect-app/infra/api/routing"
 import { makeAllDSL, makeOneDSL } from "@effect-app/infra/Model"
 import { expectTypeOf, it } from "@effect/vitest"
@@ -7,20 +6,11 @@ import { InvalidStateError, makeRpcClient, UnauthorizedError } from "effect-app/
 import { DefaultGenericMiddlewares } from "effect-app/middleware"
 import { type FixEnv } from "effect-app/Pure"
 import { MiddlewareMaker } from "effect-app/rpc"
-import { TypeTestId } from "effect-app/TypeTest"
+import { type TypeTestId } from "effect-app/TypeTest"
+import { type ConfigError } from "effect/Config"
+import { type RpcSerialization } from "effect/unstable/rpc/RpcSerialization"
 import { DefaultGenericMiddlewaresLive, DevModeMiddlewareLive } from "../src/api/routing/middleware.js"
-import {
-  AllowAnonymous,
-  AllowAnonymousLive,
-  RequestContextMap,
-  RequireRoles,
-  RequireRolesLive,
-  Some,
-  SomeElse,
-  SomeService,
-  Test,
-  TestLive
-} from "./fixtures.js"
+import { AllowAnonymous, AllowAnonymousLive, RequestContextMap, RequireRoles, RequireRolesLive, Some, SomeElse, SomeService, Test, TestLive } from "./fixtures.js"
 
 // Inline minimal context provider (provides `Some`)
 class CtxProvider extends RpcX.RpcMiddleware.Tag<CtxProvider, { provides: Some }>()("CtxProvider") {
@@ -34,9 +24,7 @@ class CtxProvider extends RpcX.RpcMiddleware.Tag<CtxProvider, { provides: Some }
 }
 
 // Provides `SomeElse` so AllowAnonymous's requirement is met.
-class SomeElseProvider
-  extends RpcX.RpcMiddleware.Tag<SomeElseProvider, { provides: SomeElse }>()("SomeElseProvider")
-{
+class SomeElseProvider extends RpcX.RpcMiddleware.Tag<SomeElseProvider, { provides: SomeElse }>()("SomeElseProvider") {
   static Default = Layer.make(this, {
     *make() {
       return Effect.fnUntraced(function*(effect) {
@@ -124,8 +112,10 @@ const routerRaw = Router({ GetThing })({
 })
 
 it("router with generator-method handlers compiles", () => {
-  expectTypeOf(router).toMatchTypeOf<Layer.Layer<never, any, any>>()
-  expectTypeOf(routerRaw).toMatchTypeOf<Layer.Layer<never, any, any>>()
+  expectTypeOf(router).toMatchTypeOf<
+    Layer.Layer<never, ConfigError | InvalidStateError, SomeService | RpcSerialization>
+  >()
+  expectTypeOf(routerRaw).toMatchTypeOf<Layer.Layer<never, ConfigError, SomeService | RpcSerialization>>()
 })
 
 // Type-level assertions: verify generator yields propagate to MakeErrors / MakeContext
@@ -135,7 +125,9 @@ expectTypeOf<Errors>().toEqualTypeOf<InvalidStateError>()
 expectTypeOf<Ctx>().toEqualTypeOf<ThingRepo>()
 
 const matched = matchAll({ router })
-expectTypeOf(matched).toMatchTypeOf<Layer.Layer<never, any, any>>()
+expectTypeOf(matched).toMatchTypeOf<
+  Layer.Layer<never, ConfigError | InvalidStateError, SomeService | RpcSerialization>
+>()
 
 // ---------------------------------------------------------------------------
 // DSL R-inference regression
@@ -179,10 +171,10 @@ const oneModify = Item$.modify((item, _dsl) =>
 
 // `R` should be `FixEnv<Dep, Evt, …>` — never collapsed to `unknown`/`never`.
 // The regression manifested as `unknown` here, breaking `Dep` assignability.
-expectTypeOf(oneUpdate).toMatchTypeOf<Effect.Effect<Item, never, FixEnv<Dep, Evt, Item, Item>>>();
+expectTypeOf(oneUpdate).toMatchTypeOf<Effect.Effect<Item, never, FixEnv<Dep, Evt, Item, Item>>>()
 expectTypeOf(allUpdate).toMatchTypeOf<
   Effect.Effect<readonly Item[], never, FixEnv<Dep, Evt, readonly Item[], readonly Item[]>>
->();
+>()
 expectTypeOf(oneModify).toMatchTypeOf<
   Effect.Effect<{ tag: "dep"; id: string; label: string }, never, FixEnv<Dep, Evt, Item, Item>>
 >()


### PR DESCRIPTION
Wrapping the callback's effect return type in FixEnv<R, ...> deadlocked inference of R, collapsing it to never (TS6) or unknown (tsgo). This broke generator-syntax handlers using userRepo.queryAndSavePure(..., User$.update(cb)) by yielding effects with unknown environment.

Fix mirrors the existing AllDSLExt.update pattern: bare R in the callback parameter, FixEnv<R, ...> only in the return type. FixEnv on the callback param had no real type-safety payoff since PureEnvEnv shares a single Symbol() at runtime.