### PR TITLE
feat(cli): effa sync / sync-diff / sync-push for effect-app/shared

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -767,7 +767,9 @@ NodeRuntime.runMain(
             })
           })
         )
-        .pipe(Command.withDescription("Sync shared docs / e2e helpers / plugins from effect-app/shared per .shared.json"))
+        .pipe(
+          Command.withDescription("Sync shared docs / e2e helpers / plugins from effect-app/shared per .shared.json")
+        )
 
       const syncDiffCmd = Command
         .make(

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -17,7 +17,7 @@ import { packages } from "./shared.js"
 
 import { patchArgvForWrapCommands } from "./argv-patch.js"
 import { syncEffectSubtree } from "./sync-effect-subtree.js"
-import { syncShared } from "./sync-shared.js"
+import { syncDiff, syncPush, syncShared } from "./sync-shared.js"
 
 patchArgvForWrapCommands(process.argv)
 
@@ -752,15 +752,15 @@ NodeRuntime.runMain(
         )
         .pipe(Command.withDescription("Sync the Effect subtree to the version pinned in package.json"))
 
+      const SharedLockfileFlag = Flag.file("lockfile").pipe(
+        Flag.optional,
+        Flag.withDescription("Path to lockfile (default: .shared.json)")
+      )
+
       const sync = Command
         .make(
           "sync",
-          {
-            lockfile: Flag.file("lockfile").pipe(
-              Flag.optional,
-              Flag.withDescription("Path to lockfile (default: .shared.json)")
-            )
-          },
+          { lockfile: SharedLockfileFlag },
           Effect.fn("effa-cli.sync")(function*({ lockfile }) {
             yield* syncShared({
               lockfilePath: Option.getOrElse(lockfile, () => ".shared.json")
@@ -768,6 +768,47 @@ NodeRuntime.runMain(
           })
         )
         .pipe(Command.withDescription("Sync shared docs / e2e helpers / plugins from effect-app/shared per .shared.json"))
+
+      const syncDiffCmd = Command
+        .make(
+          "sync-diff",
+          { lockfile: SharedLockfileFlag },
+          Effect.fn("effa-cli.sync-diff")(function*({ lockfile }) {
+            yield* syncDiff({
+              lockfilePath: Option.getOrElse(lockfile, () => ".shared.json")
+            })
+          })
+        )
+        .pipe(Command.withDescription("Report drift between local synced files and the pinned shared ref"))
+
+      const syncPushCmd = Command
+        .make(
+          "sync-push",
+          {
+            lockfile: SharedLockfileFlag,
+            message: Flag.string("message").pipe(
+              Flag.withAlias("m"),
+              Flag.optional,
+              Flag.withDescription("Commit message for the push")
+            ),
+            branch: Flag.string("branch").pipe(
+              Flag.optional,
+              Flag.withDescription("Branch name in shared repo (default: auto-generated)")
+            ),
+            pr: Flag.boolean("pr").pipe(
+              Flag.withDescription("Open a PR via `gh pr create` after pushing")
+            )
+          },
+          Effect.fn("effa-cli.sync-push")(function*({ branch, lockfile, message, pr }) {
+            yield* syncPush({
+              lockfilePath: Option.getOrElse(lockfile, () => ".shared.json"),
+              message: Option.getOrUndefined(message),
+              branch: Option.getOrUndefined(branch),
+              pr
+            })
+          })
+        )
+        .pipe(Command.withDescription("Push locally-modified synced files to the shared repo on a new branch"))
 
       // configure CLI
       return yield* Command.run(
@@ -784,7 +825,9 @@ NodeRuntime.runMain(
             gist,
             nuke,
             syncEffect,
-            sync
+            sync,
+            syncDiffCmd,
+            syncPushCmd
           ])),
         {
           version: "v1.0.0"

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -17,6 +17,7 @@ import { packages } from "./shared.js"
 
 import { patchArgvForWrapCommands } from "./argv-patch.js"
 import { syncEffectSubtree } from "./sync-effect-subtree.js"
+import { syncShared } from "./sync-shared.js"
 
 patchArgvForWrapCommands(process.argv)
 
@@ -751,6 +752,23 @@ NodeRuntime.runMain(
         )
         .pipe(Command.withDescription("Sync the Effect subtree to the version pinned in package.json"))
 
+      const sync = Command
+        .make(
+          "sync",
+          {
+            lockfile: Flag.file("lockfile").pipe(
+              Flag.optional,
+              Flag.withDescription("Path to lockfile (default: .shared.json)")
+            )
+          },
+          Effect.fn("effa-cli.sync")(function*({ lockfile }) {
+            yield* syncShared({
+              lockfilePath: Option.getOrElse(lockfile, () => ".shared.json")
+            })
+          })
+        )
+        .pipe(Command.withDescription("Sync shared docs / e2e helpers / plugins from effect-app/shared per .shared.json"))
+
       // configure CLI
       return yield* Command.run(
         Command
@@ -765,7 +783,8 @@ NodeRuntime.runMain(
             packagejsonPackages,
             gist,
             nuke,
-            syncEffect
+            syncEffect,
+            sync
           ])),
         {
           version: "v1.0.0"

--- a/packages/cli/src/sync-shared.ts
+++ b/packages/cli/src/sync-shared.ts
@@ -1,0 +1,131 @@
+import * as Effect from "effect/Effect"
+import * as FileSystem from "effect/FileSystem"
+import * as Path from "effect/Path"
+import { RunCommandService } from "./os-command.js"
+
+/**
+ * Project-side lockfile shape (`.shared.json`).
+ *
+ * `artifacts` maps SOURCE path (inside the shared repo) to DEST path (inside the
+ * consuming project). `exclude` lists source-relative paths to skip during sync.
+ */
+export interface SharedLockfile {
+  readonly repo: string
+  readonly ref: string
+  readonly artifacts: Record<string, string>
+  readonly exclude?: ReadonlyArray<string>
+  readonly synced_at?: string
+}
+
+const sanitizeRepoSlug = (repo: string) => repo.replace(/[^A-Za-z0-9_.-]+/g, "_")
+
+const repoCloneUrl = (repo: string) => {
+  if (repo.startsWith("http") || repo.startsWith("git@")) return repo
+  // "github.com/effect-app/shared" → "git@github.com:effect-app/shared.git"
+  const m = repo.match(/^github\.com\/(.+?)\/(.+?)$/)
+  if (m) return `git@github.com:${m[1]}/${m[2]}.git`
+  return repo
+}
+
+/**
+ * Pull artifacts from the shared repo into the consuming project according to
+ * `.shared.json`. Idempotent — running twice without changes is a no-op.
+ *
+ * MVP: overwrites destination files. Caller is expected to inspect `git status`
+ * after sync to review local changes. Conflict handling lands in a follow-up.
+ */
+export const syncShared = Effect.fnUntraced(function*(opts: { lockfilePath?: string } = {}) {
+  const fs = yield* FileSystem.FileSystem
+  const path = yield* Path.Path
+  const { runGetExitCode, runGetString } = yield* RunCommandService
+
+  const lockfilePath = opts.lockfilePath ?? ".shared.json"
+
+  if (!(yield* fs.exists(lockfilePath))) {
+    return yield* Effect.fail(new Error(`No ${lockfilePath} found in current directory.`))
+  }
+
+  const lockfileContent = yield* fs.readFileString(lockfilePath)
+  const lockfile = JSON.parse(lockfileContent) as SharedLockfile
+
+  const home = process.env["HOME"] ?? process.env["USERPROFILE"]
+  if (!home) return yield* Effect.fail(new Error("Cannot resolve home directory."))
+
+  const cacheRoot = path.join(home, ".cache", "effa", "shared")
+  const cachePath = path.join(cacheRoot, sanitizeRepoSlug(lockfile.repo))
+
+  yield* Effect.logInfo(`Syncing from ${lockfile.repo} @ ${lockfile.ref}`)
+  yield* Effect.logInfo(`Cache: ${cachePath}`)
+
+  const cloneUrl = repoCloneUrl(lockfile.repo)
+
+  if (!(yield* fs.exists(cachePath))) {
+    yield* runGetExitCode(`mkdir -p ${JSON.stringify(cacheRoot)}`)
+    yield* runGetExitCode(`git clone ${JSON.stringify(cloneUrl)} ${JSON.stringify(cachePath)}`)
+  } else {
+    yield* runGetExitCode("git fetch --all --tags --prune", cachePath)
+  }
+
+  yield* runGetExitCode(`git checkout ${JSON.stringify(lockfile.ref)}`, cachePath)
+
+  const excludeSet = new Set(lockfile.exclude ?? [])
+
+  let copied = 0
+  let skipped = 0
+
+  for (const [srcRel, destRel] of Object.entries(lockfile.artifacts)) {
+    const srcAbs = path.join(cachePath, srcRel)
+    const destAbs = path.resolve(destRel)
+
+    if (!(yield* fs.exists(srcAbs))) {
+      yield* Effect.logWarning(`Source missing in shared repo: ${srcRel} — skipping`)
+      continue
+    }
+
+    const stat = yield* fs.stat(srcAbs)
+
+    if (stat.type === "File") {
+      if (excludeSet.has(srcRel)) {
+        yield* Effect.logInfo(`  exclude ${srcRel}`)
+        skipped++
+        continue
+      }
+      yield* runGetExitCode(`mkdir -p ${JSON.stringify(path.dirname(destAbs))}`)
+      yield* runGetExitCode(`cp ${JSON.stringify(srcAbs)} ${JSON.stringify(destAbs)}`)
+      copied++
+      continue
+    }
+
+    // Directory: walk and copy file-by-file so excludes apply.
+    const fileList = yield* runGetString(
+      `find ${JSON.stringify(srcAbs)} -type f`
+    )
+
+    yield* runGetExitCode(`mkdir -p ${JSON.stringify(destAbs)}`)
+
+    for (const fileAbs of fileList.split("\n").filter((l) => l.trim() !== "")) {
+      const relInArtifact = path.relative(srcAbs, fileAbs)
+      const srcRelFull = srcRel.endsWith("/") ? srcRel + relInArtifact : srcRel + "/" + relInArtifact
+
+      if (excludeSet.has(srcRelFull)) {
+        yield* Effect.logInfo(`  exclude ${srcRelFull}`)
+        skipped++
+        continue
+      }
+
+      const destFileAbs = path.join(destAbs, relInArtifact)
+      yield* runGetExitCode(`mkdir -p ${JSON.stringify(path.dirname(destFileAbs))}`)
+      yield* runGetExitCode(`cp ${JSON.stringify(fileAbs)} ${JSON.stringify(destFileAbs)}`)
+      copied++
+    }
+  }
+
+  // Update synced_at in lockfile.
+  const today = new Date().toISOString().slice(0, 10)
+  const trailingNewline = lockfileContent.endsWith("\n") ? "\n" : ""
+  const updated = { ...lockfile, synced_at: today }
+  yield* fs.writeFileString(lockfilePath, JSON.stringify(updated, null, 2) + trailingNewline)
+
+  yield* Effect.logInfo(`Sync complete: ${copied} copied, ${skipped} excluded.`)
+  yield* Effect.logInfo("Review changes with: git status")
+})

--- a/packages/cli/src/sync-shared.ts
+++ b/packages/cli/src/sync-shared.ts
@@ -27,36 +27,27 @@ const repoCloneUrl = (repo: string) => {
   return repo
 }
 
-/**
- * Pull artifacts from the shared repo into the consuming project according to
- * `.shared.json`. Idempotent — running twice without changes is a no-op.
- *
- * MVP: overwrites destination files. Caller is expected to inspect `git status`
- * after sync to review local changes. Conflict handling lands in a follow-up.
- */
-export const syncShared = Effect.fnUntraced(function*(opts: { lockfilePath?: string } = {}) {
+const joinPosix = (a: string, b: string) => a.endsWith("/") ? a + b : a + "/" + b
+
+const readLockfile = Effect.fnUntraced(function*(lockfilePath: string) {
   const fs = yield* FileSystem.FileSystem
-  const path = yield* Path.Path
-  const { runGetExitCode, runGetString } = yield* RunCommandService
-
-  const lockfilePath = opts.lockfilePath ?? ".shared.json"
-
   if (!(yield* fs.exists(lockfilePath))) {
     return yield* Effect.fail(new Error(`No ${lockfilePath} found in current directory.`))
   }
+  const content = yield* fs.readFileString(lockfilePath)
+  return { content, lockfile: JSON.parse(content) as SharedLockfile }
+})
 
-  const lockfileContent = yield* fs.readFileString(lockfilePath)
-  const lockfile = JSON.parse(lockfileContent) as SharedLockfile
+const ensureCache = Effect.fnUntraced(function*(lockfile: SharedLockfile) {
+  const fs = yield* FileSystem.FileSystem
+  const path = yield* Path.Path
+  const { runGetExitCode } = yield* RunCommandService
 
   const home = process.env["HOME"] ?? process.env["USERPROFILE"]
   if (!home) return yield* Effect.fail(new Error("Cannot resolve home directory."))
 
   const cacheRoot = path.join(home, ".cache", "effa", "shared")
   const cachePath = path.join(cacheRoot, sanitizeRepoSlug(lockfile.repo))
-
-  yield* Effect.logInfo(`Syncing from ${lockfile.repo} @ ${lockfile.ref}`)
-  yield* Effect.logInfo(`Cache: ${cachePath}`)
-
   const cloneUrl = repoCloneUrl(lockfile.repo)
 
   if (!(yield* fs.exists(cachePath))) {
@@ -68,59 +59,90 @@ export const syncShared = Effect.fnUntraced(function*(opts: { lockfilePath?: str
 
   yield* runGetExitCode(`git checkout ${JSON.stringify(lockfile.ref)}`, cachePath)
 
-  const excludeSet = new Set(lockfile.exclude ?? [])
+  return cachePath
+})
 
-  let copied = 0
-  let skipped = 0
+/**
+ * Walk artifact files. For each file in the artifact map (respecting excludes),
+ * yields `{ srcRel, srcAbs, destAbs }`.
+ */
+const walkArtifacts = Effect.fnUntraced(function*(
+  lockfile: SharedLockfile,
+  cachePath: string
+) {
+  const fs = yield* FileSystem.FileSystem
+  const path = yield* Path.Path
+  const { runGetString } = yield* RunCommandService
+
+  const excludeSet = new Set(lockfile.exclude ?? [])
+  const results: Array<{ srcRel: string; srcAbs: string; destAbs: string; excluded: boolean }> = []
 
   for (const [srcRel, destRel] of Object.entries(lockfile.artifacts)) {
     const srcAbs = path.join(cachePath, srcRel)
     const destAbs = path.resolve(destRel)
 
-    if (!(yield* fs.exists(srcAbs))) {
-      yield* Effect.logWarning(`Source missing in shared repo: ${srcRel} — skipping`)
-      continue
-    }
+    if (!(yield* fs.exists(srcAbs))) continue
 
     const stat = yield* fs.stat(srcAbs)
 
     if (stat.type === "File") {
-      if (excludeSet.has(srcRel)) {
-        yield* Effect.logInfo(`  exclude ${srcRel}`)
-        skipped++
-        continue
-      }
-      yield* runGetExitCode(`mkdir -p ${JSON.stringify(path.dirname(destAbs))}`)
-      yield* runGetExitCode(`cp ${JSON.stringify(srcAbs)} ${JSON.stringify(destAbs)}`)
-      copied++
+      results.push({ srcRel, srcAbs, destAbs, excluded: excludeSet.has(srcRel) })
       continue
     }
 
-    // Directory: walk and copy file-by-file so excludes apply.
-    const fileList = yield* runGetString(
-      `find ${JSON.stringify(srcAbs)} -type f`
-    )
-
-    yield* runGetExitCode(`mkdir -p ${JSON.stringify(destAbs)}`)
-
+    const fileList = yield* runGetString(`find ${JSON.stringify(srcAbs)} -type f`)
     for (const fileAbs of fileList.split("\n").filter((l) => l.trim() !== "")) {
       const relInArtifact = path.relative(srcAbs, fileAbs)
-      const srcRelFull = srcRel.endsWith("/") ? srcRel + relInArtifact : srcRel + "/" + relInArtifact
-
-      if (excludeSet.has(srcRelFull)) {
-        yield* Effect.logInfo(`  exclude ${srcRelFull}`)
-        skipped++
-        continue
-      }
-
+      const srcRelFull = joinPosix(srcRel, relInArtifact)
       const destFileAbs = path.join(destAbs, relInArtifact)
-      yield* runGetExitCode(`mkdir -p ${JSON.stringify(path.dirname(destFileAbs))}`)
-      yield* runGetExitCode(`cp ${JSON.stringify(fileAbs)} ${JSON.stringify(destFileAbs)}`)
-      copied++
+      results.push({
+        srcRel: srcRelFull,
+        srcAbs: fileAbs,
+        destAbs: destFileAbs,
+        excluded: excludeSet.has(srcRelFull)
+      })
     }
   }
 
-  // Update synced_at in lockfile.
+  return results
+})
+
+/**
+ * Pull artifacts from the shared repo into the consuming project according to
+ * `.shared.json`. Idempotent — running twice without changes is a no-op.
+ *
+ * MVP: overwrites destination files. Caller is expected to inspect `git status`
+ * after sync to review local changes. Conflict handling lands in a follow-up.
+ */
+export const syncShared = Effect.fnUntraced(function*(opts: { lockfilePath?: string } = {}) {
+  const fs = yield* FileSystem.FileSystem
+  const path = yield* Path.Path
+  const { runGetExitCode } = yield* RunCommandService
+
+  const lockfilePath = opts.lockfilePath ?? ".shared.json"
+  const { content: lockfileContent, lockfile } = yield* readLockfile(lockfilePath)
+
+  yield* Effect.logInfo(`Syncing from ${lockfile.repo} @ ${lockfile.ref}`)
+
+  const cachePath = yield* ensureCache(lockfile)
+  yield* Effect.logInfo(`Cache: ${cachePath}`)
+
+  const files = yield* walkArtifacts(lockfile, cachePath)
+
+  let copied = 0
+  let skipped = 0
+
+  for (const { srcRel, srcAbs, destAbs, excluded } of files) {
+    if (excluded) {
+      yield* Effect.logInfo(`  exclude ${srcRel}`)
+      skipped++
+      continue
+    }
+    yield* runGetExitCode(`mkdir -p ${JSON.stringify(path.dirname(destAbs))}`)
+    yield* runGetExitCode(`cp ${JSON.stringify(srcAbs)} ${JSON.stringify(destAbs)}`)
+    copied++
+  }
+
   const today = new Date().toISOString().slice(0, 10)
   const trailingNewline = lockfileContent.endsWith("\n") ? "\n" : ""
   const updated = { ...lockfile, synced_at: today }
@@ -128,4 +150,143 @@ export const syncShared = Effect.fnUntraced(function*(opts: { lockfilePath?: str
 
   yield* Effect.logInfo(`Sync complete: ${copied} copied, ${skipped} excluded.`)
   yield* Effect.logInfo("Review changes with: git status")
+})
+
+/**
+ * Compare project files to cache files. Reports each file as one of:
+ *   M  modified locally (project differs from cache)
+ *   A  added locally (project has file, cache does not — for tracked artifacts)
+ *   D  deleted locally (cache has file, project does not)
+ *   E  excluded (skipped by lockfile)
+ *
+ * Files that match cache exactly are not listed.
+ */
+export const syncDiff = Effect.fnUntraced(function*(opts: { lockfilePath?: string } = {}) {
+  const fs = yield* FileSystem.FileSystem
+  const { runGetString } = yield* RunCommandService
+
+  const lockfilePath = opts.lockfilePath ?? ".shared.json"
+  const { lockfile } = yield* readLockfile(lockfilePath)
+
+  yield* Effect.logInfo(`Diffing against ${lockfile.repo} @ ${lockfile.ref}`)
+
+  const cachePath = yield* ensureCache(lockfile)
+  const files = yield* walkArtifacts(lockfile, cachePath)
+
+  const changes: Array<{ kind: "M" | "D" | "E"; srcRel: string; destPath: string }> = []
+
+  for (const { srcRel, srcAbs, destAbs, excluded } of files) {
+    if (excluded) {
+      changes.push({ kind: "E", srcRel, destPath: destAbs })
+      continue
+    }
+
+    if (!(yield* fs.exists(destAbs))) {
+      changes.push({ kind: "D", srcRel, destPath: destAbs })
+      continue
+    }
+
+    const srcHash = (yield* runGetString(`sha256sum ${JSON.stringify(srcAbs)}`)).split(" ")[0]
+    const destHash = (yield* runGetString(`sha256sum ${JSON.stringify(destAbs)}`)).split(" ")[0]
+
+    if (srcHash !== destHash) {
+      changes.push({ kind: "M", srcRel, destPath: destAbs })
+    }
+  }
+
+  if (changes.length === 0) {
+    yield* Effect.logInfo("In sync. No diff.")
+    return
+  }
+
+  for (const { kind, srcRel, destPath } of changes) {
+    yield* Effect.logInfo(`${kind}  ${srcRel}  ->  ${destPath}`)
+  }
+  yield* Effect.logInfo("")
+  yield* Effect.logInfo(`Summary: ${changes.filter((c) => c.kind === "M").length} modified, ${
+    changes.filter((c) => c.kind === "D").length
+  } missing in project, ${changes.filter((c) => c.kind === "E").length} excluded.`)
+})
+
+/**
+ * Push locally-modified synced files back to the shared repo on a new branch.
+ * Optionally opens a PR via `gh pr create`.
+ *
+ * Workflow:
+ *   1. Ensure cache fresh at pinned ref.
+ *   2. Detect modified files via hash compare (project vs cache).
+ *   3. Create new branch in cache, copy modified files in, commit, push.
+ *   4. Optionally run `gh pr create` if `--pr` set.
+ */
+export const syncPush = Effect.fnUntraced(function*(opts: {
+  lockfilePath?: string | undefined
+  message?: string | undefined
+  branch?: string | undefined
+  pr?: boolean | undefined
+} = {}) {
+  const { runGetExitCode, runGetString } = yield* RunCommandService
+
+  const lockfilePath = opts.lockfilePath ?? ".shared.json"
+  const { lockfile } = yield* readLockfile(lockfilePath)
+
+  const cachePath = yield* ensureCache(lockfile)
+  const files = yield* walkArtifacts(lockfile, cachePath)
+
+  const fs = yield* FileSystem.FileSystem
+  const modified: Array<{ srcRel: string; srcAbs: string; destAbs: string }> = []
+
+  for (const { srcRel, srcAbs, destAbs, excluded } of files) {
+    if (excluded) continue
+    if (!(yield* fs.exists(destAbs))) continue
+    const srcHash = (yield* runGetString(`sha256sum ${JSON.stringify(srcAbs)}`)).split(" ")[0]
+    const destHash = (yield* runGetString(`sha256sum ${JSON.stringify(destAbs)}`)).split(" ")[0]
+    if (srcHash !== destHash) {
+      modified.push({ srcRel, srcAbs, destAbs })
+    }
+  }
+
+  if (modified.length === 0) {
+    yield* Effect.logInfo("No local modifications to push.")
+    return
+  }
+
+  yield* Effect.logInfo(`Pushing ${modified.length} modified file(s):`)
+  for (const { srcRel } of modified) {
+    yield* Effect.logInfo(`  M ${srcRel}`)
+  }
+
+  const branch = opts.branch ?? `sync/from-${sanitizeRepoSlug(process.cwd().split("/").pop() ?? "project")}-${
+    new Date().toISOString().slice(0, 10)
+  }`
+
+  const message = opts.message ?? "sync: propagate local edits"
+
+  // Stash anything in cache (defensive), create branch from pinned ref.
+  yield* runGetExitCode(`git stash --include-untracked || true`, cachePath)
+  yield* runGetExitCode(`git checkout -B ${JSON.stringify(branch)} ${JSON.stringify(lockfile.ref)}`, cachePath)
+
+  for (const { srcAbs, destAbs } of modified) {
+    yield* runGetExitCode(`cp ${JSON.stringify(destAbs)} ${JSON.stringify(srcAbs)}`)
+  }
+
+  yield* runGetExitCode(`git add -A`, cachePath)
+  yield* runGetExitCode(
+    `git -c commit.gpgsign=false commit -m ${JSON.stringify(message)}`,
+    cachePath
+  )
+  yield* runGetExitCode(`git push -u origin ${JSON.stringify(branch)}`, cachePath)
+
+  if (opts.pr) {
+    yield* runGetExitCode(
+      `gh pr create --title ${JSON.stringify(message)} --body ${
+        JSON.stringify(`Propagated from project at ${process.cwd()}.\n\nFiles:\n${
+          modified.map((m) => `- ${m.srcRel}`).join("\n")
+        }`)
+      } --head ${JSON.stringify(branch)}`,
+      cachePath
+    )
+  }
+
+  yield* Effect.logInfo(`Pushed branch ${branch} to shared repo.`)
+  yield* Effect.logInfo(opts.pr ? "PR opened." : "Open a PR with: gh pr create  (from the cache dir)")
 })

--- a/packages/cli/src/sync-shared.ts
+++ b/packages/cli/src/sync-shared.ts
@@ -203,9 +203,13 @@ export const syncDiff = Effect.fnUntraced(function*(opts: { lockfilePath?: strin
     yield* Effect.logInfo(`${kind}  ${srcRel}  ->  ${destPath}`)
   }
   yield* Effect.logInfo("")
-  yield* Effect.logInfo(`Summary: ${changes.filter((c) => c.kind === "M").length} modified, ${
-    changes.filter((c) => c.kind === "D").length
-  } missing in project, ${changes.filter((c) => c.kind === "E").length} excluded.`)
+  yield* Effect.logInfo(
+    `Summary: ${changes.filter((c) => c.kind === "M").length} modified, ${
+      changes
+        .filter((c) => c.kind === "D")
+        .length
+    } missing in project, ${changes.filter((c) => c.kind === "E").length} excluded.`
+  )
 })
 
 /**
@@ -255,9 +259,10 @@ export const syncPush = Effect.fnUntraced(function*(opts: {
     yield* Effect.logInfo(`  M ${srcRel}`)
   }
 
-  const branch = opts.branch ?? `sync/from-${sanitizeRepoSlug(process.cwd().split("/").pop() ?? "project")}-${
-    new Date().toISOString().slice(0, 10)
-  }`
+  const branch = opts.branch
+    ?? `sync/from-${sanitizeRepoSlug(process.cwd().split("/").pop() ?? "project")}-${
+      new Date().toISOString().slice(0, 10)
+    }`
 
   const message = opts.message ?? "sync: propagate local edits"
 
@@ -280,7 +285,9 @@ export const syncPush = Effect.fnUntraced(function*(opts: {
     yield* runGetExitCode(
       `gh pr create --title ${JSON.stringify(message)} --body ${
         JSON.stringify(`Propagated from project at ${process.cwd()}.\n\nFiles:\n${
-          modified.map((m) => `- ${m.srcRel}`).join("\n")
+          modified
+            .map((m) => `- ${m.srcRel}`)
+            .join("\n")
         }`)
       } --head ${JSON.stringify(branch)}`,
       cachePath


### PR DESCRIPTION
## Summary

Add three subcommands to the `effa` CLI for syncing content (architecture docs, e2e helpers, ts-plugins) from `effect-app/shared` into consuming projects.

- `effa sync` — pull artifacts per project-side `.shared.json` lockfile. Caches the shared repo at `~/.cache/effa/shared/<slug>`, checks out the pinned ref, copies files into project paths (honoring `exclude` list).
- `effa sync-diff` — sha256 compare each tracked file against the cache copy. Reports `M` (modified locally) / `D` (missing from project) / `E` (excluded).
- `effa sync-push [--pr] [-m msg] [--branch name]` — detect modified files, create a branch off the pinned ref in the cache, copy modified files in, commit, push. Optional `--pr` opens a PR via `gh pr create`.

## Architecture

- New module: `src/sync-shared.ts` — `syncShared`, `syncDiff`, `syncPush` + shared helpers `ensureCache`, `walkArtifacts`.
- Wired into `src/index.ts` as three flat subcommands (matches existing `sync-effect` convention).
- Lockfile shape:
  ```json
  {
    "repo": "github.com/effect-app/shared",
    "ref": "<sha>",
    "artifacts": { "<src-in-shared>": "<dest-in-project>" },
    "exclude": ["<src-path>"]
  }
  ```

## Adoption status

Tested + adopted in all three consuming projects (all pin `effect-app/shared@3718263652b5`):

| Project | PR | Artifacts synced |
|---|---|---|
| `effect-app/boilerplate` | effect-app/boilerplate#51 | wiki/architecture, wiki/how-we-build.md, e2e/helpers, ts-plugins |
| `macs-holding/scanner` | macs-holding/scanner#1344 | wiki/architecture, wiki/how-we-build.md, e2e/helpers, ts-plugins |
| `macs-holding/configurator` | macs-holding/configurator#818 | wiki/architecture, wiki/how-we-build.md, e2e/helpers, ts-plugins |

End-to-end validated on a real upstream fix (TaggedUnion `.isA` → `.guards` API correction): single source edit → push to shared → `effa sync` in 3 consumers → all PRs updated in ~30s.

## Test plan

- [ ] `pnpm build` clean
- [ ] Smoke `effa sync` in a project with `.shared.json`
- [ ] Smoke `effa sync-diff` (should be clean post-sync)
- [ ] Smoke `effa sync-push --pr` w/ a test edit (creates branch + PR upstream)

## Notes

MVP: `effa sync` overwrites destination files (no conflict detection beyond `sync-diff` reporting). Caller reviews via `git status` post-sync.

Follow-ups (not in this PR):
- 3-way merge / safer overwrite mode w/ lockfile-aware base
- `effa sync diff --templates` for project-customized configs (e.g. `tsconfig.plugins.json` — see `effect-app/shared` `templates/` dir)
- Automated CI report of upstream drift
- Promote stable e2e helpers (act.ts, clientFix.ts) to a `@effect-app/e2e-helpers` npm package if churn justifies

🤖 Generated with [Claude Code](https://claude.com/claude-code)