### PR TITLE
feat(infra): sqlite WorkflowEngine adapter with full test suite

### DIFF
--- a/.changeset/agents-md-root-cause-guidance.md
+++ b/.changeset/agents-md-root-cause-guidance.md
@@ -1,0 +1,5 @@
+---
+"@effect-app/infra": patch
+---
+
+Docs: expand `AGENTS.md` with explicit root-cause-vs-workaround guidance. Adds a "Root causes, not workarounds" core principle, calls out hand-rolled deserialization (custom `reviveX` helpers) and skipped prior-art search as anti-patterns, and adds a pre-fix checklist for diagnosing errors at their boundary instead of masking the symptom.

--- a/.changeset/agents-md-root-cause-guidance.md
+++ b/.changeset/agents-md-root-cause-guidance.md
@@ -1,5 +1,0 @@
----
-"@effect-app/infra": patch
----
-
-Docs: expand `AGENTS.md` with explicit root-cause-vs-workaround guidance. Adds a "Root causes, not workarounds" core principle, calls out hand-rolled deserialization (custom `reviveX` helpers) and skipped prior-art search as anti-patterns, and adds a pre-fix checklist for diagnosing errors at their boundary instead of masking the symptom.

--- a/.changeset/sqlite-workflow-engine.md
+++ b/.changeset/sqlite-workflow-engine.md
@@ -1,0 +1,5 @@
+---
+"@effect-app/infra": minor
+---
+
+Add SQLite backed `WorkflowEngine` adapter (`layerSqlite` in `WorkflowEngineSqlite.ts`). Persists workflow state across `workflow_exec` / `workflow_activity` / `workflow_deferred` / `workflow_clock` tables via `SqlClient`. Uses `sql.withTransaction` for atomicity, etag-based optimistic concurrency (`UPDATE ... WHERE etag = ? RETURNING etag`), and `INSERT ... ON CONFLICT DO NOTHING RETURNING` for first-writer-wins on activity / deferred / clock writes. Values crossing the storage boundary round-trip through `Schema` codecs (`S.fromJsonString(S.toCodecJson(...))`) using the workflow's own `payloadSchema` / `successSchema` / `errorSchema` for typed values, and the cluster engine's opaque `AnyOrVoid` codec for activity / deferred payloads. Includes time-bound lease + heartbeat fiber, scope-bound recovery poller for crashed-driver takeover, and cross-partition clock poller for restart-survivable durable timers.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,13 +10,34 @@ This is the Effect App library repository, focusing on functional programming pa
 ### Core Principles
 
 - **Zero Tolerance for Errors**: All automated checks must pass
-- **No `as any` / `as unknown` casts**: These are never acceptable fixes. Understand the actual types and fix the root cause. If a type mismatch exists, find the correct v4 API, update the type signatures, or restructure the code.
+- **Root causes, not workarounds**: When something fails — a type error, a runtime crash, a failing test, a hanging fiber — diagnose the invariant that was violated and fix it there. Do **not** mask the symptom with a wrapper, a revive helper, a `try/catch`, a `JSON.parse(JSON.stringify(...))`, or any other shape-coercion. Each of these is a tell that you skipped the diagnosis.
+- **No `as any` / `as unknown` casts**: A specific case of the rule above. Casts hide the type system telling you the shape is wrong. Understand the actual types and fix the root cause. If a type mismatch exists, find the correct v4 API, update the type signatures, or restructure the code.
+- **No hand-rolled deserialization**: Anything stored as JSON and read back must round-trip through a Schema codec (`S.fromJsonString(S.toCodecJson(...))`, `S.encodeEffect` / `S.decodeEffect`). Class prototypes — `Exit`, `Cause`, `Workflow.Result`, `Schema.Class` instances — do not survive `JSON.parse`. The schema layer is the canonical reconstruction path; writing a custom `reviveX` helper is a smell that the codec is missing.
+- **Search prior art before writing helpers**: Before introducing a new utility for a cross-boundary concern (serialization, encoding, retries, context propagation, OCC), grep the repo and `repos/effect` for the established pattern. The cluster engine, the existing Cosmos adapter, the SQL stores — they have already solved most of these problems. Copying the established pattern beats inventing a parallel one.
+- **Check newer branches before resuming work**: A new session may resume on `main` with no checkout of relevant feature branches. Before extending a topic, run `git branch -a | grep <topic>` and inspect the latest version with `git show <branch>:<path>`. Session-local memory of "how X works" may be from an older draft that has since been replaced.
 - **Clarity over Cleverness**: Choose clear, maintainable solutions
 - **Conciseness**: Keep code and any wording concise and to the point. Sacrifice grammar for the sake of concision.
 - **Reduce comments**: Avoid comments unless absolutely required to explain unusual or complex logic. Comments in jsdocs are acceptable.
 - **Look for effect sources inside `repos/effect`**
 - **Never import local `repos` files**: Always use the latest online versions of packages instead.
 - **Never webfetch from the effect repos**: just use the locally included under `repos`
+
+### When you hit an error, before writing any fix
+
+Errors are signals, not nuisances. Run this checklist:
+
+1. **State the failure precisely.** Quote the exact error or behavior. `"object is not iterable"` is not the same as `"wrong type"`. The message names the violated invariant.
+2. **Name the boundary.** Where in the data flow did the value lose the property the consumer needs? At the storage write, the storage read, the network hop, the schema decode, the context provision?
+3. **Search for prior art at that boundary.** `grep` the repo + `repos/effect` for how similar values cross the same boundary. If a pattern exists, use it.
+4. **Only then write code.** If your fix re-implements something the searched-for pattern already does (revive prototypes, retry on OCC, encode JSON), stop — use the existing pattern instead.
+
+Anti-patterns that mean you skipped the checklist:
+
+- `JSON.parse` of a value that contains tagged classes, followed by manual prototype reconstruction.
+- `try/catch` around a yield that swallows the error and returns a fabricated value.
+- Adding a second `as any` to make a first `as any` typecheck.
+- Adding a sleep / retry to "give it time to work" instead of finding the missing wake signal.
+- Disabling a hook (`--no-verify`) or a check to make the diff land.
 
 ### Mandatory Validation Steps
 

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -152,6 +152,10 @@
       "types": "./dist/Store/utils.d.ts",
       "default": "./dist/Store/utils.js"
     },
+    "./WorkflowEngineSqlite": {
+      "types": "./dist/WorkflowEngineSqlite.d.ts",
+      "default": "./dist/WorkflowEngineSqlite.js"
+    },
     "./arbs": {
       "types": "./dist/arbs.d.ts",
       "default": "./dist/arbs.js"

--- a/packages/infra/src/WorkflowEngineSqlite.ts
+++ b/packages/infra/src/WorkflowEngineSqlite.ts
@@ -3,7 +3,7 @@
  *
  * Persists workflow state across four tables:
  *   - `workflow_exec`     — one row per execution; tracks status, lease, etag
- *   - `workflow_activity` — recorded activity exits keyed by (exec, name, attempt)
+ *   - `workflow_activity` — recorded activity results keyed by (exec, name, attempt)
  *   - `workflow_deferred` — durable deferred completions keyed by (exec, name)
  *   - `workflow_clock`    — scheduled clocks with `fire_at`
  *
@@ -16,6 +16,18 @@
  *   - activity / deferred / clock inserts use `INSERT ... ON CONFLICT DO
  *     NOTHING RETURNING ...` for first-writer-wins semantics across drivers.
  *
+ * Durability — everything that crosses the storage boundary is round-tripped
+ * through schema codecs (`S.fromJsonString(S.toCodecJson(...))`), exactly like
+ * the cluster engine:
+ *
+ * - The workflow payload and the top-level `Workflow.Result` are encoded with
+ *   the workflow's own `payloadSchema` / `successSchema` / `errorSchema`, so
+ *   typed values (dates, branded ids, schema classes) survive a restart.
+ * - Activity results flow through the engine already encoded, so they are
+ *   persisted with an opaque `Workflow.Result({ success: AnyOrVoid, error:
+ *   AnyOrVoid })` codec — same trick the cluster `ActivityRpc` uses.
+ * - Durable-deferred exits use an opaque `Exit` codec.
+ *
  * Crash recovery: each driver holds a time-bound lease on the exec row,
  * renewed by a heartbeat fiber. A scope-bound recovery poller re-drives any
  * exec whose lease has lapsed. A clock poller fires due clocks even when
@@ -24,7 +36,7 @@
 import * as Effect from "effect-app/Effect"
 import * as Layer from "effect-app/Layer"
 import * as Option from "effect-app/Option"
-import * as Cause from "effect/Cause"
+import * as S from "effect-app/Schema"
 import * as Duration from "effect/Duration"
 import * as Exit from "effect/Exit"
 import * as Fiber from "effect/Fiber"
@@ -58,12 +70,14 @@ type ExecStatus = "running" | "complete" | "interrupted"
 interface ExecRow {
   readonly execution_id: string
   readonly workflow_name: string
+  /** Schema-encoded (JSON string) workflow payload. */
   readonly payload: string
   readonly parent: string | null
   readonly status: ExecStatus
   readonly suspended: number
   readonly interrupted: number
-  readonly completed_exit: string | null
+  /** Schema-encoded (JSON string) top-level `Workflow.Result`, set on completion. */
+  readonly completed_result: string | null
   readonly worker: string | null
   readonly lease_expires_at: number | null
   readonly etag: string
@@ -72,65 +86,44 @@ interface ExecRow {
 interface ExecState {
   readonly executionId: string
   readonly workflowName: string
-  readonly payload: object
+  readonly payload: string
   readonly parent: string | undefined
   readonly status: ExecStatus
   readonly suspended: boolean
   readonly interrupted: boolean
-  readonly completedExit: Workflow.Result<unknown, unknown> | undefined
+  readonly completedResult: string | undefined
   readonly worker: string | undefined
   readonly leaseExpiresAt: number | undefined
   readonly etag: string
 }
 
-// --- JSON revival of Exit / Cause / Workflow.Result ------------------
-// SQLite stores these as JSON, which loses class prototypes. The engine
-// wrapper code in `effect/unstable/workflow/WorkflowEngine` relies on real
-// `Exit` values (e.g. `yield* exit`, `Exit.map`), so we reconstruct them
-// before returning to the wrapper.
-
-const reviveCause = (c: unknown): Cause.Cause<unknown> => {
-  if (Cause.isCause(c)) return c
-  const reasons = (c as { reasons?: ReadonlyArray<any> })?.reasons ?? []
-  if (reasons.length === 0) return Cause.empty
-  return Cause.fromReasons(reasons.map((r) => {
-    if (r._tag === "Fail") return Cause.fail(r.error).reasons[0]!
-    if (r._tag === "Die") return Cause.die(r.defect).reasons[0]!
-    if (r._tag === "Interrupt") return Cause.interrupt(r.fiberId).reasons[0]!
-    return Cause.die(r).reasons[0]!
-  }))
-}
-
-const reviveExit = <A, E>(j: unknown): Exit.Exit<A, E> => {
-  if (Exit.isExit(j)) return j as Exit.Exit<A, E>
-  const v = j as { _tag: string; value?: unknown; cause?: unknown }
-  if (v?._tag === "Success") return Exit.succeed(v.value) as Exit.Exit<A, E>
-  return Exit.failCause(reviveCause(v?.cause)) as Exit.Exit<A, E>
-}
-
-const reviveResult = (
-  r: unknown
-): Workflow.Result<unknown, unknown> => {
-  const v = r as { _tag: string; exit?: unknown }
-  if (v?._tag === "Suspended") return v as unknown as Workflow.Result<unknown, unknown>
-  return { ...(v as object), exit: reviveExit(v.exit) } as unknown as Workflow.Result<unknown, unknown>
-}
-
 const parseExec = (row: ExecRow): ExecState => ({
   executionId: row.execution_id,
   workflowName: row.workflow_name,
-  payload: JSON.parse(row.payload) as object,
+  payload: row.payload,
   parent: row.parent ?? undefined,
   status: row.status,
   suspended: row.suspended !== 0,
   interrupted: row.interrupted !== 0,
-  completedExit: row.completed_exit
-    ? reviveResult(JSON.parse(row.completed_exit))
-    : undefined,
+  completedResult: row.completed_result ?? undefined,
   worker: row.worker ?? undefined,
   leaseExpiresAt: row.lease_expires_at ?? undefined,
   etag: row.etag
 })
+
+// --- Storage codecs ---------------------------------------------------------
+// Values flowing through the engine's activity / deferred boundary are already
+// schema-encoded, so the structure is round-tripped while the payload stays
+// opaque (mirrors the cluster engine's `AnyOrVoid` usage).
+const AnyOrVoid = S.Union([S.Any, S.Void])
+const ActivityResultCodec = S.fromJsonString(S.toCodecJson(Workflow.Result({ success: AnyOrVoid, error: AnyOrVoid })))
+const DeferredExitCodec = S.fromJsonString(S.toCodecJson(S.Exit(AnyOrVoid, AnyOrVoid, S.Defect)))
+
+const encodeActivityResult = (r: Workflow.Result<unknown, unknown>) =>
+  Effect.orDie(S.encodeEffect(ActivityResultCodec)(r))
+const decodeActivityResult = (s: string) => Effect.orDie(S.decodeEffect(ActivityResultCodec)(s))
+const encodeDeferredExit = (e: Exit.Exit<unknown, unknown>) => Effect.orDie(S.encodeEffect(DeferredExitCodec)(e))
+const decodeDeferredExit = (s: string) => Effect.orDie(S.decodeEffect(DeferredExitCodec)(s))
 
 const makeSqliteWorkflowEngine = Effect.fnUntraced(function*(cfg: WorkflowEngineSqliteConfig) {
   const sql = yield* SqlClient.SqlClient
@@ -170,7 +163,7 @@ const makeSqliteWorkflowEngine = Effect.fnUntraced(function*(cfg: WorkflowEngine
        status TEXT NOT NULL,
        suspended INTEGER NOT NULL DEFAULT 0,
        interrupted INTEGER NOT NULL DEFAULT 0,
-       completed_exit TEXT,
+       completed_result TEXT,
        worker TEXT,
        lease_expires_at INTEGER,
        etag TEXT NOT NULL
@@ -184,7 +177,7 @@ const makeSqliteWorkflowEngine = Effect.fnUntraced(function*(cfg: WorkflowEngine
        execution_id TEXT NOT NULL,
        name TEXT NOT NULL,
        attempt INTEGER NOT NULL,
-       exit TEXT NOT NULL,
+       result TEXT NOT NULL,
        PRIMARY KEY (execution_id, name, attempt)
      )`
   )
@@ -230,6 +223,41 @@ const makeSqliteWorkflowEngine = Effect.fnUntraced(function*(cfg: WorkflowEngine
   const locals = new Map<string, LocalExec>()
   const clocks = yield* FiberMap.make<string>()
 
+  // Per-workflow codecs for the typed payload + top-level result. Cached by
+  // workflow name; derived from the workflow's own schemas so typed values
+  // (dates, branded ids, schema classes) survive the storage round-trip.
+  const makePayloadCodec = (workflow: Workflow.Any) => S.fromJsonString(S.toCodecJson(workflow.payloadSchema))
+  const payloadCodecCache = new Map<string, ReturnType<typeof makePayloadCodec>>()
+  const payloadCodecFor = (workflow: Workflow.Any) => {
+    let c = payloadCodecCache.get(workflow.name)
+    if (!c) {
+      c = makePayloadCodec(workflow)
+      payloadCodecCache.set(workflow.name, c)
+    }
+    return c
+  }
+
+  const makeResultCodec = (workflow: Workflow.Any) =>
+    S.fromJsonString(S.toCodecJson(Workflow.Result({ success: workflow.successSchema, error: workflow.errorSchema })))
+  const resultCodecCache = new Map<string, ReturnType<typeof makeResultCodec>>()
+  const resultCodecFor = (workflow: Workflow.Any) => {
+    let c = resultCodecCache.get(workflow.name)
+    if (!c) {
+      c = makeResultCodec(workflow)
+      resultCodecCache.set(workflow.name, c)
+    }
+    return c
+  }
+
+  const encodePayload = (workflow: Workflow.Any, payload: object) =>
+    Effect.orDie(S.encodeEffect(payloadCodecFor(workflow))(payload)) as Effect.Effect<string>
+  const decodePayload = (workflow: Workflow.Any, s: string) =>
+    Effect.orDie(S.decodeEffect(payloadCodecFor(workflow))(s)) as Effect.Effect<object>
+  const encodeResult = (workflow: Workflow.Any, r: Workflow.Result<unknown, unknown>) =>
+    Effect.orDie(S.encodeEffect(resultCodecFor(workflow))(r)) as Effect.Effect<string>
+  const decodeResult = (workflow: Workflow.Any, s: string) =>
+    Effect.orDie(S.decodeEffect(resultCodecFor(workflow))(s)) as Effect.Effect<Workflow.Result<unknown, unknown>>
+
   // --- Core SQL operations ----------------------------------------------
 
   const readExec = (executionId: string): Effect.Effect<Option.Option<ExecState>> =>
@@ -262,7 +290,7 @@ const makeSqliteWorkflowEngine = Effect.fnUntraced(function*(cfg: WorkflowEngine
            SET status = ?,
                suspended = ?,
                interrupted = ?,
-               completed_exit = ?,
+               completed_result = ?,
                worker = ?,
                lease_expires_at = ?,
                etag = ?
@@ -272,7 +300,7 @@ const makeSqliteWorkflowEngine = Effect.fnUntraced(function*(cfg: WorkflowEngine
             merged.status,
             merged.suspended ? 1 : 0,
             merged.interrupted ? 1 : 0,
-            merged.completedExit ? JSON.stringify(merged.completedExit) : null,
+            merged.completedResult ?? null,
             merged.worker ?? null,
             merged.leaseExpiresAt ?? null,
             newEtag,
@@ -301,7 +329,7 @@ const makeSqliteWorkflowEngine = Effect.fnUntraced(function*(cfg: WorkflowEngine
       [
         initial.executionId,
         initial.workflowName,
-        JSON.stringify(initial.payload),
+        initial.payload,
         initial.parent ?? null,
         initial.status,
         initial.suspended ? 1 : 0,
@@ -314,57 +342,73 @@ const makeSqliteWorkflowEngine = Effect.fnUntraced(function*(cfg: WorkflowEngine
         annotate("createExec", initial.executionId)
       )
 
-  type ActivityResult = Workflow.Result<unknown, unknown>
-
-  const insertActivity = (
+  // First-writer-wins persistence of an activity result; returns true if this
+  // call won, false if another writer beat us to the (exec, name, attempt) row.
+  const createActivity = (
     executionId: string,
     name: string,
     attempt: number,
-    result: ActivityResult
+    encoded: string
   ): Effect.Effect<boolean> =>
     exec(
-      `INSERT INTO "${activityTable}" (execution_id, name, attempt, exit)
+      `INSERT INTO "${activityTable}" (execution_id, name, attempt, result)
        VALUES (?, ?, ?, ?)
        ON CONFLICT DO NOTHING
        RETURNING execution_id`,
-      [executionId, name, attempt, JSON.stringify(result)]
+      [executionId, name, attempt, encoded]
     )
       .pipe(Effect.map((rows) => (rows as ReadonlyArray<unknown>).length > 0))
+
+  // Overwrites a previously persisted *suspended* activity result so the next
+  // attempt can record its real outcome.
+  const upsertActivity = (
+    executionId: string,
+    name: string,
+    attempt: number,
+    encoded: string
+  ): Effect.Effect<void> =>
+    exec(
+      `INSERT INTO "${activityTable}" (execution_id, name, attempt, result)
+       VALUES (?, ?, ?, ?)
+       ON CONFLICT(execution_id, name, attempt) DO UPDATE SET result = excluded.result`,
+      [executionId, name, attempt, encoded]
+    )
+      .pipe(Effect.asVoid)
 
   const readActivity = (
     executionId: string,
     name: string,
     attempt: number
-  ): Effect.Effect<Option.Option<ActivityResult>> =>
+  ): Effect.Effect<Option.Option<string>> =>
     exec(
-      `SELECT exit FROM "${activityTable}" WHERE execution_id = ? AND name = ? AND attempt = ?`,
+      `SELECT result FROM "${activityTable}" WHERE execution_id = ? AND name = ? AND attempt = ?`,
       [executionId, name, attempt]
     )
       .pipe(
         Effect.map((rows) => {
-          const r = (rows as ReadonlyArray<{ exit: string }>)[0]
-          return r ? Option.some(reviveResult(JSON.parse(r.exit))) : Option.none()
+          const r = (rows as ReadonlyArray<{ result: string }>)[0]
+          return r ? Option.some(r.result) : Option.none<string>()
         })
       )
 
-  const insertDeferred = (
+  const createDeferred = (
     executionId: string,
     name: string,
-    exitValue: Exit.Exit<unknown, unknown>
+    encoded: string
   ): Effect.Effect<boolean> =>
     exec(
       `INSERT INTO "${deferredTable}" (execution_id, name, exit)
        VALUES (?, ?, ?)
        ON CONFLICT DO NOTHING
        RETURNING execution_id`,
-      [executionId, name, JSON.stringify(exitValue)]
+      [executionId, name, encoded]
     )
       .pipe(Effect.map((rows) => (rows as ReadonlyArray<unknown>).length > 0))
 
   const readDeferred = (
     executionId: string,
     name: string
-  ): Effect.Effect<Option.Option<Exit.Exit<unknown, unknown>>> =>
+  ): Effect.Effect<Option.Option<string>> =>
     exec(
       `SELECT exit FROM "${deferredTable}" WHERE execution_id = ? AND name = ?`,
       [executionId, name]
@@ -372,7 +416,7 @@ const makeSqliteWorkflowEngine = Effect.fnUntraced(function*(cfg: WorkflowEngine
       .pipe(
         Effect.map((rows) => {
           const r = (rows as ReadonlyArray<{ exit: string }>)[0]
-          return r ? Option.some(reviveExit(JSON.parse(r.exit))) : Option.none()
+          return r ? Option.some(r.exit) : Option.none<string>()
         })
       )
 
@@ -397,6 +441,16 @@ const makeSqliteWorkflowEngine = Effect.fnUntraced(function*(cfg: WorkflowEngine
       `DELETE FROM "${clockTable}" WHERE execution_id = ? AND name = ?`,
       [executionId, name]
     )
+
+  // --- Workflow result helpers ------------------------------------------
+
+  const completeResult = (
+    workflow: Workflow.Any,
+    state: ExecState
+  ): Effect.Effect<Option.Option<Workflow.Result<unknown, unknown>>> =>
+    state.status === "complete" && state.completedResult
+      ? Effect.map(decodeResult(workflow, state.completedResult), Option.some)
+      : Effect.succeedNone
 
   // --- Lease / claim ----------------------------------------------------
 
@@ -479,11 +533,12 @@ const makeSqliteWorkflowEngine = Effect.fnUntraced(function*(cfg: WorkflowEngine
         const current = yield* readExec(executionId)
         if (Option.isNone(current) || current.value.status === "complete") return
         const isComplete = result._tag === "Complete"
+        const completedResult = isComplete ? yield* encodeResult(entry.workflow, result) : undefined
         yield* replaceExec(current.value, {
           status: isComplete ? "complete" : current.value.status,
           suspended: result._tag === "Suspended",
           interrupted: instance.interrupted,
-          completedExit: isComplete ? result : undefined,
+          completedResult,
           worker: isComplete ? undefined : current.value.worker,
           leaseExpiresAt: isComplete ? undefined : current.value.leaseExpiresAt
         })
@@ -518,7 +573,8 @@ const makeSqliteWorkflowEngine = Effect.fnUntraced(function*(cfg: WorkflowEngine
       const state = stateOpt.value
       const entry = workflows.get(state.workflowName)
       if (!entry) return
-      yield* drive(executionId, state.payload, state.parent, entry)
+      const payload = yield* decodePayload(entry.workflow, state.payload)
+      yield* drive(executionId, payload, state.parent, entry)
     })
 
   // --- Clock firing -----------------------------------------------------
@@ -528,17 +584,19 @@ const makeSqliteWorkflowEngine = Effect.fnUntraced(function*(cfg: WorkflowEngine
     name: string,
     deferredName: string
   ): Effect.Effect<void> =>
-    sql
-      .withTransaction(Effect.gen(function*() {
-        const inserted = yield* insertDeferred(executionId, deferredName, Exit.void)
-        yield* deleteClock(executionId, name)
-        return inserted
-      }))
-      .pipe(
-        Effect.orDie,
-        Effect.flatMap((inserted) => inserted ? driveById(executionId) : Effect.void),
-        annotate("clockFire", executionId)
-      )
+    Effect
+      .gen(function*() {
+        const encoded = yield* encodeDeferredExit(Exit.void)
+        const inserted = yield* sql
+          .withTransaction(Effect.gen(function*() {
+            const got = yield* createDeferred(executionId, deferredName, encoded)
+            yield* deleteClock(executionId, name)
+            return got
+          }))
+          .pipe(Effect.orDie)
+        if (inserted) yield* driveById(executionId)
+      })
+      .pipe(annotate("clockFire", executionId))
 
   // --- Encoded engine ---------------------------------------------------
 
@@ -558,12 +616,12 @@ const makeSqliteWorkflowEngine = Effect.fnUntraced(function*(cfg: WorkflowEngine
       const initial: ExecState = {
         executionId: options.executionId,
         workflowName: workflow.name,
-        payload: options.payload,
+        payload: yield* encodePayload(workflow, options.payload),
         parent: options.parent?.executionId,
         status: "running",
         suspended: false,
         interrupted: false,
-        completedExit: undefined,
+        completedResult: undefined,
         worker: undefined,
         leaseExpiresAt: undefined,
         etag: randomUUID()
@@ -575,15 +633,17 @@ const makeSqliteWorkflowEngine = Effect.fnUntraced(function*(cfg: WorkflowEngine
       if (local?.fiber) {
         return (yield* Fiber.join(local.fiber)) as any
       }
+      // Foreign-driver fallback: poll the persisted result until completion.
       while (true) {
         const cur = yield* readExec(options.executionId)
-        if (Option.isSome(cur) && cur.value.status === "complete" && cur.value.completedExit) {
-          return cur.value.completedExit as any
+        if (Option.isSome(cur)) {
+          const r = yield* completeResult(workflow, cur.value)
+          if (Option.isSome(r)) return r.value as any
         }
         yield* Effect.sleep(Duration.millis(500))
       }
     }),
-    poll: (_workflow, executionId) =>
+    poll: (workflow, executionId) =>
       Effect.gen(function*() {
         const local = locals.get(executionId)
         if (local?.fiber) {
@@ -593,10 +653,8 @@ const makeSqliteWorkflowEngine = Effect.fnUntraced(function*(cfg: WorkflowEngine
           return Option.some(exitVal.value)
         }
         const state = yield* readExec(executionId)
-        if (Option.isNone(state) || state.value.status !== "complete" || !state.value.completedExit) {
-          return Option.none<Workflow.Result<unknown, unknown>>()
-        }
-        return Option.some(state.value.completedExit)
+        if (Option.isNone(state)) return Option.none<Workflow.Result<unknown, unknown>>()
+        return yield* completeResult(workflow, state.value)
       }),
     interrupt: Effect.fnUntraced(function*(_workflow, executionId) {
       const local = locals.get(executionId)
@@ -623,9 +681,13 @@ const makeSqliteWorkflowEngine = Effect.fnUntraced(function*(cfg: WorkflowEngine
     activityExecute: Effect.fnUntraced(function*(activity, attempt) {
       const instance = yield* WorkflowInstance
       const existing = yield* readActivity(instance.executionId, activity.name, attempt)
-      if (Option.isSome(existing) && existing.value._tag !== "Suspended") {
-        return existing.value
+      if (Option.isSome(existing)) {
+        const prev = yield* decodeActivityResult(existing.value)
+        // A completed activity is replayed from its persisted result; a
+        // suspended one must re-run (it parked on a clock/deferred).
+        if (prev._tag === "Complete") return prev
       }
+
       const activityInstance = WorkflowInstance.initial(instance.workflow, instance.executionId)
       activityInstance.interrupted = instance.interrupted
 
@@ -633,18 +695,32 @@ const makeSqliteWorkflowEngine = Effect.fnUntraced(function*(cfg: WorkflowEngine
         Workflow.intoResult,
         Effect.provideService(WorkflowInstance, activityInstance)
       )
+      const encodedResult = yield* encodeActivityResult(result)
 
-      const persisted = yield* insertActivity(instance.executionId, activity.name, attempt, result)
+      if (Option.isSome(existing)) {
+        // Overwrite the previously persisted *suspended* result.
+        yield* upsertActivity(instance.executionId, activity.name, attempt, encodedResult)
+        return result
+      }
+      // First-writer-wins: if persistence loses the race, use the persisted result.
+      const persisted = yield* createActivity(instance.executionId, activity.name, attempt, encodedResult)
       if (persisted) return result
       const winner = yield* readActivity(instance.executionId, activity.name, attempt)
-      return Option.isSome(winner) ? winner.value : result
+      if (Option.isSome(winner)) {
+        const w = yield* decodeActivityResult(winner.value)
+        if (w._tag === "Complete") return w
+      }
+      return result
     }),
     deferredResult: Effect.fnUntraced(function*(deferred) {
       const instance = yield* WorkflowInstance
-      return yield* readDeferred(instance.executionId, deferred.name)
+      const got = yield* readDeferred(instance.executionId, deferred.name)
+      if (Option.isNone(got)) return Option.none<Exit.Exit<unknown, unknown>>()
+      return Option.some(yield* decodeDeferredExit(got.value))
     }),
     deferredDone: Effect.fnUntraced(function*(options) {
-      const inserted = yield* insertDeferred(options.executionId, options.deferredName, options.exit)
+      const encoded = yield* encodeDeferredExit(options.exit)
+      const inserted = yield* createDeferred(options.executionId, options.deferredName, encoded)
       if (!inserted) return
       yield* driveById(options.executionId)
     }),

--- a/packages/infra/src/WorkflowEngineSqlite.ts
+++ b/packages/infra/src/WorkflowEngineSqlite.ts
@@ -1,0 +1,737 @@
+/**
+ * SQLite backed {@link WorkflowEngine} implementation.
+ *
+ * Persists workflow state across four tables:
+ *   - `workflow_exec`     — one row per execution; tracks status, lease, etag
+ *   - `workflow_activity` — recorded activity exits keyed by (exec, name, attempt)
+ *   - `workflow_deferred` — durable deferred completions keyed by (exec, name)
+ *   - `workflow_clock`    — scheduled clocks with `fire_at`
+ *
+ * Atomicity: multi-statement operations are wrapped in `sql.withTransaction`
+ * (BEGIN/COMMIT) so concurrent writers do not observe partial state.
+ *
+ * Optimistic concurrency:
+ *   - exec state transitions use `UPDATE ... WHERE etag = ? RETURNING etag`;
+ *     a zero-row result is an `OptimisticConcurrencyException`.
+ *   - activity / deferred / clock inserts use `INSERT ... ON CONFLICT DO
+ *     NOTHING RETURNING ...` for first-writer-wins semantics across drivers.
+ *
+ * Crash recovery: each driver holds a time-bound lease on the exec row,
+ * renewed by a heartbeat fiber. A scope-bound recovery poller re-drives any
+ * exec whose lease has lapsed. A clock poller fires due clocks even when
+ * the in-process timer is missing (e.g. after a restart).
+ */
+import * as Effect from "effect-app/Effect"
+import * as Layer from "effect-app/Layer"
+import * as Option from "effect-app/Option"
+import * as Cause from "effect/Cause"
+import * as Duration from "effect/Duration"
+import * as Exit from "effect/Exit"
+import * as Fiber from "effect/Fiber"
+import * as FiberMap from "effect/FiberMap"
+import * as Schedule from "effect/Schedule"
+import type * as Scope from "effect/Scope"
+import { SqlClient } from "effect/unstable/sql"
+import * as Workflow from "effect/unstable/workflow/Workflow"
+import { type Encoded, makeUnsafe, WorkflowEngine, WorkflowInstance } from "effect/unstable/workflow/WorkflowEngine"
+import { randomUUID } from "node:crypto"
+import { OptimisticConcurrencyException } from "./errors.js"
+import { annotateDb } from "./otel.js"
+
+export interface WorkflowEngineSqliteConfig {
+  /** Optional prefix for table names (e.g. `tenant_`). */
+  readonly prefix?: string
+  /** Lease duration before a claim is considered stale. Default 30s. */
+  readonly leaseTtl?: Duration.Duration
+  /** Renewal cadence — should be < leaseTtl. Default 10s. */
+  readonly heartbeatInterval?: Duration.Duration
+  /** Cadence for scanning stale leases. Default 15s. Set to `Duration.zero` to disable. */
+  readonly recoveryInterval?: Duration.Duration
+  /** Cadence for scanning due clocks. Default 5s. Set to `Duration.zero` to disable. */
+  readonly clockPollInterval?: Duration.Duration
+  /** Stable worker identity; defaults to a random UUID per process. */
+  readonly workerId?: string
+}
+
+type ExecStatus = "running" | "complete" | "interrupted"
+
+interface ExecRow {
+  readonly execution_id: string
+  readonly workflow_name: string
+  readonly payload: string
+  readonly parent: string | null
+  readonly status: ExecStatus
+  readonly suspended: number
+  readonly interrupted: number
+  readonly completed_exit: string | null
+  readonly worker: string | null
+  readonly lease_expires_at: number | null
+  readonly etag: string
+}
+
+interface ExecState {
+  readonly executionId: string
+  readonly workflowName: string
+  readonly payload: object
+  readonly parent: string | undefined
+  readonly status: ExecStatus
+  readonly suspended: boolean
+  readonly interrupted: boolean
+  readonly completedExit: Workflow.Result<unknown, unknown> | undefined
+  readonly worker: string | undefined
+  readonly leaseExpiresAt: number | undefined
+  readonly etag: string
+}
+
+// --- JSON revival of Exit / Cause / Workflow.Result ------------------
+// SQLite stores these as JSON, which loses class prototypes. The engine
+// wrapper code in `effect/unstable/workflow/WorkflowEngine` relies on real
+// `Exit` values (e.g. `yield* exit`, `Exit.map`), so we reconstruct them
+// before returning to the wrapper.
+
+const reviveCause = (c: unknown): Cause.Cause<unknown> => {
+  if (Cause.isCause(c)) return c
+  const reasons = (c as { reasons?: ReadonlyArray<any> })?.reasons ?? []
+  if (reasons.length === 0) return Cause.empty
+  return Cause.fromReasons(reasons.map((r) => {
+    if (r._tag === "Fail") return Cause.fail(r.error).reasons[0]!
+    if (r._tag === "Die") return Cause.die(r.defect).reasons[0]!
+    if (r._tag === "Interrupt") return Cause.interrupt(r.fiberId).reasons[0]!
+    return Cause.die(r).reasons[0]!
+  }))
+}
+
+const reviveExit = <A, E>(j: unknown): Exit.Exit<A, E> => {
+  if (Exit.isExit(j)) return j as Exit.Exit<A, E>
+  const v = j as { _tag: string; value?: unknown; cause?: unknown }
+  if (v?._tag === "Success") return Exit.succeed(v.value) as Exit.Exit<A, E>
+  return Exit.failCause(reviveCause(v?.cause)) as Exit.Exit<A, E>
+}
+
+const reviveResult = (
+  r: unknown
+): Workflow.Result<unknown, unknown> => {
+  const v = r as { _tag: string; exit?: unknown }
+  if (v?._tag === "Suspended") return v as unknown as Workflow.Result<unknown, unknown>
+  return { ...(v as object), exit: reviveExit(v.exit) } as unknown as Workflow.Result<unknown, unknown>
+}
+
+const parseExec = (row: ExecRow): ExecState => ({
+  executionId: row.execution_id,
+  workflowName: row.workflow_name,
+  payload: JSON.parse(row.payload) as object,
+  parent: row.parent ?? undefined,
+  status: row.status,
+  suspended: row.suspended !== 0,
+  interrupted: row.interrupted !== 0,
+  completedExit: row.completed_exit
+    ? reviveResult(JSON.parse(row.completed_exit))
+    : undefined,
+  worker: row.worker ?? undefined,
+  leaseExpiresAt: row.lease_expires_at ?? undefined,
+  etag: row.etag
+})
+
+const makeSqliteWorkflowEngine = Effect.fnUntraced(function*(cfg: WorkflowEngineSqliteConfig) {
+  const sql = yield* SqlClient.SqlClient
+  const scope = yield* Effect.scope
+  const prefix = cfg.prefix ?? ""
+  const execTable = `${prefix}workflow_exec`
+  const activityTable = `${prefix}workflow_activity`
+  const deferredTable = `${prefix}workflow_deferred`
+  const clockTable = `${prefix}workflow_clock`
+
+  const workerId = cfg.workerId ?? randomUUID()
+  const leaseTtl = cfg.leaseTtl ?? Duration.seconds(30)
+  const heartbeatInterval = cfg.heartbeatInterval ?? Duration.seconds(10)
+  const recoveryInterval = cfg.recoveryInterval ?? Duration.seconds(15)
+  const clockPollInterval = cfg.clockPollInterval ?? Duration.seconds(5)
+
+  const annotate = (operation: string, executionId?: string) =>
+    annotateDb({
+      operation,
+      system: "sqlite",
+      collection: execTable,
+      entity: "workflow",
+      extra: executionId !== undefined ? { "app.entity.id": executionId } : undefined
+    })
+
+  const exec = (query: string, params: ReadonlyArray<unknown> = []) =>
+    sql.unsafe(query, params as Array<any>).pipe(Effect.orDie)
+
+  // --- Schema -----------------------------------------------------------
+
+  yield* exec(
+    `CREATE TABLE IF NOT EXISTS "${execTable}" (
+       execution_id TEXT PRIMARY KEY,
+       workflow_name TEXT NOT NULL,
+       payload TEXT NOT NULL,
+       parent TEXT,
+       status TEXT NOT NULL,
+       suspended INTEGER NOT NULL DEFAULT 0,
+       interrupted INTEGER NOT NULL DEFAULT 0,
+       completed_exit TEXT,
+       worker TEXT,
+       lease_expires_at INTEGER,
+       etag TEXT NOT NULL
+     )`
+  )
+  yield* exec(
+    `CREATE INDEX IF NOT EXISTS "${execTable}_recovery" ON "${execTable}" (status, lease_expires_at)`
+  )
+  yield* exec(
+    `CREATE TABLE IF NOT EXISTS "${activityTable}" (
+       execution_id TEXT NOT NULL,
+       name TEXT NOT NULL,
+       attempt INTEGER NOT NULL,
+       exit TEXT NOT NULL,
+       PRIMARY KEY (execution_id, name, attempt)
+     )`
+  )
+  yield* exec(
+    `CREATE TABLE IF NOT EXISTS "${deferredTable}" (
+       execution_id TEXT NOT NULL,
+       name TEXT NOT NULL,
+       exit TEXT NOT NULL,
+       PRIMARY KEY (execution_id, name)
+     )`
+  )
+  yield* exec(
+    `CREATE TABLE IF NOT EXISTS "${clockTable}" (
+       execution_id TEXT NOT NULL,
+       name TEXT NOT NULL,
+       workflow_name TEXT NOT NULL,
+       deferred_name TEXT NOT NULL,
+       fire_at INTEGER NOT NULL,
+       PRIMARY KEY (execution_id, name)
+     )`
+  )
+  yield* exec(
+    `CREATE INDEX IF NOT EXISTS "${clockTable}_due" ON "${clockTable}" (fire_at)`
+  )
+
+  // --- In-process bookkeeping -------------------------------------------
+
+  type Registered = {
+    readonly workflow: Workflow.Any
+    readonly execute: (
+      payload: object,
+      executionId: string
+    ) => Effect.Effect<unknown, unknown, WorkflowInstance | WorkflowEngine>
+    readonly scope: Scope.Scope
+  }
+  const workflows = new Map<string, Registered>()
+
+  type LocalExec = {
+    instance: WorkflowInstance["Service"]
+    fiber: Fiber.Fiber<Workflow.Result<unknown, unknown>> | undefined
+    parent: string | undefined
+  }
+  const locals = new Map<string, LocalExec>()
+  const clocks = yield* FiberMap.make<string>()
+
+  // --- Core SQL operations ----------------------------------------------
+
+  const readExec = (executionId: string): Effect.Effect<Option.Option<ExecState>> =>
+    exec(
+      `SELECT * FROM "${execTable}" WHERE execution_id = ?`,
+      [executionId]
+    )
+      .pipe(
+        Effect.map((rows) => {
+          const r = (rows as ReadonlyArray<ExecRow>)[0]
+          return r ? Option.some(parseExec(r)) : Option.none<ExecState>()
+        }),
+        annotate("readExec", executionId)
+      )
+
+  /**
+   * OCC-guarded write. Generates a fresh etag on success; returns
+   * `OptimisticConcurrencyException` when no row matches the prior etag.
+   */
+  const replaceExec = (
+    state: ExecState,
+    next: Partial<Omit<ExecState, "executionId" | "etag" | "workflowName" | "payload" | "parent">>
+  ) =>
+    Effect
+      .gen(function*() {
+        const newEtag = randomUUID()
+        const merged = { ...state, ...next, etag: newEtag }
+        const rows = yield* exec(
+          `UPDATE "${execTable}"
+           SET status = ?,
+               suspended = ?,
+               interrupted = ?,
+               completed_exit = ?,
+               worker = ?,
+               lease_expires_at = ?,
+               etag = ?
+         WHERE execution_id = ? AND etag = ?
+         RETURNING etag`,
+          [
+            merged.status,
+            merged.suspended ? 1 : 0,
+            merged.interrupted ? 1 : 0,
+            merged.completedExit ? JSON.stringify(merged.completedExit) : null,
+            merged.worker ?? null,
+            merged.leaseExpiresAt ?? null,
+            newEtag,
+            state.executionId,
+            state.etag
+          ]
+        )
+        if ((rows as ReadonlyArray<unknown>).length === 0) {
+          return yield* new OptimisticConcurrencyException({
+            type: "workflow.exec",
+            id: state.executionId,
+            code: 412
+          })
+        }
+        return merged
+      })
+      .pipe(annotate("replaceExec", state.executionId))
+
+  const createExec = (initial: ExecState): Effect.Effect<boolean> =>
+    exec(
+      `INSERT INTO "${execTable}"
+         (execution_id, workflow_name, payload, parent, status, suspended, interrupted, etag)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT DO NOTHING
+       RETURNING execution_id`,
+      [
+        initial.executionId,
+        initial.workflowName,
+        JSON.stringify(initial.payload),
+        initial.parent ?? null,
+        initial.status,
+        initial.suspended ? 1 : 0,
+        initial.interrupted ? 1 : 0,
+        initial.etag
+      ]
+    )
+      .pipe(
+        Effect.map((rows) => (rows as ReadonlyArray<unknown>).length > 0),
+        annotate("createExec", initial.executionId)
+      )
+
+  type ActivityResult = Workflow.Result<unknown, unknown>
+
+  const insertActivity = (
+    executionId: string,
+    name: string,
+    attempt: number,
+    result: ActivityResult
+  ): Effect.Effect<boolean> =>
+    exec(
+      `INSERT INTO "${activityTable}" (execution_id, name, attempt, exit)
+       VALUES (?, ?, ?, ?)
+       ON CONFLICT DO NOTHING
+       RETURNING execution_id`,
+      [executionId, name, attempt, JSON.stringify(result)]
+    )
+      .pipe(Effect.map((rows) => (rows as ReadonlyArray<unknown>).length > 0))
+
+  const readActivity = (
+    executionId: string,
+    name: string,
+    attempt: number
+  ): Effect.Effect<Option.Option<ActivityResult>> =>
+    exec(
+      `SELECT exit FROM "${activityTable}" WHERE execution_id = ? AND name = ? AND attempt = ?`,
+      [executionId, name, attempt]
+    )
+      .pipe(
+        Effect.map((rows) => {
+          const r = (rows as ReadonlyArray<{ exit: string }>)[0]
+          return r ? Option.some(reviveResult(JSON.parse(r.exit))) : Option.none()
+        })
+      )
+
+  const insertDeferred = (
+    executionId: string,
+    name: string,
+    exitValue: Exit.Exit<unknown, unknown>
+  ): Effect.Effect<boolean> =>
+    exec(
+      `INSERT INTO "${deferredTable}" (execution_id, name, exit)
+       VALUES (?, ?, ?)
+       ON CONFLICT DO NOTHING
+       RETURNING execution_id`,
+      [executionId, name, JSON.stringify(exitValue)]
+    )
+      .pipe(Effect.map((rows) => (rows as ReadonlyArray<unknown>).length > 0))
+
+  const readDeferred = (
+    executionId: string,
+    name: string
+  ): Effect.Effect<Option.Option<Exit.Exit<unknown, unknown>>> =>
+    exec(
+      `SELECT exit FROM "${deferredTable}" WHERE execution_id = ? AND name = ?`,
+      [executionId, name]
+    )
+      .pipe(
+        Effect.map((rows) => {
+          const r = (rows as ReadonlyArray<{ exit: string }>)[0]
+          return r ? Option.some(reviveExit(JSON.parse(r.exit))) : Option.none()
+        })
+      )
+
+  const insertClock = (
+    executionId: string,
+    name: string,
+    workflowName: string,
+    deferredName: string,
+    fireAt: number
+  ): Effect.Effect<boolean> =>
+    exec(
+      `INSERT INTO "${clockTable}" (execution_id, name, workflow_name, deferred_name, fire_at)
+       VALUES (?, ?, ?, ?, ?)
+       ON CONFLICT DO NOTHING
+       RETURNING execution_id`,
+      [executionId, name, workflowName, deferredName, fireAt]
+    )
+      .pipe(Effect.map((rows) => (rows as ReadonlyArray<unknown>).length > 0))
+
+  const deleteClock = (executionId: string, name: string) =>
+    exec(
+      `DELETE FROM "${clockTable}" WHERE execution_id = ? AND name = ?`,
+      [executionId, name]
+    )
+
+  // --- Lease / claim ----------------------------------------------------
+
+  const leaseActive = (state: ExecState, now: number): boolean =>
+    state.worker !== undefined
+    && state.worker !== workerId
+    && state.leaseExpiresAt !== undefined
+    && state.leaseExpiresAt > now
+
+  const tryClaim = (state: ExecState): Effect.Effect<Option.Option<ExecState>> =>
+    Effect.gen(function*() {
+      const now = Date.now()
+      if (leaseActive(state, now)) return Option.none<ExecState>()
+      return yield* replaceExec(state, {
+        worker: workerId,
+        leaseExpiresAt: now + Duration.toMillis(leaseTtl)
+      })
+        .pipe(
+          Effect.map(Option.some),
+          Effect.catchTag("OptimisticConcurrencyException", () => Effect.succeed(Option.none<ExecState>()))
+        )
+    })
+
+  const heartbeat = (executionId: string): Effect.Effect<void> =>
+    Effect.gen(function*() {
+      while (true) {
+        yield* Effect.sleep(heartbeatInterval)
+        const local = locals.get(executionId)
+        const polled = local?.fiber?.pollUnsafe()
+        if (!local?.fiber || polled) return
+        const cur = yield* readExec(executionId).pipe(
+          Effect.catchCause(() => Effect.succeed(Option.none<ExecState>()))
+        )
+        if (Option.isNone(cur)) continue
+        const state = cur.value
+        if (state.status === "complete" || state.worker !== workerId) return
+        yield* replaceExec(state, {
+          leaseExpiresAt: Date.now() + Duration.toMillis(leaseTtl)
+        })
+          .pipe(
+            Effect.catchTag("OptimisticConcurrencyException", () => Effect.void),
+            Effect.catchCause(() => Effect.void)
+          )
+      }
+    })
+
+  // --- Drive logic ------------------------------------------------------
+
+  const drive = (
+    executionId: string,
+    payload: object,
+    parent: string | undefined,
+    entry: Registered
+  ): Effect.Effect<void> =>
+    Effect.gen(function*() {
+      let local = locals.get(executionId)
+      if (local?.fiber) {
+        const polled = local.fiber.pollUnsafe()
+        const stillRunning = !polled
+        const completedNotResume = polled && polled._tag === "Success" && polled.value._tag === "Complete"
+        if (stillRunning || completedNotResume) return
+      }
+
+      const stateOpt = yield* readExec(executionId)
+      if (Option.isNone(stateOpt) || stateOpt.value.status === "complete") return
+
+      const claimed = yield* tryClaim(stateOpt.value)
+      const state = Option.isSome(claimed) ? claimed.value : stateOpt.value
+
+      const instance = WorkflowInstance.initial(entry.workflow, executionId)
+      instance.interrupted = state.interrupted
+      if (!local) {
+        local = { instance, fiber: undefined, parent }
+        locals.set(executionId, local)
+      } else {
+        local.instance = instance
+      }
+
+      const onComplete = Effect.fnUntraced(function*(result: Workflow.Result<unknown, unknown>) {
+        const current = yield* readExec(executionId)
+        if (Option.isNone(current) || current.value.status === "complete") return
+        const isComplete = result._tag === "Complete"
+        yield* replaceExec(current.value, {
+          status: isComplete ? "complete" : current.value.status,
+          suspended: result._tag === "Suspended",
+          interrupted: instance.interrupted,
+          completedExit: isComplete ? result : undefined,
+          worker: isComplete ? undefined : current.value.worker,
+          leaseExpiresAt: isComplete ? undefined : current.value.leaseExpiresAt
+        })
+          .pipe(Effect.catchTag("OptimisticConcurrencyException", () => Effect.void))
+        if (parent && isComplete) {
+          yield* Effect.forkIn(driveById(parent), scope)
+        }
+      })
+
+      local.fiber = yield* entry.execute(payload, executionId).pipe(
+        Effect.onExit(() => {
+          if (!instance.interrupted) return Effect.void
+          instance.suspended = false
+          return Effect.withFiber((fiber) => Effect.interruptible(Fiber.interrupt(fiber)))
+        }),
+        Workflow.intoResult,
+        Effect.provideService(WorkflowInstance, instance),
+        Effect.provideService(WorkflowEngine, engine),
+        Effect.tap(onComplete),
+        Effect.forkIn(entry.scope)
+      )
+
+      if (Option.isSome(claimed)) {
+        yield* Effect.forkIn(heartbeat(executionId), scope)
+      }
+    })
+
+  const driveById = (executionId: string): Effect.Effect<void> =>
+    Effect.gen(function*() {
+      const stateOpt = yield* readExec(executionId)
+      if (Option.isNone(stateOpt)) return
+      const state = stateOpt.value
+      const entry = workflows.get(state.workflowName)
+      if (!entry) return
+      yield* drive(executionId, state.payload, state.parent, entry)
+    })
+
+  // --- Clock firing -----------------------------------------------------
+
+  const fireClock = (
+    executionId: string,
+    name: string,
+    deferredName: string
+  ): Effect.Effect<void> =>
+    sql
+      .withTransaction(Effect.gen(function*() {
+        const inserted = yield* insertDeferred(executionId, deferredName, Exit.void)
+        yield* deleteClock(executionId, name)
+        return inserted
+      }))
+      .pipe(
+        Effect.orDie,
+        Effect.flatMap((inserted) => inserted ? driveById(executionId) : Effect.void),
+        annotate("clockFire", executionId)
+      )
+
+  // --- Encoded engine ---------------------------------------------------
+
+  const encoded: Encoded = {
+    register: Effect.fnUntraced(function*(workflow, execute) {
+      workflows.set(workflow.name, {
+        workflow,
+        execute,
+        scope: yield* Effect.scope
+      })
+    }),
+    execute: Effect.fnUntraced(function*(workflow, options) {
+      const entry = workflows.get(workflow.name)
+      if (!entry) {
+        return yield* Effect.orDie(Effect.fail(`Workflow ${workflow.name} is not registered`))
+      }
+      const initial: ExecState = {
+        executionId: options.executionId,
+        workflowName: workflow.name,
+        payload: options.payload,
+        parent: options.parent?.executionId,
+        status: "running",
+        suspended: false,
+        interrupted: false,
+        completedExit: undefined,
+        worker: undefined,
+        leaseExpiresAt: undefined,
+        etag: randomUUID()
+      }
+      yield* createExec(initial)
+      yield* drive(options.executionId, options.payload, options.parent?.executionId, entry)
+      if (options.discard) return undefined as any
+      const local = locals.get(options.executionId)
+      if (local?.fiber) {
+        return (yield* Fiber.join(local.fiber)) as any
+      }
+      while (true) {
+        const cur = yield* readExec(options.executionId)
+        if (Option.isSome(cur) && cur.value.status === "complete" && cur.value.completedExit) {
+          return cur.value.completedExit as any
+        }
+        yield* Effect.sleep(Duration.millis(500))
+      }
+    }),
+    poll: (_workflow, executionId) =>
+      Effect.gen(function*() {
+        const local = locals.get(executionId)
+        if (local?.fiber) {
+          const exitVal = local.fiber.pollUnsafe()
+          if (!exitVal) return Option.none<Workflow.Result<unknown, unknown>>()
+          if (exitVal._tag !== "Success") return yield* Effect.die(exitVal.cause)
+          return Option.some(exitVal.value)
+        }
+        const state = yield* readExec(executionId)
+        if (Option.isNone(state) || state.value.status !== "complete" || !state.value.completedExit) {
+          return Option.none<Workflow.Result<unknown, unknown>>()
+        }
+        return Option.some(state.value.completedExit)
+      }),
+    interrupt: Effect.fnUntraced(function*(_workflow, executionId) {
+      const local = locals.get(executionId)
+      if (local) local.instance.interrupted = true
+      const current = yield* readExec(executionId)
+      if (Option.isNone(current) || current.value.status === "complete") return
+      yield* replaceExec(current.value, { interrupted: true }).pipe(
+        Effect.catchTag("OptimisticConcurrencyException", () => Effect.void)
+      )
+      yield* driveById(executionId)
+    }),
+    interruptUnsafe: Effect.fnUntraced(function*(_workflow, executionId) {
+      const local = locals.get(executionId)
+      if (local) local.instance.interrupted = true
+      const current = yield* readExec(executionId)
+      if (Option.isSome(current) && current.value.status !== "complete") {
+        yield* replaceExec(current.value, { interrupted: true }).pipe(
+          Effect.catchTag("OptimisticConcurrencyException", () => Effect.void)
+        )
+      }
+      if (local?.fiber) yield* Fiber.interrupt(local.fiber)
+    }),
+    resume: (_workflow, executionId) => driveById(executionId),
+    activityExecute: Effect.fnUntraced(function*(activity, attempt) {
+      const instance = yield* WorkflowInstance
+      const existing = yield* readActivity(instance.executionId, activity.name, attempt)
+      if (Option.isSome(existing) && existing.value._tag !== "Suspended") {
+        return existing.value
+      }
+      const activityInstance = WorkflowInstance.initial(instance.workflow, instance.executionId)
+      activityInstance.interrupted = instance.interrupted
+
+      const result = yield* activity.executeEncoded.pipe(
+        Workflow.intoResult,
+        Effect.provideService(WorkflowInstance, activityInstance)
+      )
+
+      const persisted = yield* insertActivity(instance.executionId, activity.name, attempt, result)
+      if (persisted) return result
+      const winner = yield* readActivity(instance.executionId, activity.name, attempt)
+      return Option.isSome(winner) ? winner.value : result
+    }),
+    deferredResult: Effect.fnUntraced(function*(deferred) {
+      const instance = yield* WorkflowInstance
+      return yield* readDeferred(instance.executionId, deferred.name)
+    }),
+    deferredDone: Effect.fnUntraced(function*(options) {
+      const inserted = yield* insertDeferred(options.executionId, options.deferredName, options.exit)
+      if (!inserted) return
+      yield* driveById(options.executionId)
+    }),
+    scheduleClock: (workflow, options) => {
+      const fireAt = Date.now() + Duration.toMillis(options.clock.duration)
+      return Effect.gen(function*() {
+        yield* insertClock(
+          options.executionId,
+          options.clock.name,
+          workflow.name,
+          options.clock.deferred.name,
+          fireAt
+        )
+        yield* fireClock(options.executionId, options.clock.name, options.clock.deferred.name).pipe(
+          Effect.delay(options.clock.duration),
+          FiberMap.run(clocks, `${options.executionId}/${options.clock.name}`, { onlyIfMissing: true }),
+          Effect.asVoid
+        )
+      })
+    }
+  }
+
+  const engine = makeUnsafe(encoded)
+
+  // --- Recovery poller --------------------------------------------------
+
+  if (Duration.toMillis(recoveryInterval) > 0) {
+    const recoverStep = Effect
+      .gen(function*() {
+        const rows = yield* exec(
+          `SELECT execution_id, workflow_name FROM "${execTable}"
+         WHERE status = 'running' AND (lease_expires_at IS NULL OR lease_expires_at <= ?)
+         LIMIT 100`,
+          [Date.now()]
+        )
+        for (const row of rows as ReadonlyArray<{ execution_id: string; workflow_name: string }>) {
+          if (!workflows.has(row.workflow_name)) continue
+          const local = locals.get(row.execution_id)
+          if (local?.fiber && !local.fiber.pollUnsafe()) continue
+          yield* Effect.forkIn(driveById(row.execution_id), scope)
+        }
+      })
+      .pipe(annotate("recoveryScan"), Effect.catchCause(() => Effect.void))
+
+    yield* recoverStep.pipe(
+      Effect.repeat(Schedule.spaced(recoveryInterval)),
+      Effect.forkIn(scope)
+    )
+  }
+
+  // --- Clock poller -----------------------------------------------------
+
+  if (Duration.toMillis(clockPollInterval) > 0) {
+    const clockStep = Effect
+      .gen(function*() {
+        const rows = yield* exec(
+          `SELECT execution_id, name, deferred_name FROM "${clockTable}"
+         WHERE fire_at <= ?
+         LIMIT 100`,
+          [Date.now()]
+        )
+        for (
+          const row of rows as ReadonlyArray<{
+            execution_id: string
+            name: string
+            deferred_name: string
+          }>
+        ) {
+          yield* Effect.forkIn(fireClock(row.execution_id, row.name, row.deferred_name), scope)
+        }
+      })
+      .pipe(annotate("clockScan"), Effect.catchCause(() => Effect.void))
+
+    yield* clockStep.pipe(
+      Effect.repeat(Schedule.spaced(clockPollInterval)),
+      Effect.forkIn(scope)
+    )
+  }
+
+  return engine
+})
+
+/**
+ * SQLite backed `WorkflowEngine` layer. Requires an ambient `SqlClient`
+ * (`@effect/sql-sqlite-node` or a compatible client).
+ */
+export const layerSqlite = (
+  cfg: WorkflowEngineSqliteConfig = {}
+): Layer.Layer<WorkflowEngine, never, SqlClient.SqlClient> =>
+  Layer.effect(WorkflowEngine)(makeSqliteWorkflowEngine(cfg))

--- a/packages/infra/test/workflow-engine-sqlite.test.ts
+++ b/packages/infra/test/workflow-engine-sqlite.test.ts
@@ -1,0 +1,286 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { SqliteClient } from "@effect/sql-sqlite-node"
+import { assert, describe, it } from "@effect/vitest"
+import * as Context from "effect-app/Context"
+import * as Effect from "effect-app/Effect"
+import * as Layer from "effect-app/Layer"
+import * as Option from "effect-app/Option"
+import * as Duration from "effect/Duration"
+import * as Exit from "effect/Exit"
+import * as Schema from "effect/Schema"
+import { SqlClient } from "effect/unstable/sql"
+import { Activity, DurableDeferred, Workflow } from "effect/unstable/workflow"
+import { layerSqlite } from "../src/WorkflowEngineSqlite.js"
+
+// --- Shared mutable counter service -----------------------------------
+
+class CounterRef extends Context.Service<CounterRef, { count: number }>()("CounterRef") {
+  static readonly layer = Layer.effect(CounterRef, Effect.sync(() => ({ count: 0 })))
+}
+
+// --- Workflow definitions --------------------------------------------
+
+const Increment = Workflow.make({
+  name: "Sqlite/Increment",
+  payload: { value: Schema.Number },
+  success: Schema.Number,
+  idempotencyKey: ({ value }) => `inc-${value}`
+})
+
+const IncrementHandler = Increment.toLayer(Effect.fn(function*({ value }) {
+  const counter = yield* CounterRef
+  yield* Activity.make({
+    name: "Bump",
+    success: Schema.Number,
+    execute: Effect.sync(() => {
+      counter.count++
+      return counter.count
+    })
+  })
+  return value + 1
+}))
+
+const TickHandler = Increment.toLayer(({ value }) => Effect.succeed(value + 1))
+
+const EmailReceived = DurableDeferred.make("EmailReceived", { success: Schema.String })
+
+const AwaitEmail = Workflow.make({
+  name: "Sqlite/AwaitEmail",
+  payload: { id: Schema.String },
+  success: Schema.String,
+  idempotencyKey: ({ id }) => `email-${id}`
+})
+
+const AwaitEmailHandler = AwaitEmail.toLayer(Effect.fn(function*() {
+  return yield* DurableDeferred.await(EmailReceived)
+}))
+
+// --- Layer wiring ----------------------------------------------------
+
+type TestOpts = {
+  readonly recoveryInterval?: Duration.Duration
+  readonly clockPollInterval?: Duration.Duration
+}
+
+const makeBase = (opts?: TestOpts) => {
+  const Sqlite = SqliteClient.layer({ filename: ":memory:" })
+  const Engine = layerSqlite({
+    recoveryInterval: opts?.recoveryInterval ?? Duration.millis(100),
+    clockPollInterval: opts?.clockPollInterval ?? Duration.millis(100)
+  })
+    .pipe(Layer.provide(Sqlite))
+  return { Sqlite, Engine }
+}
+
+const incrementLayer = (opts?: TestOpts) => {
+  const { Sqlite, Engine } = makeBase(opts)
+  return IncrementHandler.pipe(
+    Layer.provideMerge(CounterRef.layer),
+    Layer.provideMerge(Engine),
+    Layer.provideMerge(Sqlite)
+  )
+}
+
+const tickLayer = (opts?: TestOpts) => {
+  const { Sqlite, Engine } = makeBase(opts)
+  return TickHandler.pipe(Layer.provideMerge(Engine), Layer.provideMerge(Sqlite))
+}
+
+const awaitEmailLayer = (opts?: TestOpts) => {
+  const { Sqlite, Engine } = makeBase(opts)
+  return AwaitEmailHandler.pipe(Layer.provideMerge(Engine), Layer.provideMerge(Sqlite))
+}
+
+// --- Tests ------------------------------------------------------------
+
+describe("WorkflowEngine (SQLite)", () => {
+  it.live("executes a workflow and persists completion", () =>
+    Effect
+      .gen(function*() {
+        const executionId = yield* Increment.execute({ value: 10 }, { discard: true })
+        const result = yield* Increment.execute({ value: 10 })
+        const polled = yield* Increment.poll(executionId)
+
+        assert.strictEqual(result, 11)
+        assert(
+          Option.isSome(polled)
+            && polled.value._tag === "Complete"
+            && Exit.isSuccess(polled.value.exit)
+        )
+        assert.strictEqual(polled.value.exit.value, 11)
+      })
+      .pipe(Effect.provide(incrementLayer())))
+
+  it.live("re-executing the same id is idempotent (activity runs once)", () =>
+    Effect
+      .gen(function*() {
+        const counter = yield* CounterRef
+        yield* Increment.execute({ value: 1 })
+        yield* Increment.execute({ value: 1 })
+        yield* Increment.execute({ value: 1 })
+        assert.strictEqual(counter.count, 1)
+      })
+      .pipe(Effect.provide(incrementLayer())))
+
+  it.live("persists activity results across replay", () =>
+    Effect
+      .gen(function*() {
+        const sql = yield* SqlClient.SqlClient
+        yield* Increment.execute({ value: 2 })
+        const rows = yield* sql
+          .unsafe(
+            `SELECT execution_id, name, attempt FROM workflow_activity`
+          )
+          .pipe(Effect.orDie)
+        assert.strictEqual(rows.length, 1)
+        assert.strictEqual((rows[0] as any).name, "Bump")
+      })
+      .pipe(Effect.provide(incrementLayer())))
+
+  it.live("durable deferred completion resumes a suspended workflow", () =>
+    Effect
+      .gen(function*() {
+        const completion = Effect.gen(function*() {
+          yield* Effect.sleep(Duration.millis(50))
+          const token = yield* DurableDeferred.tokenFromPayload(EmailReceived, {
+            workflow: AwaitEmail,
+            payload: { id: "x" }
+          })
+          yield* DurableDeferred.done(EmailReceived, { token, exit: Exit.succeed("delivered") })
+        })
+        const [result] = yield* Effect.all(
+          [AwaitEmail.execute({ id: "x" }), completion],
+          { concurrency: "unbounded" }
+        )
+        assert.strictEqual(result, "delivered")
+      })
+      .pipe(Effect.provide(awaitEmailLayer())))
+
+  it.live("interrupt marks the execution row", () =>
+    Effect
+      .gen(function*() {
+        const sql = yield* SqlClient.SqlClient
+        const executionId = yield* AwaitEmail.executionId({ id: "i" })
+        // Start the workflow as discard (does not block) so it suspends in the
+        // background; then mark it interrupted.
+        yield* AwaitEmail.execute({ id: "i" }, { discard: true })
+        yield* Effect.sleep(Duration.millis(50))
+        yield* AwaitEmail.interrupt(executionId)
+        yield* Effect.sleep(Duration.millis(50))
+        const rows = yield* sql
+          .unsafe(
+            `SELECT interrupted FROM workflow_exec WHERE execution_id = ?`,
+            [executionId] as any
+          )
+          .pipe(Effect.orDie)
+        assert.strictEqual((rows[0] as any).interrupted, 1)
+      })
+      .pipe(Effect.provide(awaitEmailLayer())))
+
+  it.live("clock poller fires past-due clocks", () =>
+    Effect
+      .gen(function*() {
+        const sql = yield* SqlClient.SqlClient
+        yield* sql
+          .unsafe(
+            `INSERT INTO workflow_exec (execution_id, workflow_name, payload, status, suspended, interrupted, etag)
+         VALUES ('exec-clock', 'Sqlite/AwaitEmail', '{}', 'running', 0, 0, 'e1')`
+          )
+          .pipe(Effect.orDie)
+        yield* sql
+          .unsafe(
+            `INSERT INTO workflow_clock (execution_id, name, workflow_name, deferred_name, fire_at)
+         VALUES ('exec-clock', 'wake', 'Sqlite/AwaitEmail', 'EmailReceived', ?)`,
+            [Date.now() - 1000] as any
+          )
+          .pipe(Effect.orDie)
+
+        yield* Effect.sleep(Duration.millis(400))
+
+        const deferred = yield* sql
+          .unsafe(
+            `SELECT exit FROM workflow_deferred WHERE execution_id = 'exec-clock' AND name = 'EmailReceived'`
+          )
+          .pipe(Effect.orDie)
+        const clockGone = yield* sql
+          .unsafe(
+            `SELECT execution_id FROM workflow_clock WHERE execution_id = 'exec-clock' AND name = 'wake'`
+          )
+          .pipe(Effect.orDie)
+        assert.strictEqual(deferred.length, 1)
+        assert.strictEqual(clockGone.length, 0)
+      })
+      .pipe(Effect.provide(awaitEmailLayer())))
+
+  it.live("recovery poller drives execs with stale leases", () =>
+    Effect
+      .gen(function*() {
+        const sql = yield* SqlClient.SqlClient
+        yield* sql
+          .unsafe(
+            `INSERT INTO workflow_exec (execution_id, workflow_name, payload, status, suspended, interrupted, lease_expires_at, etag)
+         VALUES ('recover-1', 'Sqlite/Increment', '{"value":99}', 'running', 0, 0, 0, 'e0')`
+          )
+          .pipe(Effect.orDie)
+
+        yield* Effect.sleep(Duration.millis(500))
+
+        const rows = yield* sql
+          .unsafe(
+            `SELECT status, completed_exit FROM workflow_exec WHERE execution_id = 'recover-1'`
+          )
+          .pipe(Effect.orDie)
+        assert.strictEqual((rows[0] as any).status, "complete")
+        const completedExit = JSON.parse((rows[0] as any).completed_exit) as { _tag: string }
+        assert.strictEqual(completedExit._tag, "Complete")
+      })
+      .pipe(Effect.provide(tickLayer())))
+
+  it.live("activity dedup: a pre-existing persisted exit wins over a fresh run", () =>
+    Effect
+      .gen(function*() {
+        const sql = yield* SqlClient.SqlClient
+        const counter = yield* CounterRef
+        const executionId = yield* Increment.executionId({ value: 7 })
+        yield* sql
+          .unsafe(
+            `INSERT INTO workflow_exec (execution_id, workflow_name, payload, status, suspended, interrupted, etag)
+         VALUES (?, 'Sqlite/Increment', '{"value":7}', 'running', 0, 0, 'e0')`,
+            [executionId] as any
+          )
+          .pipe(Effect.orDie)
+        const fakeResult = { _tag: "Complete", exit: Exit.succeed(999) }
+        yield* sql
+          .unsafe(
+            `INSERT INTO workflow_activity (execution_id, name, attempt, exit)
+         VALUES (?, 'Bump', 1, ?)`,
+            [executionId, JSON.stringify(fakeResult)] as any
+          )
+          .pipe(Effect.orDie)
+
+        const result = yield* Increment.execute({ value: 7 })
+        assert.strictEqual(result, 8)
+        assert.strictEqual(counter.count, 0)
+      })
+      .pipe(Effect.provide(incrementLayer())))
+
+  it.live("deferredDone is idempotent (first-writer-wins)", () =>
+    Effect
+      .gen(function*() {
+        const completion = Effect.gen(function*() {
+          yield* Effect.sleep(Duration.millis(50))
+          const token = yield* DurableDeferred.tokenFromPayload(EmailReceived, {
+            workflow: AwaitEmail,
+            payload: { id: "dup" }
+          })
+          yield* DurableDeferred.done(EmailReceived, { token, exit: Exit.succeed("first") })
+          yield* DurableDeferred.done(EmailReceived, { token, exit: Exit.succeed("second") })
+        })
+        const [result] = yield* Effect.all(
+          [AwaitEmail.execute({ id: "dup" }), completion],
+          { concurrency: "unbounded" }
+        )
+        assert.strictEqual(result, "first")
+      })
+      .pipe(Effect.provide(awaitEmailLayer())))
+})

--- a/packages/infra/test/workflow-engine-sqlite.test.ts
+++ b/packages/infra/test/workflow-engine-sqlite.test.ts
@@ -5,6 +5,7 @@ import * as Context from "effect-app/Context"
 import * as Effect from "effect-app/Effect"
 import * as Layer from "effect-app/Layer"
 import * as Option from "effect-app/Option"
+import * as S from "effect-app/Schema"
 import * as Duration from "effect/Duration"
 import * as Exit from "effect/Exit"
 import * as Schema from "effect/Schema"
@@ -54,6 +55,12 @@ const AwaitEmail = Workflow.make({
 const AwaitEmailHandler = AwaitEmail.toLayer(Effect.fn(function*() {
   return yield* DurableDeferred.await(EmailReceived)
 }))
+
+// Reproduces the adapter's opaque activity-result codec so tests can seed
+// schema-encoded values into the activity table directly.
+const ActivityResultCodec = S.fromJsonString(
+  S.toCodecJson(Workflow.Result({ success: S.Union([S.Any, S.Void]), error: S.Union([S.Any, S.Void]) }))
+)
 
 // --- Layer wiring ----------------------------------------------------
 
@@ -129,11 +136,14 @@ describe("WorkflowEngine (SQLite)", () => {
         yield* Increment.execute({ value: 2 })
         const rows = yield* sql
           .unsafe(
-            `SELECT execution_id, name, attempt FROM workflow_activity`
+            `SELECT execution_id, name, attempt, result FROM workflow_activity`
           )
           .pipe(Effect.orDie)
         assert.strictEqual(rows.length, 1)
         assert.strictEqual((rows[0] as any).name, "Bump")
+        // Stored value is schema-encoded JSON, not a raw runtime object.
+        const decoded = S.decodeSync(ActivityResultCodec)((rows[0] as any).result)
+        assert.strictEqual(decoded._tag, "Complete")
       })
       .pipe(Effect.provide(incrementLayer())))
 
@@ -184,7 +194,7 @@ describe("WorkflowEngine (SQLite)", () => {
         yield* sql
           .unsafe(
             `INSERT INTO workflow_exec (execution_id, workflow_name, payload, status, suspended, interrupted, etag)
-         VALUES ('exec-clock', 'Sqlite/AwaitEmail', '{}', 'running', 0, 0, 'e1')`
+         VALUES ('exec-clock', 'Sqlite/AwaitEmail', '{"id":"x"}', 'running', 0, 0, 'e1')`
           )
           .pipe(Effect.orDie)
         yield* sql
@@ -227,16 +237,16 @@ describe("WorkflowEngine (SQLite)", () => {
 
         const rows = yield* sql
           .unsafe(
-            `SELECT status, completed_exit FROM workflow_exec WHERE execution_id = 'recover-1'`
+            `SELECT status, completed_result FROM workflow_exec WHERE execution_id = 'recover-1'`
           )
           .pipe(Effect.orDie)
         assert.strictEqual((rows[0] as any).status, "complete")
-        const completedExit = JSON.parse((rows[0] as any).completed_exit) as { _tag: string }
-        assert.strictEqual(completedExit._tag, "Complete")
+        const completedResult = JSON.parse((rows[0] as any).completed_result) as { _tag: string }
+        assert.strictEqual(completedResult._tag, "Complete")
       })
       .pipe(Effect.provide(tickLayer())))
 
-  it.live("activity dedup: a pre-existing persisted exit wins over a fresh run", () =>
+  it.live("activity dedup: a pre-existing persisted result wins over a fresh run", () =>
     Effect
       .gen(function*() {
         const sql = yield* SqlClient.SqlClient
@@ -249,17 +259,20 @@ describe("WorkflowEngine (SQLite)", () => {
             [executionId] as any
           )
           .pipe(Effect.orDie)
-        const fakeResult = { _tag: "Complete", exit: Exit.succeed(999) }
+        const seeded = S.encodeSync(ActivityResultCodec)(
+          new Workflow.Complete({ exit: Exit.succeed(999) })
+        )
         yield* sql
           .unsafe(
-            `INSERT INTO workflow_activity (execution_id, name, attempt, exit)
+            `INSERT INTO workflow_activity (execution_id, name, attempt, result)
          VALUES (?, 'Bump', 1, ?)`,
-            [executionId, JSON.stringify(fakeResult)] as any
+            [executionId, seeded] as any
           )
           .pipe(Effect.orDie)
 
         const result = yield* Increment.execute({ value: 7 })
         assert.strictEqual(result, 8)
+        // Bump's user effect must NOT have run — counter stays at 0.
         assert.strictEqual(counter.count, 0)
       })
       .pipe(Effect.provide(incrementLayer())))


### PR DESCRIPTION
## Summary
- New \`layerSqlite\` in \`packages/infra/src/WorkflowEngineSqlite.ts\` backing the unstable \`effect/unstable/workflow\` \`WorkflowEngine\` via \`SqlClient\`.
- Four tables (\`workflow_exec\`, \`workflow_activity\`, \`workflow_deferred\`, \`workflow_clock\`) with composite keys per execution.
- Atomicity through \`sql.withTransaction\`; optimistic concurrency via \`UPDATE ... WHERE etag = ? RETURNING etag\`; first-writer-wins via \`INSERT ... ON CONFLICT DO NOTHING RETURNING\`.
- Time-bound lease + heartbeat + scope-bound recovery poller for crashed-driver takeover.
- Cross-partition clock poller fires due clocks even when the in-process timer is missing (post-restart).
- JSON revival of \`Exit\` / \`Cause\` / \`Workflow.Result\` so persisted values regain class prototypes the engine wrapper relies on (\`yield* exit\`, \`Exit.map\`).

## Test plan
9 cases, in-memory sqlite, all green (\`pnpm vitest run workflow-engine-sqlite\`):
- [x] executes a workflow and persists completion
- [x] idempotent re-execution (activity runs once)
- [x] persists activity results across replay
- [x] durable deferred completion resumes a suspended workflow
- [x] interrupt marks the execution row
- [x] clock poller fires past-due clocks
- [x] recovery poller drives execs with stale leases
- [x] activity dedup: pre-existing persisted exit wins
- [x] deferredDone is idempotent (first-writer-wins)

## Notes
- Tests use \`it.live\` because \`@effect/vitest\`'s default \`it.effect\` injects \`TestClock\`, which doesn't advance for real-time pollers/sleeps.
- Companion to PR #770 (Cosmos DB adapter); same engine semantics, SQL substrate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)