### PR TITLE
feat(infra): extend computed projections with every/distinctCount/sum/collect

### DIFF
--- a/.changeset/computed-projections-extensions.md
+++ b/.changeset/computed-projections-extensions.md
@@ -1,0 +1,12 @@
+---
+"@effect-app/infra": minor
+---
+
+Extend computed projections with additional relation operators:
+
+- `relation(path).every(op)` — boolean, all elements match the filter (compiled as `NOT EXISTS(... WHERE NOT (filter))`).
+- `relation(path).distinctCount(field, op?)` — distinct count of values at `field` within the relation.
+- `relation(path).sum(field, op?)` — numeric sum over a relation field.
+- `relation(path).collect(field, op?)` / `collectDistinct(field, op?)` — collect values into an array (with optional dedup).
+
+All operators compile to native subqueries on SQL (sqlite/pg) and Cosmos, and to in-memory equivalents on the Memory store.

--- a/packages/infra/src/Model/query/dsl.ts
+++ b/packages/infra/src/Model/query/dsl.ts
@@ -111,6 +111,30 @@ export type ComputedProjectionExpression =
     readonly path: string
     readonly operation?: ComputedProjectionOperation
   }
+  | {
+    readonly _tag: "relation-every"
+    readonly path: string
+    readonly operation: ComputedProjectionOperation
+  }
+  | {
+    readonly _tag: "relation-distinct-count"
+    readonly path: string
+    readonly field: string
+    readonly operation?: ComputedProjectionOperation
+  }
+  | {
+    readonly _tag: "relation-sum"
+    readonly path: string
+    readonly field: string
+    readonly operation?: ComputedProjectionOperation
+  }
+  | {
+    readonly _tag: "relation-collect"
+    readonly path: string
+    readonly field: string
+    readonly distinct: boolean
+    readonly operation?: ComputedProjectionOperation
+  }
 
 export type ComputedProjectionMap = Readonly<Record<string, ComputedProjectionExpression>>
 export type Q<TFieldValues extends FieldValues> =
@@ -426,6 +450,67 @@ export const relation = <TFieldValues extends FieldValues>(
       : {
         _tag: "relation-any",
         path: path as string
+      },
+  every: (operation: ComputedProjectionOperation): ComputedProjectionExpression => ({
+    _tag: "relation-every",
+    path: path as string,
+    operation
+  }),
+  distinctCount: (field: string, operation?: ComputedProjectionOperation): ComputedProjectionExpression =>
+    operation
+      ? {
+        _tag: "relation-distinct-count",
+        path: path as string,
+        field,
+        operation
+      }
+      : {
+        _tag: "relation-distinct-count",
+        path: path as string,
+        field
+      },
+  sum: (field: string, operation?: ComputedProjectionOperation): ComputedProjectionExpression =>
+    operation
+      ? {
+        _tag: "relation-sum",
+        path: path as string,
+        field,
+        operation
+      }
+      : {
+        _tag: "relation-sum",
+        path: path as string,
+        field
+      },
+  collect: (field: string, operation?: ComputedProjectionOperation): ComputedProjectionExpression =>
+    operation
+      ? {
+        _tag: "relation-collect",
+        path: path as string,
+        field,
+        distinct: false,
+        operation
+      }
+      : {
+        _tag: "relation-collect",
+        path: path as string,
+        field,
+        distinct: false
+      },
+  collectDistinct: (field: string, operation?: ComputedProjectionOperation): ComputedProjectionExpression =>
+    operation
+      ? {
+        _tag: "relation-collect",
+        path: path as string,
+        field,
+        distinct: true,
+        operation
+      }
+      : {
+        _tag: "relation-collect",
+        path: path as string,
+        field,
+        distinct: true
       }
 })
 

--- a/packages/infra/src/Model/query/new-kid-interpreter.ts
+++ b/packages/infra/src/Model/query/new-kid-interpreter.ts
@@ -19,6 +19,30 @@ export type ComputedProjectionIrExpression =
     readonly path: string
     readonly filter: readonly FilterResult[]
   }
+  | {
+    readonly _tag: "relation-every"
+    readonly path: string
+    readonly filter: readonly FilterResult[]
+  }
+  | {
+    readonly _tag: "relation-distinct-count"
+    readonly path: string
+    readonly field: string
+    readonly filter: readonly FilterResult[]
+  }
+  | {
+    readonly _tag: "relation-sum"
+    readonly path: string
+    readonly field: string
+    readonly filter: readonly FilterResult[]
+  }
+  | {
+    readonly _tag: "relation-collect"
+    readonly path: string
+    readonly field: string
+    readonly distinct: boolean
+    readonly filter: readonly FilterResult[]
+  }
 
 type Result<TFieldValues extends FieldValues, A = TFieldValues, R = never> = {
   filter: FilterResult[]
@@ -162,7 +186,29 @@ const interpret = <
             Object.entries(v.computed).map(([key, expression]) => {
               const e = expression
               const filter = e.operation ? interpret(e.operation(make())).filter.map(applyPath(e.path)) : []
-              return [key, { _tag: e._tag, path: e.path, filter } as const]
+              switch (e._tag) {
+                case "relation-count":
+                case "relation-any":
+                case "relation-every":
+                  return [key, { _tag: e._tag, path: e.path, filter } as ComputedProjectionIrExpression]
+                case "relation-distinct-count":
+                case "relation-sum":
+                  return [
+                    key,
+                    { _tag: e._tag, path: e.path, field: e.field, filter } as ComputedProjectionIrExpression
+                  ]
+                case "relation-collect":
+                  return [
+                    key,
+                    {
+                      _tag: e._tag,
+                      path: e.path,
+                      field: e.field,
+                      distinct: e.distinct,
+                      filter
+                    } as ComputedProjectionIrExpression
+                  ]
+              }
             })
           )
           : undefined

--- a/packages/infra/src/Store/Cosmos/query.ts
+++ b/packages/infra/src/Store/Cosmos/query.ts
@@ -303,6 +303,29 @@ export function buildWhereCosmosQuery3(
         return `(SELECT VALUE COUNT(1) FROM ${relationAlias} IN ${relationSource}${where}) AS ${key}`
       case "relation-any":
         return `EXISTS(SELECT VALUE ${relationAlias} FROM ${relationAlias} IN ${relationSource}${where}) AS ${key}`
+      case "relation-every": {
+        // ∀x.P(x) ≡ ¬∃x.¬P(x). Cosmos has no NOT(...) on EXISTS subqueries directly,
+        // but we can flip via NOT EXISTS(... WHERE NOT (filter)).
+        if (computed.filter.length === 0) return `true AS ${key}`
+        return `NOT EXISTS(SELECT VALUE ${relationAlias} FROM ${relationAlias} IN ${relationSource} WHERE NOT (${
+          print(computed.filter, relationPath, false)
+        })) AS ${key}`
+      }
+      case "relation-distinct-count": {
+        const fieldRef = dottedToAccess(`${relationAlias}.${computed.field}`)
+        return `(SELECT VALUE COUNT(1) FROM (SELECT DISTINCT VALUE ${fieldRef} FROM ${relationAlias} IN ${relationSource}${where})) AS ${key}`
+      }
+      case "relation-sum": {
+        const fieldRef = dottedToAccess(`${relationAlias}.${computed.field}`)
+        return `(SELECT VALUE SUM(${fieldRef}) FROM ${relationAlias} IN ${relationSource}${where}) AS ${key}`
+      }
+      case "relation-collect": {
+        const fieldRef = dottedToAccess(`${relationAlias}.${computed.field}`)
+        if (computed.distinct) {
+          return `ARRAY(SELECT DISTINCT VALUE ${fieldRef} FROM ${relationAlias} IN ${relationSource}${where}) AS ${key}`
+        }
+        return `ARRAY(SELECT VALUE ${fieldRef} FROM ${relationAlias} IN ${relationSource}${where}) AS ${key}`
+      }
     }
   }
   // with joins, you should use DISTINCT

--- a/packages/infra/src/Store/Memory.ts
+++ b/packages/infra/src/Store/Memory.ts
@@ -2,9 +2,11 @@
 
 import { Array, Context, Effect, flow, type NonEmptyReadonlyArray, Option, Order, pipe, Ref, Result, Semaphore, Struct } from "effect-app"
 import { NonEmptyString255 } from "effect-app/Schema"
+import { assertUnreachable } from "effect-app/utils"
 import { InfraLogger } from "../logger.js"
 import type { FilterResult } from "../Model/filter/filterApi.js"
 import type { FieldValues } from "../Model/filter/types.js"
+import type { ComputedProjectionIrExpression } from "../Model/query.js"
 import { annotateDb } from "../otel.js"
 import { codeFilter, codeFilter3_ } from "./codeFilter.js"
 import { type FilterArgs, type PersistenceModelType, type Store, type StoreConfig, StoreMaker } from "./service.js"
@@ -30,24 +32,69 @@ const stripRelationFilterPaths = (state: readonly FilterResult[], relationPath: 
   )
 }
 
+const emptyValueFor = (tag: ComputedProjectionIrExpression["_tag"]) => {
+  switch (tag) {
+    case "relation-count":
+    case "relation-distinct-count":
+    case "relation-sum":
+      return 0
+    case "relation-any":
+      return false
+    case "relation-every":
+      return true
+    case "relation-collect":
+      return [] as unknown[]
+    default:
+      return assertUnreachable(tag)
+  }
+}
+
 const computeProjectionValue = (
   row: FieldValues,
-  computed: {
-    readonly _tag: "relation-count" | "relation-any"
-    readonly path: string
-    readonly filter: readonly FilterResult[]
-  }
+  computed: ComputedProjectionIrExpression
 ) => {
   const relation = get(row, computed.path)
   if (!Array.isArray(relation)) {
-    return computed._tag === "relation-count" ? 0 : false
+    return emptyValueFor(computed._tag)
   }
   const filter = stripRelationFilterPaths(computed.filter, computed.path)
+  const matches = (value: unknown) => codeFilter3_(filter, value)
   switch (computed._tag) {
     case "relation-count":
-      return relation.reduce<number>((acc, value) => codeFilter3_(filter, value) ? acc + 1 : acc, 0)
+      return relation.reduce<number>((acc, value) => matches(value) ? acc + 1 : acc, 0)
     case "relation-any":
-      return relation.some((value) => codeFilter3_(filter, value))
+      return relation.some(matches)
+    case "relation-every":
+      return relation.every(matches)
+    case "relation-distinct-count": {
+      const seen = new Set<unknown>()
+      for (const value of relation) {
+        if (matches(value)) seen.add(get(value, computed.field))
+      }
+      return seen.size
+    }
+    case "relation-sum":
+      return relation.reduce<number>((acc, value) => {
+        if (!matches(value)) return acc
+        const v = get(value, computed.field)
+        return acc + (typeof v === "number" ? v : Number(v) || 0)
+      }, 0)
+    case "relation-collect": {
+      const out: unknown[] = []
+      const seen = computed.distinct ? new Set<unknown>() : undefined
+      for (const value of relation) {
+        if (!matches(value)) continue
+        const v = get(value, computed.field)
+        if (seen) {
+          if (seen.has(v)) continue
+          seen.add(v)
+        }
+        out.push(v)
+      }
+      return out
+    }
+    default:
+      return assertUnreachable(computed)
   }
 }
 
@@ -67,11 +114,7 @@ export function memFilter<T extends FieldValues, U extends keyof T = never>(f: F
         )
         const computedKeys = entries.filter((entry): entry is {
           key: string
-          computed: {
-            readonly _tag: "relation-count" | "relation-any"
-            readonly path: string
-            readonly filter: readonly FilterResult[]
-          }
+          computed: ComputedProjectionIrExpression
         } => typeof entry === "object" && entry !== null && "computed" in entry)
         const n = Struct.pick(i, keys)
         subKeys.forEach((subKey) => {

--- a/packages/infra/src/Store/SQL/query.ts
+++ b/packages/infra/src/Store/SQL/query.ts
@@ -391,18 +391,48 @@ export function buildWhereSQLQuery(
     const relationPath = dottedToJsonPath(computed.path)
     const relationAlias = `_${computed.path}`
     const relationFrom = dialect.jsonEachFrom(relationPath, relationAlias)
-    const where = computed.filter.length > 0
-      ? ` WHERE ${print(computed.filter, computed.path, false)}`
-      : ""
+    const whereClause = () =>
+      computed.filter.length > 0
+        ? ` WHERE ${print(computed.filter, computed.path, false)}`
+        : ""
+    const boolExpr = (sqlExpr: string) =>
+      dialect.jsonColumnType === "JSON"
+        ? `CASE WHEN ${sqlExpr} THEN 'true' ELSE 'false' END AS "${key}"`
+        : `${sqlExpr} AS "${key}"`
     switch (computed._tag) {
       case "relation-count":
-        return `(SELECT COUNT(1) FROM ${relationFrom}${where}) AS "${key}"`
-      case "relation-any": {
-        const existsExpr = `EXISTS(SELECT 1 FROM ${relationFrom}${where})`
+        return `(SELECT COUNT(1) FROM ${relationFrom}${whereClause()}) AS "${key}"`
+      case "relation-any":
+        return boolExpr(`EXISTS(SELECT 1 FROM ${relationFrom}${whereClause()})`)
+      case "relation-every":
+        // ∀x.P(x) ≡ ¬∃x.¬P(x). When no filter, no element exists that violates ⊤ → true.
+        return boolExpr(
+          computed.filter.length === 0
+            ? `1=1`
+            : `NOT EXISTS(SELECT 1 FROM ${relationFrom} WHERE NOT (${print(computed.filter, computed.path, false)}))`
+        )
+      case "relation-distinct-count": {
+        const fieldExtract = dialect.jsonExtractElement(relationAlias, computed.field)
+        return `(SELECT COUNT(DISTINCT ${fieldExtract}) FROM ${relationFrom}${whereClause()}) AS "${key}"`
+      }
+      case "relation-sum": {
+        const fieldExtract = dialect.jsonExtractElement(relationAlias, computed.field)
+        const cast = dialect.jsonColumnType === "JSON"
+          ? `CAST(${fieldExtract} AS REAL)`
+          : `(${fieldExtract})::numeric`
+        return `(SELECT COALESCE(SUM(${cast}), 0) FROM ${relationFrom}${whereClause()}) AS "${key}"`
+      }
+      case "relation-collect": {
+        const fieldExtract = dialect.jsonExtractElement(relationAlias, computed.field)
         if (dialect.jsonColumnType === "JSON") {
-          return `CASE WHEN ${existsExpr} THEN 'true' ELSE 'false' END AS "${key}"`
+          // sqlite: json_group_array does not accept DISTINCT; emulate via inner DISTINCT subquery
+          if (computed.distinct) {
+            return `(SELECT COALESCE(json_group_array(__v), json_array()) FROM (SELECT DISTINCT ${fieldExtract} AS __v FROM ${relationFrom}${whereClause()})) AS "${key}"`
+          }
+          return `(SELECT COALESCE(json_group_array(${fieldExtract}), json_array()) FROM ${relationFrom}${whereClause()}) AS "${key}"`
         }
-        return `${existsExpr} AS "${key}"`
+        const aggArg = computed.distinct ? `DISTINCT ${fieldExtract}` : fieldExtract
+        return `(SELECT COALESCE(jsonb_agg(${aggArg}), '[]'::jsonb) FROM ${relationFrom}${whereClause()}) AS "${key}"`
       }
       default:
         return assertUnreachable(computed)

--- a/packages/infra/test/query.test.ts
+++ b/packages/infra/test/query.test.ts
@@ -640,6 +640,96 @@ it("projection schema with computed fields fails without computed map", () => {
   expect(() => toFilter(query, baseSchema)).toThrowError("Missing computed projections for schema keys")
 })
 
+it("projectComputed.every emits relation-every IR", () => {
+  const baseSchema = S.Struct({
+    id: S.String,
+    items: S.Array(S.Struct({ state: S.Struct({ _tag: S.String }) }))
+  })
+  const query = make<S.Codec.Encoded<typeof baseSchema>>().pipe(
+    projectComputed(
+      S.Struct({ allPicked: S.Boolean }),
+      computed({
+        allPicked: relation<S.Codec.Encoded<typeof baseSchema>>("items").every(where("state._tag", "Picked"))
+      })
+    )
+  )
+  const interpreted = toFilter(query, baseSchema)
+  expect(interpreted.computed?.["allPicked"]?._tag).toBe("relation-every")
+  expect(interpreted.computed?.["allPicked"]?.path).toBe("items")
+  expect(interpreted.computed?.["allPicked"]?.filter).toEqual([
+    { t: "where", path: "items.-1.state._tag", op: "eq", value: "Picked" }
+  ])
+})
+
+it("projectComputed.distinctCount emits relation-distinct-count IR with field", () => {
+  const baseSchema = S.Struct({
+    id: S.String,
+    items: S.Array(S.Struct({ rowId: S.String, state: S.Struct({ _tag: S.String }) }))
+  })
+  const query = make<S.Codec.Encoded<typeof baseSchema>>().pipe(
+    projectComputed(
+      S.Struct({ positionCount: S.NonNegativeInt }),
+      computed({
+        positionCount: relation<S.Codec.Encoded<typeof baseSchema>>("items").distinctCount(
+          "rowId",
+          where("state._tag", "neq", "cancelled")
+        )
+      })
+    )
+  )
+  const interpreted = toFilter(query, baseSchema)
+  const ir = interpreted.computed?.["positionCount"]
+  expect(ir?._tag).toBe("relation-distinct-count")
+  expect((ir as { field: string } | undefined)?.field).toBe("rowId")
+  expect(ir?.filter).toEqual([
+    { t: "where", path: "items.-1.state._tag", op: "neq", value: "cancelled" }
+  ])
+})
+
+it("projectComputed.sum emits relation-sum IR with field", () => {
+  const baseSchema = S.Struct({
+    id: S.String,
+    items: S.Array(S.Struct({ weight: S.Number }))
+  })
+  const query = make<S.Codec.Encoded<typeof baseSchema>>().pipe(
+    projectComputed(
+      S.Struct({ totalWeight: S.Number }),
+      computed({ totalWeight: relation<S.Codec.Encoded<typeof baseSchema>>("items").sum("weight") })
+    )
+  )
+  const interpreted = toFilter(query, baseSchema)
+  const ir = interpreted.computed?.["totalWeight"]
+  expect(ir?._tag).toBe("relation-sum")
+  expect((ir as { field: string } | undefined)?.field).toBe("weight")
+  expect(ir?.filter).toEqual([])
+})
+
+it("projectComputed.collect / collectDistinct emit relation-collect IR", () => {
+  const baseSchema = S.Struct({
+    id: S.String,
+    items: S.Array(S.Struct({ articleId: S.String }))
+  })
+  const query = make<S.Codec.Encoded<typeof baseSchema>>().pipe(
+    projectComputed(
+      S.Struct({
+        all: S.Array(S.String),
+        distinct: S.Array(S.String)
+      }),
+      computed({
+        all: relation<S.Codec.Encoded<typeof baseSchema>>("items").collect("articleId"),
+        distinct: relation<S.Codec.Encoded<typeof baseSchema>>("items").collectDistinct("articleId")
+      })
+    )
+  )
+  const interpreted = toFilter(query, baseSchema)
+  const all = interpreted.computed?.["all"]
+  const distinct = interpreted.computed?.["distinct"]
+  expect(all?._tag).toBe("relation-collect")
+  expect((all as { distinct: boolean } | undefined)?.distinct).toBe(false)
+  expect(distinct?._tag).toBe("relation-collect")
+  expect((distinct as { distinct: boolean } | undefined)?.distinct).toBe(true)
+})
+
 it(
   "doesn't mess when refining fields",
   () =>

--- a/packages/infra/test/sql-store.test.ts
+++ b/packages/infra/test/sql-store.test.ts
@@ -269,6 +269,116 @@ describe("SQL query builder (SQLite dialect)", () => {
     expect(result.sql).toContain("CASE WHEN EXISTS(")
     expect(result.sql).toContain(`AS "hasPicked"`)
   })
+
+  it("computed relation every projection (sqlite emits NOT EXISTS NOT)", () => {
+    const result = buildWhereSQLQuery(
+      sqliteDialect,
+      "id",
+      [],
+      "users",
+      {},
+      [{
+        key: "allPicked",
+        computed: {
+          _tag: "relation-every",
+          path: "items",
+          filter: [{ t: "where", path: "items.-1.state._tag", op: "eq", value: "picked" }]
+        }
+      }]
+    )
+    expect(result.sql).toContain(`NOT EXISTS(SELECT 1 FROM json_each(data, '$.items') AS _items WHERE NOT (`)
+    expect(result.sql).toContain(`AS "allPicked"`)
+    expect(result.params).toContain("picked")
+  })
+
+  it("computed relation-every with no filter degenerates to true", () => {
+    const result = buildWhereSQLQuery(
+      sqliteDialect,
+      "id",
+      [],
+      "users",
+      {},
+      [{
+        key: "allPicked",
+        computed: { _tag: "relation-every", path: "items", filter: [] }
+      }]
+    )
+    expect(result.sql).toContain("CASE WHEN 1=1")
+    expect(result.sql).toContain(`AS "allPicked"`)
+  })
+
+  it("computed relation-distinct-count projection (sqlite)", () => {
+    const result = buildWhereSQLQuery(
+      sqliteDialect,
+      "id",
+      [],
+      "users",
+      {},
+      [{
+        key: "positionCount",
+        computed: {
+          _tag: "relation-distinct-count",
+          path: "items",
+          field: "rowId",
+          filter: [{ t: "where", path: "items.-1.state._tag", op: "neq", value: "cancelled" }]
+        }
+      }]
+    )
+    expect(result.sql).toContain(`SELECT COUNT(DISTINCT json_extract(_items.value, '$.rowId'))`)
+    expect(result.sql).toContain(`AS "positionCount"`)
+    expect(result.params).toContain("cancelled")
+  })
+
+  it("computed relation-sum projection (sqlite casts to REAL)", () => {
+    const result = buildWhereSQLQuery(
+      sqliteDialect,
+      "id",
+      [],
+      "users",
+      {},
+      [{
+        key: "totalWeight",
+        computed: { _tag: "relation-sum", path: "items", field: "weight", filter: [] }
+      }]
+    )
+    expect(result.sql).toContain(`SELECT COALESCE(SUM(CAST(json_extract(_items.value, '$.weight') AS REAL)), 0)`)
+    expect(result.sql).toContain(`AS "totalWeight"`)
+  })
+
+  it("computed relation-collect (non-distinct) projection (sqlite)", () => {
+    const result = buildWhereSQLQuery(
+      sqliteDialect,
+      "id",
+      [],
+      "users",
+      {},
+      [{
+        key: "tags",
+        computed: { _tag: "relation-collect", path: "items", field: "articleId", distinct: false, filter: [] }
+      }]
+    )
+    expect(result.sql).toContain(
+      `SELECT COALESCE(json_group_array(json_extract(_items.value, '$.articleId')), json_array())`
+    )
+    expect(result.sql).toContain(`AS "tags"`)
+  })
+
+  it("computed relation-collect (distinct) emits inner DISTINCT subquery (sqlite)", () => {
+    const result = buildWhereSQLQuery(
+      sqliteDialect,
+      "id",
+      [],
+      "users",
+      {},
+      [{
+        key: "tags",
+        computed: { _tag: "relation-collect", path: "items", field: "articleId", distinct: true, filter: [] }
+      }]
+    )
+    expect(result.sql).toContain(`json_group_array(__v)`)
+    expect(result.sql).toContain(`SELECT DISTINCT json_extract(_items.value, '$.articleId') AS __v`)
+    expect(result.sql).toContain(`AS "tags"`)
+  })
 })
 
 describe("SQL query builder (PostgreSQL dialect)", () => {
@@ -351,6 +461,89 @@ describe("SQL query builder (PostgreSQL dialect)", () => {
     )
     expect(result.sql).toContain("EXISTS(SELECT 1 FROM jsonb_array_elements(data->'items') AS _items")
     expect(result.sql).toContain(`AS "hasPicked"`)
+  })
+
+  it("computed relation-every (pg)", () => {
+    const result = buildWhereSQLQuery(
+      pgDialect,
+      "id",
+      [],
+      "users",
+      {},
+      [{
+        key: "allPicked",
+        computed: {
+          _tag: "relation-every",
+          path: "items",
+          filter: [{ t: "where", path: "items.-1.state._tag", op: "eq", value: "picked" }]
+        }
+      }]
+    )
+    expect(result.sql).toContain(`NOT EXISTS(SELECT 1 FROM jsonb_array_elements(data->'items') AS _items WHERE NOT (`)
+    expect(result.sql).toContain(`AS "allPicked"`)
+  })
+
+  it("computed relation-distinct-count (pg)", () => {
+    const result = buildWhereSQLQuery(
+      pgDialect,
+      "id",
+      [],
+      "users",
+      {},
+      [{
+        key: "positions",
+        computed: { _tag: "relation-distinct-count", path: "items", field: "rowId", filter: [] }
+      }]
+    )
+    expect(result.sql).toContain(`COUNT(DISTINCT _items->>'rowId')`)
+    expect(result.sql).toContain(`AS "positions"`)
+  })
+
+  it("computed relation-sum (pg casts via ::numeric)", () => {
+    const result = buildWhereSQLQuery(
+      pgDialect,
+      "id",
+      [],
+      "users",
+      {},
+      [{
+        key: "totalWeight",
+        computed: { _tag: "relation-sum", path: "items", field: "weight", filter: [] }
+      }]
+    )
+    expect(result.sql).toContain(`COALESCE(SUM((_items->>'weight')::numeric), 0)`)
+    expect(result.sql).toContain(`AS "totalWeight"`)
+  })
+
+  it("computed relation-collect (pg jsonb_agg)", () => {
+    const result = buildWhereSQLQuery(
+      pgDialect,
+      "id",
+      [],
+      "users",
+      {},
+      [{
+        key: "ids",
+        computed: { _tag: "relation-collect", path: "items", field: "articleId", distinct: false, filter: [] }
+      }]
+    )
+    expect(result.sql).toContain(`COALESCE(jsonb_agg(_items->>'articleId'), '[]'::jsonb)`)
+    expect(result.sql).toContain(`AS "ids"`)
+  })
+
+  it("computed relation-collect distinct (pg jsonb_agg DISTINCT)", () => {
+    const result = buildWhereSQLQuery(
+      pgDialect,
+      "id",
+      [],
+      "users",
+      {},
+      [{
+        key: "ids",
+        computed: { _tag: "relation-collect", path: "items", field: "articleId", distinct: true, filter: [] }
+      }]
+    )
+    expect(result.sql).toContain(`COALESCE(jsonb_agg(DISTINCT _items->>'articleId'), '[]'::jsonb)`)
   })
 })
 
@@ -654,6 +847,114 @@ describe("SQL Store (SQLite integration)", () => {
       const r10 = query(db, q10.sql, q10.params)
       expect(r10.length).toBe(2)
       expect((JSON.parse((r10[0] as any).data) as any).name).toBe("Charlie") // oldest first
+    }))
+
+  it("computed relation-every / distinct-count / sum / collect run on SQLite", () =>
+    withDb((db) => {
+      db.exec(`CREATE TABLE "test_orders" (id TEXT PRIMARY KEY, _etag TEXT, data JSON NOT NULL)`)
+      const orders = [
+        {
+          id: "o1",
+          items: [
+            { rowId: "r1", articleId: "A", weight: 1.5, state: { _tag: "picked" } },
+            { rowId: "r2", articleId: "A", weight: 2.5, state: { _tag: "picked" } },
+            { rowId: "r2", articleId: "B", weight: 0.25, state: { _tag: "picking" } }
+          ]
+        },
+        {
+          id: "o2",
+          items: [
+            { rowId: "r9", articleId: "Z", weight: 10, state: { _tag: "packed" } }
+          ]
+        }
+      ]
+      const insert = db.prepare(`INSERT INTO "test_orders" (id, _etag, data) VALUES (?, ?, ?)`)
+      for (const o of orders) {
+        const { id, ...data } = o
+        insert.run(id, `etag_${id}`, JSON.stringify(data))
+      }
+
+      const q = buildWhereSQLQuery(
+        sqliteDialect,
+        "id",
+        [],
+        "test_orders",
+        {},
+        [
+          {
+            key: "allPicked",
+            computed: {
+              _tag: "relation-every",
+              path: "items",
+              filter: [{ t: "where", path: "items.-1.state._tag", op: "eq", value: "picked" }]
+            }
+          },
+          {
+            key: "positionCount",
+            computed: { _tag: "relation-distinct-count", path: "items", field: "rowId", filter: [] }
+          },
+          {
+            key: "totalWeight",
+            computed: { _tag: "relation-sum", path: "items", field: "weight", filter: [] }
+          },
+          {
+            key: "articleIds",
+            computed: {
+              _tag: "relation-collect",
+              path: "items",
+              field: "articleId",
+              distinct: true,
+              filter: []
+            }
+          }
+        ] as any,
+        [{ key: "id", direction: "ASC" }] as any
+      )
+      const rows = query(db, q.sql, q.params) as Array<Record<string, unknown>>
+      expect(rows.length).toBe(2)
+      // o1: not all picked (one is "picking")
+      expect(JSON.parse(rows[0]!["allPicked"] as string)).toBe(false)
+      expect(rows[0]!["positionCount"]).toBe(2)
+      expect(rows[0]!["totalWeight"]).toBeCloseTo(4.25)
+      expect((JSON.parse(rows[0]!["articleIds"] as string) as string[]).sort()).toEqual(["A", "B"])
+      // o2: all packed (so not "picked"), allPicked = !exists(NOT picked) = false
+      expect(JSON.parse(rows[1]!["allPicked"] as string)).toBe(false)
+      expect(rows[1]!["positionCount"]).toBe(1)
+      expect(rows[1]!["totalWeight"]).toBeCloseTo(10)
+      expect(JSON.parse(rows[1]!["articleIds"] as string)).toEqual(["Z"])
+    }))
+
+  it("computed relation-every is true when all items match filter", () =>
+    withDb((db) => {
+      db.exec(`CREATE TABLE "test_every" (id TEXT PRIMARY KEY, _etag TEXT, data JSON NOT NULL)`)
+      db.prepare(`INSERT INTO "test_every" (id, _etag, data) VALUES (?, ?, ?)`).run(
+        "1",
+        "e",
+        JSON.stringify({
+          items: [
+            { state: { _tag: "picked" } },
+            { state: { _tag: "picked" } }
+          ]
+        })
+      )
+
+      const q = buildWhereSQLQuery(
+        sqliteDialect,
+        "id",
+        [],
+        "test_every",
+        {},
+        [{
+          key: "allPicked",
+          computed: {
+            _tag: "relation-every",
+            path: "items",
+            filter: [{ t: "where", path: "items.-1.state._tag", op: "eq", value: "picked" }]
+          }
+        }]
+      )
+      const rows = query(db, q.sql, q.params) as Array<Record<string, unknown>>
+      expect(JSON.parse(rows[0]!["allPicked"] as string)).toBe(true)
     }))
 
   it("namespace param is in correct position for SQLite positional placeholders", () =>


### PR DESCRIPTION
Adds four relation aggregation operators that complement the existing count/any pair:

- relation(path).every(op) — ∀x.P(x); compiles to NOT EXISTS(... WHERE NOT (filter)).
- relation(path).distinctCount(field, op?) — distinct count of a field across relation elements.
- relation(path).sum(field, op?) — numeric sum over a field; SQL casts to REAL/numeric, Cosmos uses SUM().
- relation(path).collect(field, op?) and collectDistinct — array collection with optional dedup; SQL uses jsonb_agg / json_group_array (with an inner DISTINCT subquery for sqlite which lacks json_group_array DISTINCT).

Adapter coverage: Memory, SQLite + PostgreSQL (via SQL.ts), and Cosmos. Interpreter compiles each tag to its own IR variant carrying field/distinct metadata when present.

The shared select expression in SQL/query.ts now defers WHERE-clause parameter accumulation (whereClause()) so the relation-every branch — which emits its own NOT EXISTS subquery instead of the standard WHERE — does not double-add filter params.

Tests cover IR shape (query.test.ts) plus generated SQL for both dialects and end-to-end SQLite execution (sql-store.test.ts).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>