### PR TITLE
chore(codegen): regenerate barrels with .ts extensions

### DIFF
--- a/packages/effect-app/src/client.ts
+++ b/packages/effect-app/src/client.ts
@@ -1,7 +1,7 @@
 // codegen:start {preset: barrel, include: ./client/*.ts}
-export * from "./client/apiClientFactory.js"
-export * from "./client/clientFor.js"
-export * from "./client/errors.js"
-export * from "./client/InvalidationKeys.js"
-export * from "./client/makeClient.js"
+export * from "./client/apiClientFactory.ts"
+export * from "./client/clientFor.ts"
+export * from "./client/errors.ts"
+export * from "./client/InvalidationKeys.ts"
+export * from "./client/makeClient.ts"
 // codegen:end

--- a/packages/effect-app/src/utils.ts
+++ b/packages/effect-app/src/utils.ts
@@ -14,11 +14,11 @@ import { identity, pipe } from "./Function.js"
 import type { DeepMutable, Equals, Mutable } from "./Types.js"
 
 // codegen:start {preset: barrel, include: ./utils/*.ts, nodir: false }
-export * from "./utils/effectify.js"
-export * from "./utils/extend.js"
-export * from "./utils/gen.js"
-export * from "./utils/logger.js"
-export * from "./utils/logLevel.js"
+export * from "./utils/effectify.ts"
+export * from "./utils/extend.ts"
+export * from "./utils/gen.ts"
+export * from "./utils/logger.ts"
+export * from "./utils/logLevel.ts"
 // codegen:end
 
 export * from "effect/Utils"

--- a/packages/infra/src/Model/filter/types.ts
+++ b/packages/infra/src/Model/filter/types.ts
@@ -1,6 +1,6 @@
 // codegen:start {preset: barrel, include: ./types/*.ts}
-export * from "./types/errors.js"
-export * from "./types/fields.js"
-export * from "./types/utils.js"
-export * from "./types/validator.js"
+export * from "./types/errors.ts"
+export * from "./types/fields.ts"
+export * from "./types/utils.ts"
+export * from "./types/validator.ts"
 // codegen:end

--- a/packages/infra/src/api/routing/middleware.ts
+++ b/packages/infra/src/api/routing/middleware.ts
@@ -1,4 +1,4 @@
 // codegen:start {preset: barrel, include: ./middleware/*.ts, nodir: false }
-export * from "./middleware/middleware.js"
-export * from "./middleware/RouterMiddleware.js"
+export * from "./middleware/middleware.ts"
+export * from "./middleware/RouterMiddleware.ts"
 // codegen:end


### PR DESCRIPTION
The codegen default extension was switched to `.ts` (`ccd484598`) but the barrel blocks were never regenerated — so the `codegen` lint check reports them as stale and CI lint fails.

Regenerates the affected barrels (`.js` → `.ts`) in `effect-app` and `infra`. Pure codegen output, no behavioral change.