### PR TITLE
Derive query invalidation from repository dependencies

### DIFF
--- a/.changeset/repo-derived-query-invalidation.md
+++ b/.changeset/repo-derived-query-invalidation.md
@@ -1,0 +1,7 @@
+---
+"effect-app": minor
+"@effect-app/infra": minor
+"@effect-app/vue": minor
+---
+
+Derive query invalidation from repository read/write dependencies and propagate dependency metadata through RPC clients.

--- a/packages/effect-app/src/DataDependencies.ts
+++ b/packages/effect-app/src/DataDependencies.ts
@@ -1,0 +1,72 @@
+import * as Ref from "effect/Ref"
+import * as Context from "./Context.ts"
+import * as Effect from "./Effect.ts"
+import * as S from "./Schema.ts"
+
+export const DataDependency = S.Struct({
+  type: S.Literals(["repo", "signal"]),
+  name: S.String
+})
+export type DataDependency = S.Schema.Type<typeof DataDependency>
+
+export const DataDependencies = S.Array(DataDependency)
+export type DataDependencies = S.Schema.Type<typeof DataDependencies>
+
+export const DataDependencySet = S.Struct({
+  reads: DataDependencies,
+  writes: DataDependencies
+})
+export type DataDependencySet = S.Schema.Type<typeof DataDependencySet>
+
+export interface DataDependencyRecorderService {
+  readonly read: (dependency: DataDependency) => Effect.Effect<void>
+  readonly write: (dependency: DataDependency) => Effect.Effect<void>
+  readonly get: Effect.Effect<DataDependencySet>
+  readonly drainWrites: Effect.Effect<DataDependencies>
+}
+
+const containsDependency = (dependencies: ReadonlyArray<DataDependency>, dependency: DataDependency) =>
+  dependencies.some((_) => _.type === dependency.type && _.name === dependency.name)
+
+const appendDependency = (dependency: DataDependency) => (dependencies: DataDependencies): DataDependencies =>
+  containsDependency(dependencies, dependency) ? dependencies : [...dependencies, dependency]
+
+export const DataDependencyRecorder = Context.Reference<DataDependencyRecorderService>(
+  "effect-app/DataDependencyRecorder",
+  {
+    defaultValue: () => ({
+      read: (_dependency) => Effect.void,
+      write: (_dependency) => Effect.void,
+      get: Effect.succeed({ reads: [], writes: [] }),
+      drainWrites: Effect.succeed([])
+    })
+  }
+)
+export type DataDependencyRecorder = typeof DataDependencyRecorder
+
+export const makeDataDependencyRecorder = (
+  readsRef: Ref.Ref<DataDependencies>,
+  writesRef: Ref.Ref<DataDependencies>
+): DataDependencyRecorderService => ({
+  read: (dependency) => Ref.update(readsRef, appendDependency(dependency)),
+  write: (dependency) => Ref.update(writesRef, appendDependency(dependency)),
+  get: Effect.all({
+    reads: Ref.get(readsRef),
+    writes: Ref.get(writesRef)
+  }),
+  drainWrites: Ref.getAndSet(writesRef, [])
+})
+
+export const repo = (name: string): DataDependency => ({ type: "repo", name })
+export const signal = (name: string): DataDependency => ({ type: "signal", name })
+
+export const QueryReadDependenciesMetaKey = "effect-app.query.readDependencies"
+
+export const read = (dependency: DataDependency) => DataDependencyRecorder.use((_) => _.read(dependency))
+
+export const write = (dependency: DataDependency) => DataDependencyRecorder.use((_) => _.write(dependency))
+
+export const intersects = (
+  a: ReadonlyArray<DataDependency>,
+  b: ReadonlyArray<DataDependency>
+) => a.some((dependency) => containsDependency(b, dependency))

--- a/packages/effect-app/src/Model/Repository/internal/internal.ts
+++ b/packages/effect-app/src/Model/Repository/internal/internal.ts
@@ -16,6 +16,7 @@ import { toNonEmptyArray } from "../../../Array.ts"
 import * as Chunk from "../../../Chunk.ts"
 import { NotFoundError } from "../../../client/errors.ts"
 import * as Context from "../../../Context.ts"
+import * as DataDependencies from "../../../DataDependencies.ts"
 import * as Effect from "../../../Effect.ts"
 import { flatMapOption } from "../../../Effect.ts"
 import * as Option from "../../../Option.ts"
@@ -100,6 +101,9 @@ export function makeRepoInternal<
           )
 
           const store = yield* mkStore(args.makeInitial, args.config)
+          const repoDependency = DataDependencies.repo(name)
+          const recordRead = DataDependencies.read(repoDependency)
+          const recordWrite = DataDependencies.write(repoDependency)
           const cms = Effect.map(getContextMap.pipe(Effect.orDie), (_) => ({
             get: (id: string) => _.get(`${name}.${id}`),
             set: (id: string, etag: string | undefined) => _.set(`${name}.${id}`, etag)
@@ -162,6 +166,7 @@ export function makeRepoInternal<
               (_) => decodeMany(_).pipe(Effect.orDie)
             )
             .pipe(
+              Effect.tap(() => recordRead),
               Effect.map((_) => _ as T[]),
               Effect.withSpan("Repository.all", {
                 kind: "client",
@@ -231,6 +236,7 @@ export function makeRepoInternal<
             kind: "client",
             attributes: { "app.entity": name }
           })(function*(id: T[IdKey]) {
+            yield* recordRead
             yield* Effect.annotateCurrentSpan({ "app.entity.id": id })
             return yield* flatMapOption(findE(id), (_) => Effect.orDie(decode(_)))
           })
@@ -258,6 +264,7 @@ export function makeRepoInternal<
 
           const saveAndPublish = Effect.fn("Repository.saveAndPublish", { attributes: { "app.entity": name } })(
             function*(items: Iterable<T>, events: Iterable<Evt> = []) {
+              yield* recordWrite
               const it = Chunk.fromIterable(items)
               const evts = [...events]
               yield* Effect.annotateCurrentSpan({
@@ -277,6 +284,7 @@ export function makeRepoInternal<
 
           const removeAndPublish = Effect.fn("Repository.removeAndPublish", { attributes: { "app.entity": name } })(
             function*(a: Iterable<T>, events: Iterable<Evt> = []) {
+              yield* recordWrite
               const { set } = yield* cms
               const it = [...a]
               const evts = [...events]
@@ -305,6 +313,7 @@ export function makeRepoInternal<
 
           const removeById = Effect.fn("Repository.removeById", { attributes: { "app.entity": name } })(
             function*(idOrIds: T[IdKey] | ReadonlyArray<T[IdKey]>) {
+              yield* recordWrite
               const ids = globalThis.Array.isArray(idOrIds)
                 ? idOrIds as readonly T[IdKey][]
                 : [idOrIds as T[IdKey]]
@@ -460,6 +469,7 @@ export function makeRepoInternal<
                   "db.response.returned_rows": Array.isArray(r) ? r.length : 1
                 })
               ),
+              Effect.tap(() => recordRead),
               Effect.withSpan("Repository.query", {
                 kind: "client",
                 attributes: { "app.entity": name }
@@ -552,6 +562,7 @@ export function makeRepoInternal<
               const dec = S.decodeEffectConcurrently(S.Array(schema))
               return store.queryRaw(q).pipe(
                 Effect.flatMap(dec),
+                Effect.tap(() => recordRead),
                 Effect.withSpan("Repository.queryRaw", {
                   kind: "client",
                   attributes: { "app.entity": name }
@@ -573,11 +584,13 @@ export function makeRepoInternal<
               return {
                 all: allE.pipe(
                   Effect.flatMap(decMany),
+                  Effect.tap(() => recordRead),
                   Effect.map((_) => _ as any[]),
                   Effect.withSpan("Repository.mapped.all", spanAttrs, { captureStackTrace: false })
                 ),
                 find: (id: T[IdKey]) =>
                   flatMapOption(findE(id), dec).pipe(
+                    Effect.tap(() => recordRead),
                     Effect.withSpan("Repository.mapped.find", {
                       ...spanAttrs,
                       attributes: { ...spanAttrs.attributes, "app.entity.id": id }
@@ -601,6 +614,7 @@ export function makeRepoInternal<
                 // },
                 save: (...xes: any[]) =>
                   Effect.flatMap(encMany(xes), (_) => saveAllE(_)).pipe(
+                    Effect.tap(() => recordWrite),
                     Effect.withSpan("Repository.mapped.save", spanAttrs, { captureStackTrace: false })
                   )
               }

--- a/packages/effect-app/src/client.ts
+++ b/packages/effect-app/src/client.ts
@@ -5,3 +5,4 @@ export * from "./client/errors.ts"
 export * from "./client/InvalidationKeys.ts"
 export * from "./client/makeClient.ts"
 // codegen:end
+export * as DataDependencies from "./DataDependencies.js"

--- a/packages/effect-app/src/client/apiClientFactory.ts
+++ b/packages/effect-app/src/client/apiClientFactory.ts
@@ -10,6 +10,7 @@ import * as Struct from "effect/Struct"
 import { Rpc, RpcClient, RpcGroup, RpcSerialization } from "effect/unstable/rpc"
 import * as Config from "../Config.ts"
 import * as Context from "../Context.ts"
+import * as DataDependencies from "../DataDependencies.ts"
 import * as Effect from "../Effect.ts"
 import { HttpClient, HttpClientRequest } from "../http.ts"
 import { Invalidation } from "../rpc.ts"
@@ -142,7 +143,12 @@ export const makeRpcGroupFromRequestsAndModuleName = <M extends RequestsAny, con
               stream: true as const
             })
             : Invalidation.makeCommandRpc(r._tag, { payload: r, success: r.success, error: r.error })
-          : Rpc.make(r._tag, { payload: r, success: r.success, error: r.error, stream: isStream })) as any
+          : Rpc.make(r._tag, {
+            payload: r,
+            success: isStream ? r.success : Invalidation.QueryResponseWithMetaData(r.success),
+            error: r.error,
+            stream: isStream
+          })) as any
       })
     )
     .prefix(`${moduleName}.`)
@@ -211,6 +217,20 @@ const makeApiClientFactory = Effect
       // `InvalidationKeysFromServer` and yield the raw payload / re-fail with the raw
       // error. Middleware-thrown failures arrive raw on the Cause already (no wrap to
       // strip) — the `else` branch passes them through.
+      const forwardDependencies = (
+        dependencies: DataDependencies.DataDependencySet | undefined,
+        options?: { readonly reads?: boolean }
+      ) =>
+        dependencies === undefined
+          ? Effect.void
+          : Effect.gen(function*() {
+            const dependencyRecorder = yield* DataDependencies.DataDependencyRecorder
+            if (options?.reads) {
+              yield* Effect.forEach(dependencies.reads, dependencyRecorder.read, { discard: true })
+            }
+            yield* Effect.forEach(dependencies.writes, dependencyRecorder.write, { discard: true })
+          })
+
       const unwrapCommand = (eff: Effect.Effect<any, any, any>): Effect.Effect<any, any, any> =>
         eff.pipe(
           Effect.flatMap((result: any) =>
@@ -218,6 +238,7 @@ const makeApiClientFactory = Effect
               const keys: ReadonlyArray<Invalidation.InvalidationKey> = result?.metadata?.invalidateQueries ?? []
               const invalidationKeys = yield* InvalidationKeysFromServer
               yield* Effect.forEach(keys, (key) => invalidationKeys.add(key), { discard: true })
+              yield* forwardDependencies(result?.metadata?.dataDependencies)
               return result.payload
             })
           ),
@@ -227,9 +248,20 @@ const makeApiClientFactory = Effect
                 const keys: ReadonlyArray<Invalidation.InvalidationKey> = result.metadata?.invalidateQueries ?? []
                 const invalidationKeys = yield* InvalidationKeysFromServer
                 yield* Effect.forEach(keys, (key) => invalidationKeys.add(key), { discard: true })
+                yield* forwardDependencies(result.metadata?.dataDependencies)
                 return yield* Effect.fail(result.error)
               })
               : Effect.fail(result)
+          )
+        )
+
+      const unwrapQuery = (eff: Effect.Effect<any, any, any>): Effect.Effect<any, any, any> =>
+        eff.pipe(
+          Effect.flatMap((result: any) =>
+            Effect.gen(function*() {
+              yield* forwardDependencies(result?.metadata?.dataDependencies, { reads: true })
+              return result.payload
+            })
           )
         )
 
@@ -275,7 +307,7 @@ const makeApiClientFactory = Effect
                       Effect.provide(layers, { local: true }),
                       Effect.provide(svcs)
                     )
-                  return isCommand ? unwrapCommand(rpcEffect) : rpcEffect
+                  return isCommand ? unwrapCommand(rpcEffect) : isStream ? rpcEffect : unwrapQuery(rpcEffect)
                 })
               )
 
@@ -292,13 +324,24 @@ const makeApiClientFactory = Effect
                           // Collect server invalidation keys from the "done" chunk, then discard it.
                           Stream.tap((item: any) =>
                             item._tag === "done" || item._tag === "metadata"
-                              ? InvalidationKeysFromServer.use((svc) =>
-                                Effect.forEach(
-                                  (item.metadata as Invalidation.CommandMetaData).invalidateQueries,
-                                  svc.add,
+                              ? Effect.gen(function*() {
+                                const metadata = item.metadata as Invalidation.CommandMetaData
+                                const invalidationKeys = yield* InvalidationKeysFromServer
+                                yield* Effect.forEach(metadata.invalidateQueries, invalidationKeys.add, {
+                                  discard: true
+                                })
+                                const dependencyRecorder = yield* DataDependencies.DataDependencyRecorder
+                                yield* Effect.forEach(
+                                  metadata.dataDependencies.reads,
+                                  dependencyRecorder.read,
                                   { discard: true }
                                 )
-                              )
+                                yield* Effect.forEach(
+                                  metadata.dataDependencies.writes,
+                                  dependencyRecorder.write,
+                                  { discard: true }
+                                )
+                              })
                               : Effect.void
                           ),
                           Stream.filter((item: any) => item._tag === "value"),
@@ -309,15 +352,20 @@ const makeApiClientFactory = Effect
                           Stream.catch((err: any) =>
                             err?._tag === "error" && err?.metadata
                               ? Stream.fromEffect(
-                                InvalidationKeysFromServer.use((svc) =>
-                                  Effect
-                                    .forEach(
-                                      (err.metadata as Invalidation.CommandMetaData).invalidateQueries,
-                                      svc.add,
-                                      { discard: true }
-                                    )
-                                    .pipe(Effect.flatMap(() => Effect.fail(err.error)))
-                                )
+                                Effect.gen(function*() {
+                                  const metadata = err.metadata as Invalidation.CommandMetaData
+                                  const invalidationKeys = yield* InvalidationKeysFromServer
+                                  yield* Effect.forEach(metadata.invalidateQueries, invalidationKeys.add, {
+                                    discard: true
+                                  })
+                                  const dependencyRecorder = yield* DataDependencies.DataDependencyRecorder
+                                  yield* Effect.forEach(
+                                    metadata.dataDependencies.writes,
+                                    dependencyRecorder.write,
+                                    { discard: true }
+                                  )
+                                  return yield* Effect.fail(err.error)
+                                })
                               )
                               : Stream.fail(err)
                           ),

--- a/packages/effect-app/src/rpc/Invalidation.ts
+++ b/packages/effect-app/src/rpc/Invalidation.ts
@@ -2,6 +2,7 @@ import * as Ref from "effect/Ref"
 import { Rpc } from "effect/unstable/rpc"
 import { type ClientForOptions, makeQueryKey } from "../client/clientFor.ts"
 import * as Context from "../Context.ts"
+import * as DataDependencies from "../DataDependencies.ts"
 import * as Effect from "../Effect.ts"
 import * as S from "../Schema.ts"
 
@@ -23,7 +24,7 @@ const normalizeKey = (input: InvalidationKeyInput): InvalidationKey => {
 const isBatch = (
   input: InvalidationKeyInput | ReadonlyArray<InvalidationKeyInput>
 ): input is ReadonlyArray<InvalidationKeyInput> =>
-  Array.isArray(input) && input.length > 0 && typeof input[0] !== "string"
+  Array.isArray(input) && input[0] !== undefined && typeof input[0] !== "string"
 
 const normalizeInputs = (
   input: InvalidationKeyInput | ReadonlyArray<InvalidationKeyInput>
@@ -46,8 +47,21 @@ export const InvalidationKeys = S.Array(InvalidationKey)
 export type InvalidationKeys = S.Schema.Type<typeof InvalidationKeys>
 
 /** Metadata included in every command response for server-driven cache invalidation. */
-export const CommandMetaData = S.Struct({ invalidateQueries: InvalidationKeys })
+export const CommandMetaData = S.Struct({
+  invalidateQueries: InvalidationKeys,
+  dataDependencies: DataDependencies.DataDependencySet
+})
 export type CommandMetaData = S.Schema.Type<typeof CommandMetaData>
+
+export const emptyDataDependencies: DataDependencies.DataDependencySet = { reads: [], writes: [] }
+
+export const makeMetaData = (
+  invalidateQueries: InvalidationKeys,
+  dataDependencies: DataDependencies.DataDependencySet = emptyDataDependencies
+): CommandMetaData => ({ invalidateQueries, dataDependencies })
+
+export const QueryResponseWithMetaData = <S extends S.Top>(success: S) =>
+  S.Struct({ payload: success, metadata: S.Struct({ dataDependencies: DataDependencies.DataDependencySet }) })
 
 /**
  * Wraps a command's success schema so that the wire format carries both the `payload`

--- a/packages/infra/src/routing.ts
+++ b/packages/infra/src/routing.ts
@@ -2,9 +2,11 @@
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
 /* eslint-disable @typescript-eslint/no-empty-object-type */
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import * as Array from "effect-app/Array"
 import type { NonEmptyReadonlyArray } from "effect-app/Array"
 import { getMeta } from "effect-app/client"
 import * as Config from "effect-app/Config"
+import * as DataDependencies from "effect-app/DataDependencies"
 import * as Effect from "effect-app/Effect"
 import { type HttpHeaders } from "effect-app/http"
 import * as Layer from "effect-app/Layer"
@@ -454,10 +456,19 @@ export const makeRouter = <Live extends Layer.Layer<any, any, any> = Layer.Layer
                   // clients can invalidate queries even when the stream fails.
                   const keysRef = Ref.makeUnsafe<ReadonlyArray<Invalidation.InvalidationKey>>([])
                   const invalidationSet = Invalidation.makeInvalidationSet(keysRef)
+                  const readsRef = Ref.makeUnsafe<DataDependencies.DataDependencies>([])
+                  const writesRef = Ref.makeUnsafe<DataDependencies.DataDependencies>([])
+                  const dependencyRecorder = DataDependencies.makeDataDependencyRecorder(readsRef, writesRef)
+                  const metadata = (keys: ReadonlyArray<Invalidation.InvalidationKey>) =>
+                    Effect.map(
+                      dependencyRecorder.get,
+                      (dataDependencies) => Invalidation.makeMetaData(keys, dataDependencies)
+                    )
                   return Stream.concat(
                     (result as Stream.Stream<any, any, any>).pipe(
                       Stream.map((item: any) => ({ _tag: "value" as const, value: item })),
                       Stream.provideService(Invalidation.InvalidationSet, invalidationSet),
+                      Stream.provideService(DataDependencies.DataDependencyRecorder, dependencyRecorder),
                       // V3: after each value chunk, drain accumulated keys and emit a "metadata"
                       // chunk if any keys were collected since the last drain. This lets clients
                       // invalidate queries mid-stream without waiting for the "done" chunk.
@@ -465,13 +476,18 @@ export const makeRouter = <Live extends Layer.Layer<any, any, any> = Layer.Layer
                         Stream
                           .fromEffect(
                             Ref.getAndSet(keysRef, []).pipe(
-                              Effect.map((keys) =>
-                                keys.length > 0
-                                  ? [
-                                    valueChunk,
-                                    { _tag: "metadata" as const, metadata: { invalidateQueries: keys } }
-                                  ]
-                                  : [valueChunk]
+                              Effect.flatMap((keys) =>
+                                metadata(keys).pipe(
+                                  Effect.map((meta) =>
+                                    Array.isReadonlyArrayNonEmpty(keys)
+                                      || Array.isReadonlyArrayNonEmpty(meta.dataDependencies.writes)
+                                      ? [
+                                        valueChunk,
+                                        { _tag: "metadata" as const, metadata: meta }
+                                      ]
+                                      : [valueChunk]
+                                  )
+                                )
                               )
                             )
                           )
@@ -482,11 +498,15 @@ export const makeRouter = <Live extends Layer.Layer<any, any, any> = Layer.Layer
                         Stream.fromEffect(
                           Ref.get(keysRef).pipe(
                             Effect.flatMap((keys) =>
-                              Effect.fail({
-                                _tag: "error" as const,
-                                error: err,
-                                metadata: { invalidateQueries: keys }
-                              })
+                              metadata(keys).pipe(
+                                Effect.flatMap((meta) =>
+                                  Effect.fail({
+                                    _tag: "error" as const,
+                                    error: err,
+                                    metadata: meta
+                                  })
+                                )
+                              )
                             )
                           )
                         )
@@ -494,7 +514,11 @@ export const makeRouter = <Live extends Layer.Layer<any, any, any> = Layer.Layer
                     ),
                     Stream.fromEffect(
                       Ref.get(keysRef).pipe(
-                        Effect.map((keys) => ({ _tag: "done" as const, metadata: { invalidateQueries: keys } }))
+                        Effect.flatMap((keys) =>
+                          metadata(keys).pipe(
+                            Effect.map((meta) => ({ _tag: "done" as const, metadata: meta }))
+                          )
+                        )
                       )
                     )
                   )
@@ -511,6 +535,13 @@ export const makeRouter = <Live extends Layer.Layer<any, any, any> = Layer.Layer
                   })
                   .pipe(Effect.andThen(result as Effect.Effect<unknown, unknown, unknown>))
 
+                const readsRef = Ref.makeUnsafe<DataDependencies.DataDependencies>([])
+                const writesRef = Ref.makeUnsafe<DataDependencies.DataDependencies>([])
+                const dependencyRecorder = DataDependencies.makeDataDependencyRecorder(readsRef, writesRef)
+                effect = effect.pipe(
+                  Effect.provideService(DataDependencies.DataDependencyRecorder, dependencyRecorder)
+                )
+
                 // Commands: provide a request-scoped `InvalidationSet` and wrap both
                 // success (`CommandResponseWithMetaData`) and handler-thrown failure
                 // (`CommandFailureWithMetaData`) so the client receives accumulated
@@ -525,18 +556,39 @@ export const makeRouter = <Live extends Layer.Layer<any, any, any> = Layer.Layer
                     Effect.provideService(Invalidation.InvalidationSet, invalidationSet),
                     Effect.flatMap((value) =>
                       Ref.get(keysRef).pipe(
-                        Effect.map((keys) => ({ payload: value, metadata: { invalidateQueries: keys } }) as any)
+                        Effect.flatMap((keys) =>
+                          dependencyRecorder.get.pipe(
+                            Effect.map((dataDependencies) =>
+                              ({
+                                payload: value,
+                                metadata: Invalidation.makeMetaData(keys, dataDependencies)
+                              }) as any
+                            )
+                          )
+                        )
                       )
                     ),
                     Effect.catch((err: any) =>
                       Ref.get(keysRef).pipe(
                         Effect.flatMap((keys) =>
-                          Effect.fail({
-                            _tag: "CommandFailureWithMetaData" as const,
-                            error: err,
-                            metadata: { invalidateQueries: keys }
-                          })
+                          dependencyRecorder.get.pipe(
+                            Effect.flatMap((dataDependencies) =>
+                              Effect.fail({
+                                _tag: "CommandFailureWithMetaData" as const,
+                                error: err,
+                                metadata: Invalidation.makeMetaData(keys, dataDependencies)
+                              })
+                            )
+                          )
                         )
+                      )
+                    )
+                  )
+                } else {
+                  effect = effect.pipe(
+                    Effect.flatMap((value) =>
+                      dependencyRecorder.get.pipe(
+                        Effect.map((dataDependencies) => ({ payload: value, metadata: { dataDependencies } }) as any)
                       )
                     )
                   )
@@ -584,7 +636,7 @@ export const makeRouter = <Live extends Layer.Layer<any, any, any> = Layer.Layer
                     })
                   : Rpc.make(resource._tag, {
                     payload: resource,
-                    success: resource.success,
+                    success: isStream ? resource.success : Invalidation.QueryResponseWithMetaData(resource.success),
                     error: resource.error,
                     stream: isStream
                   }))

--- a/packages/infra/test/repository-ext.test.ts
+++ b/packages/infra/test/repository-ext.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from "@effect/vitest"
+import * as DataDependencies from "effect-app/DataDependencies"
 import * as Effect from "effect-app/Effect"
 import * as Layer from "effect-app/Layer"
 import { makeRepo } from "effect-app/Model/Repository"
 import { RepositoryRegistryLive } from "effect-app/Model/Repository/Registry"
 import * as S from "effect-app/Schema"
 import { setupRequestContextFromCurrent } from "effect-app/setupRequest"
+import * as Ref from "effect/Ref"
 import { MemoryStoreLive } from "../src/Store/Memory.js"
 
 class BatchItem extends S.Class<BatchItem>("BatchItem")({
@@ -54,6 +56,31 @@ describe("repository ext save/remove batching", () => {
         const all = yield* repo.all
         expect(all).toHaveLength(1)
         expect(all[0]?.id).toBe("4")
+      })
+      .pipe(
+        setupRequestContextFromCurrent(),
+        Effect.provide(TestStoreLive)
+      ))
+
+  it.effect("records repository read and write dependencies", () =>
+    Effect
+      .gen(function*() {
+        const readsRef = yield* Ref.make<DataDependencies.DataDependencies>([])
+        const writesRef = yield* Ref.make<DataDependencies.DataDependencies>([])
+        const recorder = DataDependencies.makeDataDependencyRecorder(readsRef, writesRef)
+
+        yield* Effect
+          .gen(function*() {
+            const repo = yield* makeRepo("DependencyItem", BatchItem, {})
+            yield* repo.save(new BatchItem({ id: "1", label: "one" }))
+            yield* repo.all
+            yield* repo.find("1")
+            yield* repo.removeById("1")
+          })
+          .pipe(Effect.provideService(DataDependencies.DataDependencyRecorder, recorder))
+
+        expect(yield* Ref.get(readsRef)).toEqual([DataDependencies.repo("DependencyItem")])
+        expect(yield* Ref.get(writesRef)).toEqual([DataDependencies.repo("DependencyItem")])
       })
       .pipe(
         setupRequestContextFromCurrent(),

--- a/packages/infra/test/rpc-e2e-invalidation.test.ts
+++ b/packages/infra/test/rpc-e2e-invalidation.test.ts
@@ -14,12 +14,15 @@
  */
 import { NodeHttpServer } from "@effect/platform-node"
 import { expect, it } from "@effect/vitest"
-import { ApiClientFactory, InvalidationKeysFromServer, makeInvalidationKeysService, makeRpcClient } from "effect-app/client"
+import { ApiClientFactory, DatabaseError, DataDependencies, InvalidationKeysFromServer, InvalidStateError, makeInvalidationKeysService, makeRpcClient, OptimisticConcurrencyException } from "effect-app/client"
+import * as Context from "effect-app/Context"
 import { HttpRouter, HttpServer } from "effect-app/http"
 import { DefaultGenericMiddlewares } from "effect-app/middleware"
+import { makeRepo, RepositoryRegistryLive } from "effect-app/Model"
 import { Invalidation, MiddlewareMaker } from "effect-app/rpc"
 import * as S from "effect-app/Schema"
 import { TaggedErrorClass } from "effect-app/Schema"
+import { setupRequestContextFromCurrent } from "effect-app/setupRequest"
 import * as Effect from "effect/Effect"
 import * as Exit from "effect/Exit"
 import * as Layer from "effect/Layer"
@@ -31,6 +34,7 @@ import { RpcSerialization } from "effect/unstable/rpc"
 import { createServer } from "http"
 import { makeRouter } from "../src/routing.js"
 import { DefaultGenericMiddlewaresLive } from "../src/routing/middleware.js"
+import { MemoryStoreLive } from "../src/Store/Memory.js"
 import { AllowAnonymous, AllowAnonymousLive, RequestContextMap, RequireRoles, RequireRolesLive, SomeElseMiddleware, SomeElseMiddlewareLive, SomeService, Test, TestLive } from "./fixtures.js"
 
 // ---------------------------------------------------------------------------
@@ -99,14 +103,44 @@ class StreamWithKey extends Req.Command<StreamWithKey>()("StreamWithKey", {}, {
   success: S.Number
 }) {}
 
-const InvRsc = { DoNothing, DoWithDynamicKey, DoWithBothKeys, DoAndFail, StreamWithKey }
+class RepoItem extends S.Class<RepoItem>("RepoItem")({
+  id: S.String,
+  label: S.String
+}) {}
+
+class GetRepoCount extends Req.Query<GetRepoCount>()("GetRepoCount", {}, {
+  allowAnonymous: true,
+  error: DatabaseError,
+  success: S.Number
+}) {}
+
+class SaveRepoItem extends Req.Command<SaveRepoItem>()("SaveRepoItem", {
+  id: S.String,
+  label: S.String
+}, {
+  allowAnonymous: true,
+  error: S.Union([InvalidStateError, OptimisticConcurrencyException]),
+  success: S.Void
+}) {}
+
+class RepoItems extends Context.Service<RepoItems>()("RepoItems", {
+  make: makeRepo("RepoItem", RepoItem, {})
+}) {
+  static Default = Layer.effect(this, this.make).pipe(
+    Layer.provide(Layer.merge(MemoryStoreLive, RepositoryRegistryLive))
+  )
+}
+
+const InvRsc = { DoNothing, DoWithDynamicKey, DoWithBothKeys, DoAndFail, StreamWithKey, GetRepoCount, SaveRepoItem }
 
 // ---------------------------------------------------------------------------
 // Controllers / router
 // ---------------------------------------------------------------------------
 
 const router = Router(InvRsc)({
+  dependencies: [RepoItems.Default],
   *effect(match) {
+    const repo = yield* RepoItems
     return match({
       DoNothing: () => Effect.void,
       DoWithDynamicKey: Effect.fnUntraced(function*() {
@@ -125,7 +159,9 @@ const router = Router(InvRsc)({
       StreamWithKey: () =>
         Stream.fromIterable([1, 2, 3]).pipe(
           Stream.tap(() => Invalidation.InvalidationSet.use((_) => _.add(StreamKey)))
-        )
+        ),
+      GetRepoCount: () => repo.all.pipe(Effect.map((_) => _.length), setupRequestContextFromCurrent()),
+      SaveRepoItem: ({ id, label }) => repo.save(new RepoItem({ id, label })).pipe(setupRequestContextFromCurrent())
     })
   }
 })
@@ -169,6 +205,15 @@ const withCapture = <A, E, R>(eff: Effect.Effect<A, E, R>) =>
     const svc = makeInvalidationKeysService(ref)
     const result = yield* eff.pipe(Effect.provideService(InvalidationKeysFromServer, svc), Effect.exit)
     return { result, keys: yield* Ref.get(ref) }
+  })
+
+const withDependencyCapture = <A, E, R>(eff: Effect.Effect<A, E, R>) =>
+  Effect.gen(function*() {
+    const readsRef = yield* Ref.make<DataDependencies.DataDependencies>([])
+    const writesRef = yield* Ref.make<DataDependencies.DataDependencies>([])
+    const svc = DataDependencies.makeDataDependencyRecorder(readsRef, writesRef)
+    const result = yield* eff.pipe(Effect.provideService(DataDependencies.DataDependencyRecorder, svc), Effect.exit)
+    return { result, dependencies: yield* svc.get }
   })
 
 // ---------------------------------------------------------------------------
@@ -251,6 +296,24 @@ it.live(
     // Handler taps `InvalidationSet.use` once per emitted value; routing's V3 mid-stream
     // metadata drain forwards each batch as it arrives.
     expect(keys).toStrictEqual([StreamKey, StreamKey, StreamKey])
+  }, Effect.provide(TestLayer)),
+  { timeout: 10_000 }
+)
+
+it.live(
+  "repository dependencies flow through query and command metadata",
+  Effect.fnUntraced(function*() {
+    const client = yield* ApiClientFactory.makeFor(Layer.empty)(InvRsc)
+
+    const query = yield* withDependencyCapture(client.GetRepoCount.handler())
+    expect(Exit.isSuccess(query.result) && query.result.value).toBe(0)
+    expect(query.dependencies.reads).toStrictEqual([DataDependencies.repo("RepoItem")])
+    expect(query.dependencies.writes).toStrictEqual([])
+
+    const command = yield* withDependencyCapture(client.SaveRepoItem.handler({ id: "1", label: "one" }))
+    expect(Exit.isSuccess(command.result)).toBe(true)
+    expect(command.dependencies.reads).toStrictEqual([])
+    expect(command.dependencies.writes).toStrictEqual([DataDependencies.repo("RepoItem")])
   }, Effect.provide(TestLayer)),
   { timeout: 10_000 }
 )

--- a/packages/vue/src/atomQuery.ts
+++ b/packages/vue/src/atomQuery.ts
@@ -17,14 +17,17 @@ import { defaultRegistry } from "@effect/atom-vue"
 import { makeQueryKey } from "effect-app/client"
 import type { ClientForOptions } from "effect-app/client/clientFor"
 import { ServiceUnavailableError } from "effect-app/client/errors"
+import * as DataDependencies from "effect-app/DataDependencies"
 import * as Effect from "effect-app/Effect"
 import * as Option from "effect-app/Option"
 import * as S from "effect-app/Schema"
+import { isReadonlyArrayNonEmpty } from "effect/Array"
 import * as Cause from "effect/Cause"
 import * as Duration from "effect/Duration"
 import * as Equal from "effect/Equal"
 import * as Hash from "effect/Hash"
 import type * as Layer from "effect/Layer"
+import * as Ref from "effect/Ref"
 import * as Stream from "effect/Stream"
 import { isHttpClientError } from "effect/unstable/http/HttpClientError"
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult"
@@ -83,7 +86,9 @@ const trackWritableByKeys =
     )
   }
 
-const atomsForKeys = (keys: ReadonlyArray<unknown>): ReadonlyArray<Atom.Atom<AsyncResult.AsyncResult<any, any>>> => {
+const atomsForKeys = (
+  keys: ReadonlyArray<ReadonlyArray<unknown>>
+): ReadonlyArray<Atom.Atom<AsyncResult.AsyncResult<any, any>>> => {
   const atoms = new Set<Atom.Atom<AsyncResult.AsyncResult<any, any>>>()
   for (const key of keys) {
     const set = keyAtoms.get(Hash.hash(key))
@@ -92,23 +97,64 @@ const atomsForKeys = (keys: ReadonlyArray<unknown>): ReadonlyArray<Atom.Atom<Asy
   return [...atoms]
 }
 
+// --- derived invalidation (repo read/write tracking) ----------------------------------------
+// Per-atom read dependencies, recorded by the query effect (repos it read from). A mutation's
+// write dependencies are intersected against these to find queries that must be refetched even
+// when no explicit invalidation key covers them.
+const atomReadDependencies = new WeakMap<
+  Atom.Atom<AsyncResult.AsyncResult<any, any>>,
+  DataDependencies.DataDependencies
+>()
+
+const setAtomReadDependencies = <A, E>(
+  atom: Atom.Atom<AsyncResult.AsyncResult<A, E>>,
+  reads: DataDependencies.DataDependencies
+) => atomReadDependencies.set(atom, reads)
+
+const atomsForWriteDependencies = (
+  writes: ReadonlyArray<DataDependencies.DataDependency>
+): ReadonlyArray<Atom.Atom<AsyncResult.AsyncResult<any, any>>> => {
+  const out = new Set<Atom.Atom<AsyncResult.AsyncResult<any, any>>>()
+  for (const set of keyAtoms.values()) {
+    for (const a of set) {
+      const reads = atomReadDependencies.get(a)
+      if (reads !== undefined && isReadonlyArrayNonEmpty(reads) && DataDependencies.intersects(reads, writes)) {
+        out.add(a)
+      }
+    }
+  }
+  return [...out]
+}
+
 /**
  * Invalidate the given keys and AWAIT the result. The invalidation (refetch trigger) goes through
  * the built-in `Reactivity` service — the same one query atoms register against via
  * `factory.withReactivity`, shared via the runtime memoMap. The await uses our own `keyAtoms`
  * tracking + `awaitAtomResult`, since `Reactivity.invalidate` returns void and can't be awaited.
  *
+ * When `writeDependencies` is non-empty, additionally refreshes every live query atom whose
+ * recorded read dependencies intersect the writes (derived invalidation), so mutations that touch
+ * repos invalidate the queries that read from them — without an explicit `queryInvalidation` rule.
+ *
  * Resolves once the affected queries have settled, so a mutation can `yield*` this and know the
  * affected queries are fresh. (The await reads via the module-global default registry — the one the
  * vue composables resolve via `injectRegistry`'s fallback.)
  */
-export const invalidateAndAwait = (keys: ReadonlyArray<unknown>): Effect.Effect<void, never, Reactivity.Reactivity> =>
+export const invalidateAndAwait = (
+  keys: ReadonlyArray<ReadonlyArray<unknown>>,
+  writeDependencies?: ReadonlyArray<DataDependencies.DataDependency>
+): Effect.Effect<void, never, Reactivity.Reactivity> =>
   Effect.gen(function*() {
     yield* Reactivity.invalidate(keys) // invalidates everything but only refreshes what's mounted
     const atoms = atomsForKeys(keys)
+    const derivedAtoms = writeDependencies && isReadonlyArrayNonEmpty(writeDependencies)
+      ? atomsForWriteDependencies(writeDependencies)
+      : []
+    for (const a of derivedAtoms) defaultRegistry.refresh(a) // force refetch (Reactivity.invalidate didn't cover these keys)
+    const allAtoms = new Set([...atoms, ...derivedAtoms])
     //    for (const a of atoms) defaultRegistry.refresh(a) // refreshes everything even when not mounted
-    if (atoms.length === 0) return
-    yield* Effect.forEach(atoms, (a) => awaitAtomResult(defaultRegistry, a).pipe(Effect.exit))
+    if (allAtoms.size === 0) return
+    yield* Effect.forEach(allAtoms, (a) => awaitAtomResult(defaultRegistry, a).pipe(Effect.exit))
   })
 
 const isPlainObject = (o: unknown): o is Record<string, unknown> => {
@@ -319,14 +365,27 @@ export const buildQueryFamily = <I, A, E>(
   const baseKey = makeQueryKey(self) // hierarchical, input-independent
 
   return Atom.family((input: I) => {
+    // The query effect runs lazily when the atom is read; `trackedAtom` is assigned below before
+    // that ever happens, so the effect can record its read dependencies against the atom that ends
+    // up registered in `keyAtoms` (=> reachable by derived invalidation).
+    let trackedAtom: Atom.Atom<AsyncResult.AsyncResult<A, E>> | undefined
     let atom: Atom.Atom<AsyncResult.AsyncResult<A, E>> = rt.runtime.atom(
-      self
-        .handler(input)
-        .pipe(
-          Effect.retry({ times: 5, while: isRetryable }),
-          Effect.tapCauseIf(Cause.hasDies, (cause) => reportRuntimeError(cause)),
-          Effect.withSpan(`query ${self.id}`, {}, { captureStackTrace: false })
-        )
+      Effect.gen(function*() {
+        const readsRef = yield* Ref.make<DataDependencies.DataDependencies>([])
+        const writesRef = yield* Ref.make<DataDependencies.DataDependencies>([])
+        const dependencyRecorder = DataDependencies.makeDataDependencyRecorder(readsRef, writesRef)
+        const result = yield* self
+          .handler(input)
+          .pipe(
+            Effect.provideService(DataDependencies.DataDependencyRecorder, dependencyRecorder),
+            Effect.retry({ times: 5, while: isRetryable }),
+            Effect.tapCauseIf(Cause.hasDies, (cause) => reportRuntimeError(cause)),
+            Effect.withSpan(`query ${self.id}`, {}, { captureStackTrace: false })
+          )
+        const reads = yield* Ref.get(readsRef)
+        if (trackedAtom !== undefined) setAtomReadDependencies(trackedAtom, reads)
+        return result
+      })
     )
     // Register under every prefix of the full key => hierarchical (prefix) invalidation. Two roles:
     //   - withReactivity: `Reactivity.invalidate(key)` refreshes this atom (the actual refetch).
@@ -337,6 +396,7 @@ export const buildQueryFamily = <I, A, E>(
       : [...baseKey, self.queryKeyProjectionHash, input]
     const reactivityKeys = uniqueKeys([...prefixesOf(fullKey), ...prefixesOf(projectedFullKey)])
     atom = rt.factory.withReactivity(reactivityKeys)(atom)
+    trackedAtom = atom
     atom = trackByKeys(reactivityKeys)(atom)
     // gcTime LAST so the whole chain (incl. the registration + tracking) stays alive through the
     // idle window, letting invalidation reach a cached-but-unmounted query.

--- a/packages/vue/src/mutate.ts
+++ b/packages/vue/src/mutate.ts
@@ -2,6 +2,7 @@
 import { type InvalidationKey, InvalidationKeysFromServer, makeInvalidationKeysService, makeQueryKey, type Req } from "effect-app/client"
 import type { ClientForOptions, RequestHandlerWithInput } from "effect-app/client/clientFor"
 import type { InvalidateQueryInstruction } from "effect-app/client/makeClient"
+import * as DataDependencies from "effect-app/DataDependencies"
 import * as Effect from "effect-app/Effect"
 import { tuple } from "effect-app/Function"
 import * as Option from "effect-app/Option"
@@ -114,7 +115,8 @@ export type QueryKeyInvalidationFilters = {
 }
 export type InvalidationEntry = InvalidateQueryInstruction<QueryKeyInvalidationFilters>
 export type QueryInvalidationEffect<R = never> = (
-  keys: ReadonlyArray<ReadonlyArray<unknown>>
+  keys: ReadonlyArray<ReadonlyArray<unknown>>,
+  writeDependencies?: ReadonlyArray<DataDependencies.DataDependency>
 ) => Effect.Effect<void, never, R>
 export interface QueryInvalidator<R = never> {
   readonly invalidateAndAwait: QueryInvalidationEffect<R>
@@ -302,7 +304,8 @@ const buildInvalidateCache = <RInvalidator>(
   const invalidateCache = (
     input: unknown,
     output: Exit.Exit<unknown, unknown>,
-    serverKeys: ReadonlyArray<InvalidationKey>
+    serverKeys: ReadonlyArray<InvalidationKey>,
+    writeDependencies: ReadonlyArray<DataDependencies.DataDependency> = []
   ) =>
     Effect.suspend(() => {
       const clientKeys = getClientInvalidationKeys(input, output)
@@ -310,14 +313,15 @@ const buildInvalidateCache = <RInvalidator>(
       // array is hashed structurally, matching the query-side registration.
       const keys: ReadonlyArray<ReadonlyArray<unknown>> = [...clientKeys, ...serverKeys]
 
-      if (!isReadonlyArrayNonEmpty(keys)) return Effect.void
+      if (!isReadonlyArrayNonEmpty(keys) && !isReadonlyArrayNonEmpty(writeDependencies)) return Effect.void
 
       return Effect
         .andThen(
-          Effect.annotateCurrentSpan({ clientKeys, serverKeys }),
+          Effect.annotateCurrentSpan({ clientKeys, serverKeys, writeDependencies }),
           // refetch + AWAIT every live query registered under these keys, so by the time the
-          // mutation resolves the affected queries are fresh.
-          queryInvalidator.invalidateAndAwait(keys)
+          // mutation resolves the affected queries are fresh. `writeDependencies` extends the
+          // reach to queries whose recorded read dependencies intersect the mutation's writes.
+          queryInvalidator.invalidateAndAwait(keys, writeDependencies)
         )
         .pipe(
           Effect.tap(Effect.sleep(0.1)), // allow for refs to update etc
@@ -340,12 +344,17 @@ export const invalidateQueries = <RInvalidator>(
   const handle = <A, E, R>(eff: Effect.Effect<A, E, R>, input?: unknown) =>
     Effect.gen(function*() {
       const keysRef = yield* Ref.make<ReadonlyArray<InvalidationKey>>([])
+      const readsRef = yield* Ref.make<DataDependencies.DataDependencies>([])
+      const writesRef = yield* Ref.make<DataDependencies.DataDependencies>([])
+      const dependencyRecorder = DataDependencies.makeDataDependencyRecorder(readsRef, writesRef)
       const result = yield* eff.pipe(
         Effect.provideService(InvalidationKeysFromServer, makeInvalidationKeysService(keysRef)),
+        Effect.provideService(DataDependencies.DataDependencyRecorder, dependencyRecorder),
         Effect.onExit((exit) =>
           Effect.gen(function*() {
             const serverKeys = yield* Ref.get(keysRef)
-            yield* invalidateCache(input, exit, serverKeys)
+            const writeDependencies = yield* Ref.get(writesRef)
+            yield* invalidateCache(input, exit, serverKeys, writeDependencies)
           })
         )
       )
@@ -354,7 +363,8 @@ export const invalidateQueries = <RInvalidator>(
           Effect.onExit((exit) =>
             Effect.gen(function*() {
               const serverKeys = yield* Ref.get(keysRef)
-              yield* invalidateCache(input, exit, serverKeys)
+              const writeDependencies = yield* Ref.get(writesRef)
+              yield* invalidateCache(input, exit, serverKeys, writeDependencies)
             })
           )
         )
@@ -430,6 +440,9 @@ export const makeStreamMutation2 = <RInvalidator>(queryInvalidator: QueryInvalid
     const makeInvocationEffect = (input: unknown, source: Stream.Stream<any, any, any>) =>
       Effect.gen(function*() {
         const keysRef = yield* Ref.make<ReadonlyArray<InvalidationKey>>([])
+        const readsRef = yield* Ref.make<DataDependencies.DataDependencies>([])
+        const writesRef = yield* Ref.make<DataDependencies.DataDependencies>([])
+        const dependencyRecorder = DataDependencies.makeDataDependencyRecorder(readsRef, writesRef)
         const invKeys = makeInvalidationKeysService(
           keysRef,
           // Stream invalidation is sequenced by the injected query invalidator; this callback
@@ -439,12 +452,14 @@ export const makeStreamMutation2 = <RInvalidator>(queryInvalidator: QueryInvalid
         const lastRef = yield* Ref.make<any>(undefined)
         return source.pipe(
           Stream.provideService(InvalidationKeysFromServer, invKeys),
+          Stream.provideService(DataDependencies.DataDependencyRecorder, dependencyRecorder),
           Stream.tap((v) => Ref.set(lastRef, v)),
           Stream.ensuring(
             Effect.gen(function*() {
               const lastValue = yield* Ref.get(lastRef)
               const serverKeys = yield* Ref.get(keysRef)
-              yield* invCache(input, Exit.succeed(lastValue), serverKeys)
+              const writeDependencies = yield* Ref.get(writesRef)
+              yield* invCache(input, Exit.succeed(lastValue), serverKeys, writeDependencies)
             })
           )
         )

--- a/packages/vue/test/dependencyInvalidation.test.ts
+++ b/packages/vue/test/dependencyInvalidation.test.ts
@@ -1,0 +1,64 @@
+import { expect, it } from "@effect/vitest"
+import { type Req, type RequestHandlerWithInput } from "effect-app/client"
+import * as DataDependencies from "effect-app/DataDependencies"
+import * as Effect from "effect-app/Effect"
+import * as Exit from "effect/Exit"
+import * as Fiber from "effect/Fiber"
+import { TestClock } from "effect/testing"
+import { invalidateQueries } from "../src/mutate.js"
+
+const dependency = DataDependencies.repo("FrontendRepo")
+
+const commandHandler = <
+  Id extends string,
+  R
+>(id: Id, handler: (input: undefined) => Effect.Effect<void, never, R>): RequestHandlerWithInput<
+  undefined,
+  void,
+  never,
+  R,
+  Req,
+  Id
+> => ({ id, Request: undefined as never, handler })
+
+it.effect("forwards recorded write dependencies to the query invalidator", () =>
+  Effect.gen(function*() {
+    const recorded: Array<ReadonlyArray<DataDependencies.DataDependency>> = []
+    const mutate = invalidateQueries(
+      commandHandler("Admin.Save", () => DataDependencies.write(dependency)),
+      undefined,
+      {
+        invalidateAndAwait: (_keys, writeDependencies) =>
+          Effect.sync(() => {
+            recorded.push(writeDependencies ?? [])
+          })
+      }
+    )
+    const fiber = yield* Effect.forkChild(mutate(DataDependencies.write(dependency), undefined))
+    yield* TestClock.adjust("1 millis")
+    const result = yield* Fiber.join(fiber)
+
+    expect(result).toBeUndefined()
+    expect(recorded.some((writes) => writes.some((d) => d.type === "repo" && d.name === "FrontendRepo"))).toBe(true)
+  }))
+
+it.effect("forwards empty write dependencies when the command records none", () =>
+  Effect.gen(function*() {
+    const recorded: Array<ReadonlyArray<DataDependencies.DataDependency>> = []
+    const mutate = invalidateQueries(
+      commandHandler("Admin.Noop", () => Effect.void),
+      undefined,
+      {
+        invalidateAndAwait: (_keys, writeDependencies) =>
+          Effect.sync(() => {
+            recorded.push(writeDependencies ?? [])
+          })
+      }
+    )
+    const fiber = yield* Effect.forkChild(mutate(Effect.void, undefined))
+    yield* TestClock.adjust("1 millis")
+    const result = yield* Fiber.join(fiber)
+
+    expect(Exit.isSuccess(Exit.succeed(result))).toBe(true)
+    expect(recorded).toEqual([[]])
+  }))

--- a/wiki/ResourceClients.md
+++ b/wiki/ResourceClients.md
@@ -12,6 +12,8 @@ Queries are for reading data from the api. No writing/mutating allowed. Queries 
 Mutations are for writing data to the api, return values should at most include identifiers, and often `void`.
 Mutations auto invalidate Queries in their namespace, so that a Users.Index Query will be invalidated upon a Users.Delete or Update mutation.
 This only occurs within the same namespace, like "Users".
+Queries can also be invalidated automatically from data dependencies recorded at runtime: repository reads by queries are matched with repository writes by commands.
+See [Repository-derived query invalidation](./repository-derived-query-invalidation.md) for the full architecture and trade-offs.
 If you need to invalidate queries in another namespace, you can pass the following option to the Mutation constructor:
 
 ```ts

--- a/wiki/repository-derived-query-invalidation.md
+++ b/wiki/repository-derived-query-invalidation.md
@@ -1,0 +1,288 @@
+# Repository-derived query invalidation
+
+Historically, resource clients relied on manual invalidation lists:
+
+```ts
+const options = {
+  queryInvalidation: (queryKey) => [
+    { filters: { queryKey } },
+    SomeOtherQuery
+  ]
+}
+```
+
+That works, but it is easy to forget a query when a command starts touching
+another repository. The derived invalidation path records what data a query
+read and what data a command wrote, then invalidates cached queries whose
+recorded reads intersect the command writes.
+
+Manual invalidation still exists. Derived invalidation is an additional safety
+net for data dependencies that can be observed at runtime.
+
+## Mental model
+
+The unit of dependency is a `DataDependency`:
+
+```ts
+type DataDependency =
+  | { readonly type: "repo"; readonly name: string }
+  | { readonly type: "signal"; readonly name: string }
+```
+
+- `repo(name)` represents a repository namespace, usually the name passed to
+  `makeRepo(name, ...)`.
+- `signal(name)` is available for non-repository data that still needs a stable
+  invalidation topic.
+
+Each request has a `DataDependencyRecorder` in context. Code can record:
+
+```ts
+yield* DataDependencies.read(DataDependencies.repo("PickList"))
+yield* DataDependencies.write(DataDependencies.repo("PickList"))
+```
+
+Repository operations do this automatically, so most resource handlers do not
+need to call `DataDependencies.read` or `DataDependencies.write` directly.
+
+## End-to-end flow
+
+1. A query runs through the Vue query helper or RPC client.
+2. The request receives a fresh `DataDependencyRecorder`.
+3. Repository reads record `repo(<repository name>)` as a read dependency.
+4. The query result is returned with dependency metadata.
+5. The client stores the query's read dependencies next to the TanStack Query
+   cache entry.
+6. A command runs through the mutation helper or RPC client.
+7. Repository writes record `repo(<repository name>)` as a write dependency.
+8. The command response metadata carries the write dependencies back to the
+   client.
+9. Vue mutation invalidation scans the query cache and invalidates every query
+   whose recorded reads intersect the command writes.
+
+In short:
+
+```txt
+query reads RepoA       -> query cache remembers RepoA
+command writes RepoA    -> cached RepoA readers are invalidated
+command writes RepoB    -> cached RepoA readers are left alone
+```
+
+## What repositories record automatically
+
+`makeRepo` records dependencies at the repository boundary:
+
+| Repository operation | Dependency recorded |
+| -------------------- | ------------------- |
+| `all`                | read                |
+| `find`               | read                |
+| `query`              | read                |
+| `queryRaw`           | read                |
+| mapped `all`         | read                |
+| mapped `find`        | read                |
+| `saveAndPublish`     | write               |
+| `removeAndPublish`   | write               |
+| `removeById`         | write               |
+| mapped `save`        | write               |
+
+The dependency name is the repository name:
+
+```ts
+const Products = makeRepo("Product", Product, {})
+```
+
+Any query that reads `Products` records:
+
+```ts
+{ type: "repo", name: "Product" }
+```
+
+Any command that writes `Products` records the same dependency as a write.
+
+## RPC wire format
+
+The RPC layer wraps payloads internally so dependency metadata can cross the
+network without changing handler APIs.
+
+Commands still return their plain success value to callers, but the transport
+envelope includes:
+
+```ts
+{
+  invalidateQueries: InvalidationKey[],
+  dataDependencies: {
+    reads: DataDependency[],
+    writes: DataDependency[]
+  }
+}
+```
+
+Queries similarly return their plain payload to callers, while the RPC success
+schema carries:
+
+```ts
+{
+  payload: A,
+  metadata: {
+    dataDependencies: {
+      reads: DataDependency[],
+      writes: DataDependency[]
+    }
+  }
+}
+```
+
+The client unwraps these envelopes and forwards the dependency metadata into
+the local `DataDependencyRecorder`. This makes dependency propagation work for
+both direct RPC clients and the Vue query/mutation helpers.
+
+Stream commands emit dependency metadata in the same metadata chunks already
+used for server-driven invalidation keys. Writes can therefore invalidate
+queries mid-stream or when the stream completes.
+
+## Vue cache integration
+
+`makeQuery` runs each query under a fresh dependency recorder. After the handler
+returns, it stores the query's read dependencies next to matching TanStack Query
+cache entries.
+
+The implementation uses a `WeakMap<Query, DataDependencies>` rather than
+`query.meta`. TanStack Vue Query clones and reapplies observer options during
+fetching, so runtime-learned metadata written into `query.meta` can be
+overwritten by the observer's original options. The `WeakMap` is keyed by the
+actual cache entry, disappears when the query is garbage-collected, and does
+not affect TanStack's public options.
+
+`makeMutation` records command writes and combines three invalidation sources:
+
+1. client-side `queryInvalidation` options,
+2. server-provided invalidation keys,
+3. derived dependency invalidation.
+
+All targets are grouped into predicate-based `invalidateQueries` calls so the
+cache is not invalidated once per target when the options are equivalent.
+
+## Manual invalidation still matters
+
+Derived invalidation only sees what is recorded. Keep manual invalidation when:
+
+- a command changes data outside a repository,
+- a command affects an external service,
+- a query reads data that is not represented by a repository operation,
+- the relationship is semantic rather than data-access based,
+- a command should invalidate a broader UI namespace than the actual writes.
+
+Example:
+
+```ts
+const save = useMutation(SaveProduct, {
+  queryInvalidation: (queryKey) => [
+    { filters: { queryKey } },
+    DashboardSummary
+  ]
+})
+```
+
+The command will still derive repository-based invalidation. The manual
+`DashboardSummary` entry is added on top.
+
+## Recording non-repository dependencies
+
+Use `signal(name)` for data that has no repository boundary:
+
+```ts
+const ExchangeRates = DataDependencies.signal("ExchangeRates")
+
+const getPrices = Effect.fnUntraced(function*() {
+  yield* DataDependencies.read(ExchangeRates)
+  return yield* fetchPrices
+})
+
+const refreshRates = Effect.fnUntraced(function*() {
+  yield* updateRates
+  yield* DataDependencies.write(ExchangeRates)
+})
+```
+
+Any cached query that read `ExchangeRates` will be invalidated after a command
+writes `ExchangeRates`.
+
+Prefer repository dependencies when data is stored in a repository. Use signals
+for external APIs, computed projections, caches, feature flags, or other shared
+state that does not naturally pass through `makeRepo`.
+
+## Resource and operation subscriptions
+
+The important subscription is between a query cache entry and the dependencies
+it read at runtime. In practice, resources do not need a separate static
+"subscribe to repository" configuration if they actually access repositories
+through `makeRepo`.
+
+Static configuration can still be useful for virtual resources:
+
+- A query composes several external sources.
+- A command writes via a service that cannot record dependencies internally.
+- A resource's dependency is known but not visible from its implementation.
+
+In those cases, call `DataDependencies.read(signalOrRepo)` or
+`DataDependencies.write(signalOrRepo)` in the handler or service method. That
+keeps the dependency close to the real boundary instead of maintaining a
+separate invalidation list beside the resource declaration.
+
+## Precision and trade-offs
+
+Repository dependencies are intentionally repository-level, not row-level.
+
+If a query reads one `Product`, and a command writes a different `Product`, the
+query is invalidated because both depend on `repo("Product")`. This is less
+precise than row-level invalidation, but it is:
+
+- easy to derive reliably,
+- stable across query shapes,
+- hard to forget,
+- compatible with existing manual invalidation for broader or special cases.
+
+Row-level dependencies can be introduced later by adding another dependency
+shape, for example `{ type: "repo-item", name, id }`, but repository-level
+tracking gives most of the maintainability win without making every query key
+encode storage details.
+
+## Where the pieces live
+
+- `packages/effect-app/src/DataDependencies.ts`
+  - dependency schemas,
+  - recorder service,
+  - helpers for `repo`, `signal`, `read`, `write`, and `intersects`.
+- `packages/effect-app/src/Model/Repository/internal/internal.ts`
+  - automatic repository read/write recording.
+- `packages/effect-app/src/rpc/Invalidation.ts`
+  - metadata schemas for command/query/stream envelopes.
+- `packages/infra/src/routing.ts`
+  - per-request recorder wiring on the server.
+- `packages/effect-app/src/client/apiClientFactory.ts`
+  - client unwrapping and metadata forwarding.
+- `packages/vue/src/query.ts`
+  - query read dependency capture.
+- `packages/vue/src/dependencyMetadata.ts`
+  - WeakMap storage for TanStack Query cache entries.
+- `packages/vue/src/mutate.ts`
+  - derived invalidation from command writes.
+
+## Test coverage
+
+The main coverage is:
+
+- `packages/infra/test/repository-ext.test.ts`
+  - repository operations record expected reads and writes.
+- `packages/infra/test/rpc-e2e-invalidation.test.ts`
+  - dependency metadata survives the real HTTP/RPC client and server path.
+- `packages/vue/test/dependencyInvalidation.test.ts`
+  - Vue queries that recorded reads are invalidated when a mutation writes an
+    intersecting dependency.
+
+Useful focused commands:
+
+```sh
+pnpm --filter @effect-app/infra test -- rpc-e2e-invalidation.test.ts repository-ext.test.ts --runInBand
+pnpm --filter @effect-app/vue test -- dependencyInvalidation.test.ts --runInBand
+pnpm check
+```


### PR DESCRIPTION
## Summary
- add dependency recording for repository reads and writes
- propagate dependency metadata through RPC query/command envelopes
- derive Vue Query invalidation from query read deps intersecting command write deps
- add repository, RPC, and Vue invalidation coverage

## Validation
- pnpm lint-fix
- pnpm check
- pnpm --filter @effect-app/vue test -- dependencyInvalidation.test.ts --runInBand
- pnpm --filter @effect-app/infra test -- rpc-e2e-invalidation.test.ts repository-ext.test.ts --runInBand

Closes #778