### PR TITLE
restore onBlur on OmegaInput

### DIFF
--- a/.changeset/nice-jars-grow.md
+++ b/.changeset/nice-jars-grow.md
@@ -1,0 +1,5 @@
+---
+"@effect-app/vue-components": patch
+---
+
+Uses onBlur instead of intrusive onChange

--- a/packages/vue-components/__tests__/OmegaForm/IntersectionError.test.ts
+++ b/packages/vue-components/__tests__/OmegaForm/IntersectionError.test.ts
@@ -1,6 +1,6 @@
 import { mount } from "@vue/test-utils"
 import { S } from "effect-app"
-import { describe, expect, it } from "vitest"
+import { beforeEach, describe, expect, it } from "vitest"
 import { useOmegaForm } from "../../src/components/OmegaForm"
 import OmegaIntlProvider from "../OmegaIntlProvider.vue"
 
@@ -55,12 +55,13 @@ describe("OmegaForm Intersection/Union", () => {
     myUnion: S.Union([AlphaSchema, BetaSchema])
   })
 
-  const wrapper = mount({
-    components: {
-      OmegaIntlProvider,
-      CustomInput: mockComponents.CustomInput
-    },
-    template: `
+  const createWrapper = () =>
+    mount({
+      components: {
+        OmegaIntlProvider,
+        CustomInput: mockComponents.CustomInput
+      },
+      template: `
       <OmegaIntlProvider>
         <component :is="form.Form" :subscribe="['values']">
           <template #default="{ subscribedValues: { values } }">
@@ -104,22 +105,28 @@ describe("OmegaForm Intersection/Union", () => {
         </component>
       </OmegaIntlProvider>
     `,
-    setup() {
-      let submittedValue: any = null
-      const form = useOmegaForm(MySchema, {
-        onSubmit: async ({ value }) => {
-          submittedValue = value
-        }
-      })
-      return { form, getSubmittedValue: () => submittedValue }
-    }
-  }, {
-    global: {
-      stubs: {
-        CustomInput: mockComponents.CustomInput,
-        OmegaErrorsInternal: mockComponents.OmegaErrors
+      setup() {
+        let submittedValue: any = null
+        const form = useOmegaForm(MySchema, {
+          onSubmit: async ({ value }) => {
+            submittedValue = value
+          }
+        })
+        return { form, getSubmittedValue: () => submittedValue }
       }
-    }
+    }, {
+      global: {
+        stubs: {
+          CustomInput: mockComponents.CustomInput,
+          OmegaErrorsInternal: mockComponents.OmegaErrors
+        }
+      }
+    })
+
+  let wrapper: ReturnType<typeof createWrapper>
+
+  beforeEach(() => {
+    wrapper = createWrapper()
   })
 
   it("handles discriminated union with conditional fields", async () => {

--- a/packages/vue-components/src/components/OmegaForm/OmegaInput.vue
+++ b/packages/vue-components/src/components/OmegaForm/OmegaInput.vue
@@ -4,7 +4,7 @@
     :key="fieldKey"
     :name="name"
     :validators="{
-      onChange: schema,
+      onBlur: schema,
       ...validators
     }"
   >


### PR DESCRIPTION
## Summary
- Restores `onBlur: schema` on `OmegaInput.vue` (originally landed in #683, then reverted in 78823c187)
- Companion to #688 which handled blur on `OmegaInputVuetify.vue`

## Test plan
- [ ] Verify validation on OmegaInput fires on blur instead of on every change