### PR TITLE
Fix Vue suspense result timing race

### DIFF
--- a/.changeset/vue-suspense-result-race.md
+++ b/.changeset/vue-suspense-result-race.md
@@ -1,0 +1,5 @@
+---
+"@effect-app/vue": patch
+---
+
+Wait for Vue query result refs to settle after TanStack suspense resolves.

--- a/packages/vue/src/makeClient.ts
+++ b/packages/vue/src/makeClient.ts
@@ -22,6 +22,7 @@ import { type CommanderResolved, makeUseCommand } from "./makeUseCommand.js"
 import { type InvalidationEntry, makeMutation, makeStreamMutation2, type MutationOptionsBase, useMakeMutation } from "./mutate.js"
 import { type CustomUndefinedInitialQueryOptions, makeQuery, makeStreamQuery } from "./query.js"
 import { makeRunPromise } from "./runtime.js"
+import { awaitResolvedSuspenseResult } from "./suspense.js"
 import { type Toast } from "./toast.js"
 
 export type { Progress }
@@ -405,7 +406,7 @@ export class QueryImpl<R> {
         if (!isMounted.value) {
           return yield* Effect.interrupt
         }
-        const result = resultRef.value
+        const result = yield* awaitResolvedSuspenseResult(resultRef)
         if (AsyncResult.isInitial(result)) {
           console.error("Internal Error: Promise should be resolved already", {
             self,

--- a/packages/vue/src/suspense.ts
+++ b/packages/vue/src/suspense.ts
@@ -1,0 +1,17 @@
+import { Effect } from "effect-app"
+import * as AsyncResult from "effect/unstable/reactivity/AsyncResult"
+import { type ComputedRef, nextTick } from "vue"
+
+export const awaitResolvedSuspenseResult = <A, E>(
+  resultRef: ComputedRef<AsyncResult.AsyncResult<A, E>>
+) =>
+  Effect.gen(function*() {
+    let result = resultRef.value
+
+    for (let remainingTicks = 3; remainingTicks > 0 && AsyncResult.isInitial(result); remainingTicks--) {
+      yield* Effect.promise(() => nextTick())
+      result = resultRef.value
+    }
+
+    return result
+  })

--- a/packages/vue/test/suspense.test.ts
+++ b/packages/vue/test/suspense.test.ts
@@ -1,0 +1,20 @@
+import { Effect, Option } from "effect-app"
+import * as AsyncResult from "effect/unstable/reactivity/AsyncResult"
+import { computed, ref } from "vue"
+import { awaitResolvedSuspenseResult } from "../src/suspense.js"
+
+it("waits for the query result ref after suspense resolves", async () => {
+  const result = ref<AsyncResult.AsyncResult<number, never>>(AsyncResult.initial(true))
+  const promise = Effect.runPromise(awaitResolvedSuspenseResult(computed(() => result.value)))
+
+  result.value = AsyncResult.success(123)
+
+  expect(Option.getOrUndefined(AsyncResult.value(await promise))).toBe(123)
+})
+
+it("keeps unresolved query results initial", async () => {
+  const result = ref<AsyncResult.AsyncResult<number, never>>(AsyncResult.initial(true))
+  const settled = await Effect.runPromise(awaitResolvedSuspenseResult(computed(() => result.value)))
+
+  expect(AsyncResult.isInitial(settled)).toBe(true)
+})


### PR DESCRIPTION
## Why

A downstream Vue app hit `Internal Error: Promise should be resolved already` from `makeClient.suspense()` after the network requests had completed successfully.

The existing code assumes that once TanStack Query's `suspense()` promise resolves, the derived Vue `resultRef` has already flushed from `Initial` to success/failure in the same tick. The production evidence points at a narrower race: `suspense()` resolved, but the computed `AsyncResult` was still `Initial` when the invariant was checked.

This PR does not claim a full reproduction of TanStack/Vue internals. It makes the invariant tolerant of Vue flush timing while preserving the invariant for genuinely stuck query state.

## What

- Add `awaitResolvedSuspenseResult`, which waits a few Vue ticks while the query result ref is still `Initial`.
- Use it after `uqrt.suspense()` resolves and before checking the existing invariant.
- Keep the existing `Internal Error: Promise should be resolved already` failure if the result is still `Initial` after those ticks.

## How

The fix is intentionally conservative:

- Success/failure behavior is unchanged once `resultRef` has settled.
- Cancelled navigation still interrupts before result handling.
- A permanently unresolved query still fails loudly instead of being converted into success.

## Validation

- `cd packages/vue && pnpm lint-fix` (passes; existing warnings remain)
- `cd packages/vue && pnpm test:run suspense.test.ts`
- `cd packages/vue && pnpm check`
