### PR TITLE
fix: restore OmegaForm input reactivity with @tanstack/vue-form 1.32

### DIFF
--- a/.changeset/little-planets-bake.md
+++ b/.changeset/little-planets-bake.md
@@ -1,0 +1,5 @@
+---
+"@effect-app/vue-components": minor
+---
+
+Restore OmegaForm input reactivity broken by the @tanstack/vue-form 1.32 bump — the Field slot's state prop became a stale snapshot, so bind inputs to the reactive field.state instead.

--- a/packages/vue-components/__tests__/OmegaForm/InputReactivity.test.ts
+++ b/packages/vue-components/__tests__/OmegaForm/InputReactivity.test.ts
@@ -1,0 +1,49 @@
+import { mount } from "@vue/test-utils"
+import * as S from "effect-app/Schema"
+import { describe, expect, it } from "vitest"
+import { useOmegaForm } from "../../src/components/OmegaForm"
+import OmegaIntlProvider from "../OmegaIntlProvider.vue"
+
+describe("OmegaForm input reactivity", () => {
+  it("reflects value changes from the slot `state` in the view", async () => {
+    const schema = S.Struct({
+      name: S.String
+    })
+
+    const wrapper = mount({
+      components: { OmegaIntlProvider },
+      template: `
+        <OmegaIntlProvider>
+          <component :is="form.Form">
+            <component :is="form.Input" label="Name" name="name">
+              <template #default="{ field, state }">
+                <input
+                  data-testid="input"
+                  :value="state.value"
+                  @input="(e) => field.handleChange(e.target.value)"
+                />
+                <span data-testid="display">{{ state.value }}</span>
+              </template>
+            </component>
+          </component>
+        </OmegaIntlProvider>
+      `,
+      setup() {
+        const form = useOmegaForm(schema, {
+          defaultValues: { name: "" }
+        })
+        return { form }
+      }
+    })
+
+    await wrapper.vm.$nextTick()
+
+    const input = wrapper.find("[data-testid='input']")
+    await input.setValue("hello")
+    await wrapper.vm.$nextTick()
+
+    // The slot `state` must stay in sync with the form store
+    expect(wrapper.find("[data-testid='display']").text()).toBe("hello")
+    expect((input.element as HTMLInputElement).value).toBe("hello")
+  })
+})

--- a/packages/vue-components/src/components/OmegaForm/InputProps.ts
+++ b/packages/vue-components/src/components/OmegaForm/InputProps.ts
@@ -43,7 +43,7 @@ export type InputProps<From extends Record<PropertyKey, any>, TName extends Deep
     inputClass: string | undefined | null
   }
   field: OmegaFieldInternalApi<From, TName>
-  /** be sure to use this state and not `field.state` as it is not reactive */
+  /** reactive field state, sourced from `field.state` (the Field slot's own `state` prop is a stale snapshot since @tanstack/vue-form 1.32) */
   state: OmegaFieldInternalApi<From, TName>["state"]
 }
 

--- a/packages/vue-components/src/components/OmegaForm/OmegaArray.vue
+++ b/packages/vue-components/src/components/OmegaForm/OmegaArray.vue
@@ -3,10 +3,11 @@
     :is="form.Field"
     :name="name"
   >
-    <template #default="{ field, state }">
+    <!-- `field.state` is reactive; the Field slot's `state` prop is a stale snapshot since @tanstack/vue-form 1.32 -->
+    <template #default="{ field }">
       <slot
         name="pre-array"
-        v-bind="{ field, state }"
+        v-bind="{ field, state: field.state }"
       />
       <component
         :is="form.Field"
@@ -14,11 +15,11 @@
         :key="`${name}[${Number(i)}]`"
         :name="`${name}[${Number(i)}]` as DeepKeys<From>"
       >
-        <template #default="{ field: subField, state: subState }">
+        <template #default="{ field: subField }">
           <slot
             v-bind="{
               subField,
-              subState,
+              subState: subField.state,
               index: Number(i),
               field
             }"
@@ -27,7 +28,7 @@
       </component>
       <slot
         name="post-array"
-        v-bind="{ field, state }"
+        v-bind="{ field, state: field.state }"
       />
       <!-- TODO: legacy slot, remove this slot -->
       <slot

--- a/packages/vue-components/src/components/OmegaForm/OmegaInput.vue
+++ b/packages/vue-components/src/components/OmegaForm/OmegaInput.vue
@@ -4,12 +4,18 @@
     :name="name"
     :validators="validators"
   >
-    <template #default="{ field, state }">
+    <!--
+      Read `state` from `field.state`, not the Field slot's `state` prop.
+      Since @tanstack/vue-form 1.32 the slot `state` is a one-time snapshot
+      taken when the field mounts and never updates, whereas `field.state`
+      is a reactive getter backed by the field store.
+    -->
+    <template #default="{ field }">
       <OmegaInternalInput
         v-if="meta"
         v-bind="{ ...$attrs, ...$props, inputClass: computedClass }"
         :field="field as any"
-        :state="state"
+        :state="field.state"
         :register="form.registerField"
         :label="label ?? errori18n(propsName)"
         :meta="meta"


### PR DESCRIPTION
## Problem

After bumping `@tanstack/vue-form` from `1.23.5` to `1.32.0` (#755), typing in OmegaForm inputs no longer updates the view — the form store value changes, but the rendered input is frozen.

Repro: `components-omegaform--simple-form` story.

## Root cause

`@tanstack/vue-form` **inverted** its `Field` slot reactivity between the two versions.

- **1.23.5** — `useField` returned `state` as a *ref*, and `Field` unwrapped it inside its render function. The slot `state` prop was reactive; `field.state` was not.
- **1.32.0** — `useField` returns `state: fieldState.value`, unwrapped **once**. The `Field` component passes that frozen snapshot as the slot `state` prop. Reactivity moved onto `field.state`, now a reactive getter.

OmegaForm bound inputs to the slot `state` prop (`OmegaInput → OmegaInternalInput → OmegaInputVuetify`, `:model-value="state.value"`). After the bump that prop is a static snapshot, so the view never re-renders.

The same #755 commit's `OmegaTaggedUnion` refactor (off `inputProps.state.value` onto `currentTag` from the form store) was half-addressing this — the input path was missed.

## Fix

Switch the `form.Field` slot consumers from the dead `state` prop to the reactive `field.state`:

- `OmegaInput.vue` — `:state="field.state"` (drives all input types)
- `OmegaArray.vue` — `pre-array` / `post-array` / item slots forward `field.state` / `subField.state`
- `InputProps.ts` — correct the now-inverted doc comment

## Verification

- New test `InputReactivity.test.ts` — fails before the fix (`expected '' to be 'hello'`), passes after.
- Full suite: **172/172 pass** across 35 files.
- Storybook `components-omegaform--simple-form`: typing updates the view live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)