### PR TITLE
feat(effect-app): type-safe query DSL with pipe-inferred field paths

### DIFF
--- a/.changeset/typed-query-builders.md
+++ b/.changeset/typed-query-builders.md
@@ -8,4 +8,5 @@ Tighten typing of query DSL builders so field/path parameters are constrained to
 - `relation(path).expr` exposes a scope-bound math-expression builder so `expr.field(...)` inside `sumExpr`/`sumExprBy`/`sumExprNormalized` is typed against the relation element.
 - Top-level `expr.field` accepts an optional generic for opt-in tightening (`expr.field<E>("x")`).
 - `aggregate(schema, build)` accepts a builder callback whose `agg` argument is bound to the source row inferred from the pipe — paths are checked without any explicit generic: `make<Row>().pipe(aggregate(schema, ($) => ({ city: $.field("address.city") })))`. Plain `AggregateMap` form still accepted.
+- `projectComputed(schema, build, mode?)` accepts a builder callback whose `{ relation }` argument is bound to the source row inferred from the pipe: `make<Row>().pipe(projectComputed(out, ({ relation }) => ({ total: relation("items").sum("qty") })))`. Plain `ComputedProjectionMap` form still accepted.
 - `agg<Row>()` factory remains as an escape hatch when the builder is built outside a pipe.

--- a/.changeset/typed-query-builders.md
+++ b/.changeset/typed-query-builders.md
@@ -1,0 +1,10 @@
+---
+"effect-app": minor
+---
+
+Tighten typing of query DSL builders so field/path parameters are constrained to actual field paths instead of bare `string`:
+
+- `relation(path)` now infers the relation's element type and constrains `distinctCount`/`sum`/`collect`/`collectDistinct`/`collectFields`/`collectDistinctFields` and the `unit` of `sumExprBy`/`sumExprNormalized` to `FieldPath<Element>`.
+- `relation(path).expr` exposes a scope-bound math-expression builder so `expr.field(...)` inside `sumExpr`/`sumExprBy`/`sumExprNormalized` is typed against the relation element.
+- Top-level `expr.field` accepts an optional generic for opt-in tightening (`expr.field<E>("x")`).
+- `agg` becomes a generic factory: `agg<Row>().field/sum/min/max(...)` constrains the path to `FieldPath<Row>`. Update call sites accordingly.

--- a/.changeset/typed-query-builders.md
+++ b/.changeset/typed-query-builders.md
@@ -7,4 +7,5 @@ Tighten typing of query DSL builders so field/path parameters are constrained to
 - `relation(path)` now infers the relation's element type and constrains `distinctCount`/`sum`/`collect`/`collectDistinct`/`collectFields`/`collectDistinctFields` and the `unit` of `sumExprBy`/`sumExprNormalized` to `FieldPath<Element>`.
 - `relation(path).expr` exposes a scope-bound math-expression builder so `expr.field(...)` inside `sumExpr`/`sumExprBy`/`sumExprNormalized` is typed against the relation element.
 - Top-level `expr.field` accepts an optional generic for opt-in tightening (`expr.field<E>("x")`).
-- `agg` becomes a generic factory: `agg<Row>().field/sum/min/max(...)` constrains the path to `FieldPath<Row>`. Update call sites accordingly.
+- `aggregate(schema, build)` accepts a builder callback whose `agg` argument is bound to the source row inferred from the pipe — paths are checked without any explicit generic: `make<Row>().pipe(aggregate(schema, ($) => ({ city: $.field("address.city") })))`. Plain `AggregateMap` form still accepted.
+- `agg<Row>()` factory remains as an escape hatch when the builder is built outside a pipe.

--- a/packages/effect-app/src/Model/query/dsl.ts
+++ b/packages/effect-app/src/Model/query/dsl.ts
@@ -506,9 +506,42 @@ export const project: {
   ) => QueryProjection<ExtractFieldValuesRefined<Q>, A, R, ExtractTType<Q>, E>
 } = (schema: any, mode = "transform") => (current: any) => new Project({ current, schema, mode } as any)
 
-export const relation = <TFieldValues extends FieldValues>(
-  path: FieldPath<TFieldValues>
+/**
+ * Element type of an array-valued field path on `TFieldValues`. Falls back to
+ * `FieldValues` when the path does not resolve to an array of structs so that
+ * `FieldPath<...>` stays defined (it just degrades to `string`).
+ *
+ * Uses `Extract` so that when `P` defaults to the full `FieldPath<TFieldValues>`
+ * union, only the array-valued branches contribute to the element type.
+ */
+export type RelationElement<
+  TFieldValues extends FieldValues,
+  P extends FieldPath<TFieldValues>
+> = Extract<FieldPathValue<TFieldValues, P>, ReadonlyArray<unknown>> extends ReadonlyArray<infer E>
+  ? (E extends FieldValues ? E : FieldValues)
+  : FieldValues
+
+export const relation = <
+  TFieldValues extends FieldValues,
+  const P extends FieldPath<TFieldValues> = FieldPath<TFieldValues>
+>(
+  path: P
 ) => ({
+  /**
+   * Typed math-expression builder bound to the relation's element scope:
+   * `relation("items").expr.field("weight")` constrains the field path to
+   * `FieldPath<RelationElement<TFieldValues, P>>`.
+   */
+  expr: {
+    field: (field: FieldPath<RelationElement<TFieldValues, P>>): ComputedProjectionMathExpression => ({
+      _tag: "field",
+      field: field as string
+    }),
+    mul: (
+      left: ComputedProjectionMathExpression,
+      right: ComputedProjectionMathExpression
+    ): ComputedProjectionMathExpression => ({ _tag: "mul", left, right })
+  },
   length: (): ComputedProjectionExpression => ({
     _tag: "relation-length",
     path: path as string
@@ -540,31 +573,37 @@ export const relation = <TFieldValues extends FieldValues>(
     path: path as string,
     operation
   }),
-  distinctCount: (field: string, operation?: ComputedProjectionOperation): ComputedProjectionExpression =>
+  distinctCount: (
+    field: FieldPath<RelationElement<TFieldValues, P>>,
+    operation?: ComputedProjectionOperation
+  ): ComputedProjectionExpression =>
     operation
       ? {
         _tag: "relation-distinct-count",
         path: path as string,
-        field,
+        field: field as string,
         operation
       }
       : {
         _tag: "relation-distinct-count",
         path: path as string,
-        field
+        field: field as string
       },
-  sum: (field: string, operation?: ComputedProjectionOperation): ComputedProjectionExpression =>
+  sum: (
+    field: FieldPath<RelationElement<TFieldValues, P>>,
+    operation?: ComputedProjectionOperation
+  ): ComputedProjectionExpression =>
     operation
       ? {
         _tag: "relation-sum",
         path: path as string,
-        field,
+        field: field as string,
         operation
       }
       : {
         _tag: "relation-sum",
         path: path as string,
-        field
+        field: field as string
       },
   sumExpr: (
     expression: ComputedProjectionMathExpression,
@@ -584,7 +623,7 @@ export const relation = <TFieldValues extends FieldValues>(
       },
   sumExprBy: (
     expression: ComputedProjectionMathExpression,
-    options: { unit: string },
+    options: { unit: FieldPath<RelationElement<TFieldValues, P>> },
     operation?: ComputedProjectionOperation
   ): ComputedProjectionExpression =>
     operation
@@ -592,18 +631,22 @@ export const relation = <TFieldValues extends FieldValues>(
         _tag: "relation-sum-expr-by",
         path: path as string,
         expression,
-        unit: options.unit,
+        unit: options.unit as string,
         operation
       }
       : {
         _tag: "relation-sum-expr-by",
         path: path as string,
         expression,
-        unit: options.unit
+        unit: options.unit as string
       },
   sumExprNormalized: (
     expression: ComputedProjectionMathExpression,
-    options: { unit: string; toBase: string; factors: Readonly<Record<string, number>> },
+    options: {
+      unit: FieldPath<RelationElement<TFieldValues, P>>
+      toBase: string
+      factors: Readonly<Record<string, number>>
+    },
     operation?: ComputedProjectionOperation
   ): ComputedProjectionExpression =>
     operation
@@ -611,7 +654,7 @@ export const relation = <TFieldValues extends FieldValues>(
         _tag: "relation-sum-expr-normalized",
         path: path as string,
         expression,
-        unit: options.unit,
+        unit: options.unit as string,
         toBase: options.toBase,
         factors: options.factors,
         operation
@@ -620,77 +663,96 @@ export const relation = <TFieldValues extends FieldValues>(
         _tag: "relation-sum-expr-normalized",
         path: path as string,
         expression,
-        unit: options.unit,
+        unit: options.unit as string,
         toBase: options.toBase,
         factors: options.factors
       },
-  collect: (field: string, operation?: ComputedProjectionOperation): ComputedProjectionExpression =>
+  collect: (
+    field: FieldPath<RelationElement<TFieldValues, P>>,
+    operation?: ComputedProjectionOperation
+  ): ComputedProjectionExpression =>
     operation
       ? {
         _tag: "relation-collect",
         path: path as string,
-        field,
+        field: field as string,
         distinct: false,
         operation
       }
       : {
         _tag: "relation-collect",
         path: path as string,
-        field,
+        field: field as string,
         distinct: false
       },
-  collectDistinct: (field: string, operation?: ComputedProjectionOperation): ComputedProjectionExpression =>
+  collectDistinct: (
+    field: FieldPath<RelationElement<TFieldValues, P>>,
+    operation?: ComputedProjectionOperation
+  ): ComputedProjectionExpression =>
     operation
       ? {
         _tag: "relation-collect",
         path: path as string,
-        field,
+        field: field as string,
         distinct: true,
         operation
       }
       : {
         _tag: "relation-collect",
         path: path as string,
-        field,
+        field: field as string,
         distinct: true
       },
-  collectFields: (fields: readonly string[], operation?: ComputedProjectionOperation): ComputedProjectionExpression =>
-    operation
-      ? {
-        _tag: "relation-collect-fields",
-        path: path as string,
-        fields,
-        distinct: false,
-        operation
-      }
-      : {
-        _tag: "relation-collect-fields",
-        path: path as string,
-        fields,
-        distinct: false
-      },
-  collectDistinctFields: (
-    fields: readonly string[],
+  collectFields: (
+    fields: readonly FieldPath<RelationElement<TFieldValues, P>>[],
     operation?: ComputedProjectionOperation
   ): ComputedProjectionExpression =>
     operation
       ? {
         _tag: "relation-collect-fields",
         path: path as string,
-        fields,
+        fields: fields as readonly string[],
+        distinct: false,
+        operation
+      }
+      : {
+        _tag: "relation-collect-fields",
+        path: path as string,
+        fields: fields as readonly string[],
+        distinct: false
+      },
+  collectDistinctFields: (
+    fields: readonly FieldPath<RelationElement<TFieldValues, P>>[],
+    operation?: ComputedProjectionOperation
+  ): ComputedProjectionExpression =>
+    operation
+      ? {
+        _tag: "relation-collect-fields",
+        path: path as string,
+        fields: fields as readonly string[],
         distinct: true,
         operation
       }
       : {
         _tag: "relation-collect-fields",
         path: path as string,
-        fields,
+        fields: fields as readonly string[],
         distinct: true
       }
 })
 
+/**
+ * Untyped math-expression builder. Field paths are not statically validated —
+ * prefer the scope-bound `relation(path).expr` builder when the element type
+ * is known, since it constrains the field argument to `FieldPath<E>`.
+ *
+ * The generic parameter is accepted for symmetry with the scoped builder so
+ * callers may opt into a tighter check via `expr.field<E>("x")`.
+ */
 export const expr = {
-  field: (field: string): ComputedProjectionMathExpression => ({ _tag: "field", field }),
+  field: <T extends FieldValues = FieldValues>(
+    field: FieldPath<T>
+  ): ComputedProjectionMathExpression => ({ _tag: "field", field: field as string }),
   mul: (
     left: ComputedProjectionMathExpression,
     right: ComputedProjectionMathExpression
@@ -731,46 +793,64 @@ export const projectComputed: {
   new Project({ current, schema, mode, computed: computedProjection } as any)
 
 /**
- * DSL helpers for building aggregate expressions used with {@link aggregate}.
+ * Scope-bound aggregate-expression builder factory. Invoke with the source
+ * document field-value shape to get a builder whose `field`/`sum`/`min`/`max`
+ * arguments are constrained to `FieldPath<TFieldValues>`.
  *
- * - `agg.field(path)` — references a document field for GROUP BY (with optional output alias)
- * - `agg.count()` — COUNT(*) across all rows in the group
- * - `agg.countWhen(op)` — COUNT of rows matching the filter operation
- * - `agg.sum(field)` — SUM of a numeric document field
- * - `agg.min(field)` / `agg.max(field)` — MIN/MAX of a document field
+ * Example: `agg<Row>().field("address.city")`, `agg<Row>().sum("qty")`.
+ *
+ * - `field(path)` — references a document field for GROUP BY (with optional output alias)
+ * - `count()` — COUNT(*) across all rows in the group
+ * - `countWhen(op)` — COUNT of rows matching the filter operation
+ * - `sum(field)` — SUM of a numeric document field
+ * - `min(field)` / `max(field)` — MIN/MAX of a document field
  */
-export const agg = {
-  field: (path: string): AggregateExpression => ({ _tag: "agg-field", path }),
+export const agg = <TFieldValues extends FieldValues = FieldValues>() => ({
+  field: (path: FieldPath<TFieldValues>): AggregateExpression => ({
+    _tag: "agg-field",
+    path: path as string
+  }),
   count: (): AggregateExpression => ({ _tag: "agg-count" }),
   countWhen: (operation: ComputedProjectionOperation): AggregateExpression => ({
     _tag: "agg-count-when",
     operation
   }),
-  sum: (field: string): AggregateExpression => ({ _tag: "agg-sum", field }),
-  min: (field: string): AggregateExpression => ({ _tag: "agg-min", field }),
-  max: (field: string): AggregateExpression => ({ _tag: "agg-max", field })
-} as const
+  sum: (field: FieldPath<TFieldValues>): AggregateExpression => ({
+    _tag: "agg-sum",
+    field: field as string
+  }),
+  min: (field: FieldPath<TFieldValues>): AggregateExpression => ({
+    _tag: "agg-min",
+    field: field as string
+  }),
+  max: (field: FieldPath<TFieldValues>): AggregateExpression => ({
+    _tag: "agg-max",
+    field: field as string
+  })
+})
 
 /**
  * Attach an aggregate projection to a query, performing GROUP BY + aggregate functions at the
  * database level instead of fetching all rows and grouping in memory.
  *
  * The `aggregateMap` maps each output field name to either:
- * - `agg.field(path)` — a group-by field (document path → output alias)
- * - `agg.count()` / `agg.countWhen(op)` / `agg.sum(f)` / `agg.min(f)` / `agg.max(f)` — an aggregate
+ * - `agg<Row>().field(path)` — a group-by field (document path → output alias)
+ * - `agg<Row>().count()` / `agg<Row>().countWhen(op)` / `agg<Row>().sum(f)` / `agg<Row>().min(f)` /
+ *   `agg<Row>().max(f)` — an aggregate
  *
  * The output is decoded directly with `schema` (no PM reverse-mapping, no etag tracking).
  * Decode failures surface as `S.SchemaError`.
  *
  * @example
  * ```ts
+ * const a = agg<Row>()
  * repo.query(
  *   where("status", "active"),
  *   aggregate(
  *     S.Struct({ city: S.String, count: S.Number }),
  *     {
- *       city: agg.field("address.city"),
- *       count: agg.countWhen((q) => q.pipe(where("active", true)))
+ *       city: a.field("address.city"),
+ *       count: a.countWhen((q) => q.pipe(where("active", true)))
  *     }
  *   )
  * )

--- a/packages/effect-app/src/Model/query/dsl.ts
+++ b/packages/effect-app/src/Model/query/dsl.ts
@@ -793,70 +793,81 @@ export const projectComputed: {
   new Project({ current, schema, mode, computed: computedProjection } as any)
 
 /**
+ * Builder shape returned by {@link agg}. Field-taking methods are constrained
+ * to `FieldPath<TFieldValues>` so paths are validated against the document
+ * shape.
+ */
+export interface AggBuilder<TFieldValues extends FieldValues> {
+  field: (path: FieldPath<TFieldValues>) => AggregateExpression
+  count: () => AggregateExpression
+  countWhen: (operation: ComputedProjectionOperation) => AggregateExpression
+  sum: (field: FieldPath<TFieldValues>) => AggregateExpression
+  min: (field: FieldPath<TFieldValues>) => AggregateExpression
+  max: (field: FieldPath<TFieldValues>) => AggregateExpression
+}
+
+const makeAggBuilder = <TFieldValues extends FieldValues>(): AggBuilder<TFieldValues> => ({
+  field: (path) => ({ _tag: "agg-field", path: path as string }),
+  count: () => ({ _tag: "agg-count" }),
+  countWhen: (operation) => ({ _tag: "agg-count-when", operation }),
+  sum: (field) => ({ _tag: "agg-sum", field: field as string }),
+  min: (field) => ({ _tag: "agg-min", field: field as string }),
+  max: (field) => ({ _tag: "agg-max", field: field as string })
+})
+
+/**
  * Scope-bound aggregate-expression builder factory. Invoke with the source
  * document field-value shape to get a builder whose `field`/`sum`/`min`/`max`
  * arguments are constrained to `FieldPath<TFieldValues>`.
  *
- * Example: `agg<Row>().field("address.city")`, `agg<Row>().sum("qty")`.
- *
- * - `field(path)` — references a document field for GROUP BY (with optional output alias)
- * - `count()` — COUNT(*) across all rows in the group
- * - `countWhen(op)` — COUNT of rows matching the filter operation
- * - `sum(field)` — SUM of a numeric document field
- * - `min(field)` / `max(field)` — MIN/MAX of a document field
+ * Prefer the inline callback form of {@link aggregate} (`aggregate(schema,
+ * ($) => ({...}))`) — there the source shape is inferred from the pipe so no
+ * explicit type argument is needed. This factory is the escape hatch when
+ * the builder is constructed outside the pipe.
  */
-export const agg = <TFieldValues extends FieldValues = FieldValues>() => ({
-  field: (path: FieldPath<TFieldValues>): AggregateExpression => ({
-    _tag: "agg-field",
-    path: path as string
-  }),
-  count: (): AggregateExpression => ({ _tag: "agg-count" }),
-  countWhen: (operation: ComputedProjectionOperation): AggregateExpression => ({
-    _tag: "agg-count-when",
-    operation
-  }),
-  sum: (field: FieldPath<TFieldValues>): AggregateExpression => ({
-    _tag: "agg-sum",
-    field: field as string
-  }),
-  min: (field: FieldPath<TFieldValues>): AggregateExpression => ({
-    _tag: "agg-min",
-    field: field as string
-  }),
-  max: (field: FieldPath<TFieldValues>): AggregateExpression => ({
-    _tag: "agg-max",
-    field: field as string
-  })
-})
+export const agg = <TFieldValues extends FieldValues = FieldValues>(): AggBuilder<TFieldValues> =>
+  makeAggBuilder<TFieldValues>()
 
 /**
  * Attach an aggregate projection to a query, performing GROUP BY + aggregate functions at the
  * database level instead of fetching all rows and grouping in memory.
  *
- * The `aggregateMap` maps each output field name to either:
- * - `agg<Row>().field(path)` — a group-by field (document path → output alias)
- * - `agg<Row>().count()` / `agg<Row>().countWhen(op)` / `agg<Row>().sum(f)` / `agg<Row>().min(f)` /
- *   `agg<Row>().max(f)` — an aggregate
- *
- * The output is decoded directly with `schema` (no PM reverse-mapping, no etag tracking).
- * Decode failures surface as `S.SchemaError`.
+ * Pass a builder callback to get a typed `agg` bound to the source row shape
+ * (inferred from the pipe — no explicit generic needed):
  *
  * @example
  * ```ts
- * const a = agg<Row>()
  * repo.query(
  *   where("status", "active"),
  *   aggregate(
  *     S.Struct({ city: S.String, count: S.Number }),
- *     {
- *       city: a.field("address.city"),
- *       count: a.countWhen((q) => q.pipe(where("active", true)))
- *     }
+ *     ($) => ({
+ *       city: $.field("address.city"),
+ *       count: $.countWhen((q) => q.pipe(where("active", true)))
+ *     })
  *   )
  * )
  * ```
+ *
+ * A plain {@link AggregateMap} is also accepted for the rare case where the
+ * map is built outside the pipe (loses path inference).
+ *
+ * The output is decoded directly with `schema` (no PM reverse-mapping, no etag tracking).
+ * Decode failures surface as `S.SchemaError`.
  */
 export const aggregate: {
+  <
+    Q extends Query<any> | QueryWhere<any, any, any> | QueryEnd<any, "one" | "many", any>,
+    I extends Record<string, unknown>,
+    A = ExtractFieldValuesRefined<Q>,
+    R = never,
+    E extends boolean = ExtractExclusiveness<Q>
+  >(
+    schema: S.Codec<A, I, R>,
+    build: (agg: AggBuilder<ExtractFieldValuesRefined<Q>>) => AggregateMap
+  ): (
+    current: Q
+  ) => QueryProjection<ExtractFieldValuesRefined<Q>, A, R, ExtractTType<Q>, E>
   <
     Q extends Query<any> | QueryWhere<any, any, any> | QueryEnd<any, "one" | "many", any>,
     I extends Record<string, unknown>,
@@ -869,8 +880,12 @@ export const aggregate: {
   ): (
     current: Q
   ) => QueryProjection<ExtractFieldValuesRefined<Q>, A, R, ExtractTType<Q>, E>
-} = (schema: any, aggregateMap: AggregateMap) => (current: any) =>
-  new Project({ current, schema, mode: "aggregate", aggregateMap } as any)
+} = (schema: any, mapOrBuild: AggregateMap | ((agg: AggBuilder<FieldValues>) => AggregateMap)) => (current: any) => {
+  const aggregateMap = typeof mapOrBuild === "function"
+    ? mapOrBuild(makeAggBuilder())
+    : mapOrBuild
+  return new Project({ current, schema, mode: "aggregate", aggregateMap } as any)
+}
 
 type GetArV<T> = T extends readonly (infer R)[] ? R : never
 

--- a/packages/effect-app/src/Model/query/dsl.ts
+++ b/packages/effect-app/src/Model/query/dsl.ts
@@ -761,7 +761,49 @@ export const expr = {
 
 export const computed = <T extends ComputedProjectionMap>(value: T): T => value
 
+/**
+ * Helpers passed to the inline-builder form of {@link projectComputed}. The
+ * `relation` factory is bound to the source row shape so paths/fields inside
+ * the projection are validated against the document shape inferred from the
+ * pipe.
+ */
+export interface ComputedHelpers<TFieldValues extends FieldValues> {
+  relation: <const P extends FieldPath<TFieldValues>>(path: P) => ReturnType<typeof relation<TFieldValues, P>>
+}
+
+const makeComputedHelpers = <TFieldValues extends FieldValues>(): ComputedHelpers<TFieldValues> => ({
+  relation: (path) => relation<TFieldValues, typeof path>(path)
+})
+
 export const projectComputed: {
+  <
+    Q extends Query<any> | QueryWhere<any, any, any> | QueryEnd<any, "one" | "many", any>,
+    I extends Record<string, unknown>,
+    A = ExtractFieldValuesRefined<Q>,
+    R = never,
+    E extends boolean = ExtractExclusiveness<Q>
+  >(
+    schema: S.Codec<Option.Option<A>, I, R>,
+    build: (helpers: ComputedHelpers<ExtractFieldValuesRefined<Q>>) => ComputedProjectionMap,
+    mode: "collect"
+  ): (
+    current: Q
+  ) => QueryProjection<ExtractFieldValuesRefined<Q>, A, R, ExtractTType<Q>, E>
+
+  <
+    Q extends Query<any> | QueryWhere<any, any, any> | QueryEnd<any, "one" | "many", any>,
+    I extends Record<string, unknown>,
+    A = ExtractFieldValuesRefined<Q>,
+    R = never,
+    E extends boolean = ExtractExclusiveness<Q>
+  >(
+    schema: S.Codec<A, I, R>,
+    build: (helpers: ComputedHelpers<ExtractFieldValuesRefined<Q>>) => ComputedProjectionMap,
+    mode?: "project"
+  ): (
+    current: Q
+  ) => QueryProjection<ExtractFieldValuesRefined<Q>, A, R, ExtractTType<Q>, E>
+
   <
     Q extends Query<any> | QueryWhere<any, any, any> | QueryEnd<any, "one" | "many", any>,
     I extends Record<string, unknown>,
@@ -789,8 +831,19 @@ export const projectComputed: {
   ): (
     current: Q
   ) => QueryProjection<ExtractFieldValuesRefined<Q>, A, R, ExtractTType<Q>, E>
-} = (schema: any, computedProjection: ComputedProjectionMap, mode = "project") => (current: any) =>
-  new Project({ current, schema, mode, computed: computedProjection } as any)
+} = (
+  schema: any,
+  mapOrBuild:
+    | ComputedProjectionMap
+    | ((helpers: ComputedHelpers<FieldValues>) => ComputedProjectionMap),
+  mode = "project"
+) =>
+(current: any) => {
+  const computedProjection = typeof mapOrBuild === "function"
+    ? mapOrBuild(makeComputedHelpers())
+    : mapOrBuild
+  return new Project({ current, schema, mode, computed: computedProjection } as any)
+}
 
 /**
  * Builder shape returned by {@link agg}. Field-taking methods are constrained


### PR DESCRIPTION
## Summary

The query DSL helpers previously accepted `field: string`, so typos and stale field names only surfaced at the store boundary (or silently produced wrong results in memory filters). This PR tightens the builder input types to `FieldPath<Element>` derived from the source shape — IR representation stays `string` under the hood; only the *builder inputs* are tightened.

### Tightened builders

- `relation<Row>(path)` infers the array element type and constrains `distinctCount`/`sum`/`collect`/`collectDistinct`/`collectFields`/`collectDistinctFields` and the `unit` of `sumExprBy`/`sumExprNormalized` to `FieldPath<Element>`.
- `relation(path).expr` — scope-bound math-expression builder so `sumExpr(relation("items").expr.mul(...))` validates field paths.
- Top-level `expr.field` keeps the existing API but takes an optional generic for opt-in checking: `expr.field<Element>("weight")`.
- `agg<Row>()` factory: `field`/`sum`/`min`/`max` paths validated against `Row`.

### Pipe-inferred callback forms (no explicit `<Row>` needed)

`aggregate` and `projectComputed` now accept a builder callback. The builder is bound to the source row inferred contextually from the pipe — same TS inference trick `order(field)` already uses (callback body is checked after pipe binds `Q`).

```ts
make<Row>().pipe(
  aggregate(
    S.Struct({ city: S.String, total: S.Number }),
    ($) => ({
      city: $.field(\"address.city\"),
      total: $.sum(\"qty\")
    })
  )
)

make<Row>().pipe(
  projectComputed(
    S.Struct({ total: S.Number, distinctArticles: S.NonNegativeInt }),
    ({ relation }) => ({
      total: relation(\"items\").sum(\"qty\"),
      distinctArticles: relation(\"items\").distinctCount(\"articleId\", where(\"qty\", \"gte\", 0))
    })
  )
)
```

Pre-existing forms (`aggregate(schema, aggregateMap)`, `projectComputed(schema, computed({...}))`) still accepted as loose escape hatches via overloads.

### Implementation notes

- `RelationElement<TFieldValues, P>` uses `Extract<..., ReadonlyArray<unknown>>` so when `P` defaults to the full `FieldPath<TFieldValues>` union, only the array-valued branches contribute. Existing call sites like `relation<Row>(\"items\")` (without explicit `P`) stay tight.
- `AggBuilder<TFieldValues>` and `ComputedHelpers<TFieldValues>` are exported interfaces so callers can name builder parameters in stored closures.

## Test plan

- [x] \`pnpm check\` clean.
- [x] \`pnpm --filter @effect-app/infra test query.test.ts rawQuery.test.ts cosmos-query.test.ts\` — 72 tests pass, 7 skipped.
- [x] Verified bad paths rejected:
  - \`relation<Row>(\"items\").sum(\"nonexistent\")\` → \`Argument of type '\"nonexistent\"' is not assignable to parameter of type '\"articleId\" | \"qty\"'\`.
  - \`aggregate(out, (\$) => ({ a: \$.field(\"nonexistent\") }))\` rejected against \`Row\`.
  - \`projectComputed(out, ({ relation }) => ({ a: relation(\"items\").sum(\"nonexistent\") }))\` rejected against element type.

Pre-existing unrelated lint error in [packages/effect-app/src/ids.ts:27](packages/effect-app/src/ids.ts#L27) (\`unbound-method\` on \`StringId.make\`) is not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)