### PR TITLE
Reduce schema type instantiations

### DIFF
--- a/.changeset/slow-structs-fold.md
+++ b/.changeset/slow-structs-fold.md
@@ -1,0 +1,5 @@
+---
+"@effect-app/infra": patch
+---
+
+Expose SQL repository failures in model helper error channels.

--- a/packages/infra/src/SQL/Model.ts
+++ b/packages/infra/src/SQL/Model.ts
@@ -9,6 +9,7 @@
  */
 import crypto from "crypto" // TODO
 import type { Brand } from "effect/Brand"
+import type * as Cause from "effect/Cause"
 import * as DateTime from "effect/DateTime"
 import type { Input } from "effect/Duration"
 import * as Effect from "effect/Effect"
@@ -22,6 +23,7 @@ import * as Transformation from "effect/SchemaTransformation"
 import type { Scope } from "effect/Scope"
 import * as VariantSchema from "effect/unstable/schema/VariantSchema"
 import { SqlClient } from "effect/unstable/sql/SqlClient"
+import type { SqlError } from "effect/unstable/sql/SqlError"
 import * as SqlResolver from "effect/unstable/sql/SqlResolver"
 import * as SqlSchema from "effect/unstable/sql/SqlSchema"
 import { type DbSystem, withDbSpan } from "../otel.js"
@@ -602,26 +604,34 @@ export const makeRepository = <
   {
     readonly insert: (
       insert: S["insert"]["Type"]
-    ) => Effect.Effect<S["Type"], Schema.SchemaError, S["DecodingServices"] | S["insert"]["EncodingServices"]>
+    ) => Effect.Effect<
+      S["Type"],
+      Schema.SchemaError | SqlError,
+      S["DecodingServices"] | S["insert"]["EncodingServices"]
+    >
     readonly insertVoid: (
       insert: S["insert"]["Type"]
-    ) => Effect.Effect<void, Schema.SchemaError, S["insert"]["EncodingServices"]>
+    ) => Effect.Effect<void, Schema.SchemaError | SqlError, S["insert"]["EncodingServices"]>
     readonly update: (
       update: S["update"]["Type"]
-    ) => Effect.Effect<S["Type"], Schema.SchemaError, S["DecodingServices"] | S["update"]["EncodingServices"]>
+    ) => Effect.Effect<
+      S["Type"],
+      Schema.SchemaError | SqlError,
+      S["DecodingServices"] | S["update"]["EncodingServices"]
+    >
     readonly updateVoid: (
       update: S["update"]["Type"]
-    ) => Effect.Effect<void, Schema.SchemaError, S["update"]["EncodingServices"]>
+    ) => Effect.Effect<void, Schema.SchemaError | SqlError, S["update"]["EncodingServices"]>
     readonly findById: (
       id: S["fields"][Id]["Type"]
     ) => Effect.Effect<
       Option.Option<S["Type"]>,
-      Schema.SchemaError,
+      Schema.SchemaError | SqlError,
       S["DecodingServices"] | S["fields"][Id]["EncodingServices"]
     >
     readonly delete: (
       id: S["fields"][Id]["Type"]
-    ) => Effect.Effect<void, Schema.SchemaError, S["fields"][Id]["EncodingServices"]>
+    ) => Effect.Effect<void, Schema.SchemaError | SqlError, S["fields"][Id]["EncodingServices"]>
   },
   never,
   SqlClient
@@ -658,11 +668,15 @@ select * from ${sql(options.tableName)} where ${sql(idColumn)} = LAST_INSERT_ID(
     })
     const insert = (
       insert: S["insert"]["Type"]
-    ): Effect.Effect<S["Type"], Schema.SchemaError, S["DecodingServices"] | S["insert"]["EncodingServices"]> =>
+    ): Effect.Effect<
+      S["Type"],
+      Schema.SchemaError | SqlError,
+      S["DecodingServices"] | S["insert"]["EncodingServices"]
+    > =>
       insertSchema(insert).pipe(
         Effect.catchTag("NoSuchElementError", Effect.die),
         opSpan("insert")
-      ) as any
+      )
 
     const insertVoidSchema = SqlSchema.void({
       Request: Model.insert,
@@ -670,10 +684,10 @@ select * from ${sql(options.tableName)} where ${sql(idColumn)} = LAST_INSERT_ID(
     })
     const insertVoid = (
       insert: S["insert"]["Type"]
-    ): Effect.Effect<void, Schema.SchemaError, S["insert"]["EncodingServices"]> =>
+    ): Effect.Effect<void, Schema.SchemaError | SqlError, S["insert"]["EncodingServices"]> =>
       insertVoidSchema(insert).pipe(
         opSpan("insertVoid")
-      ) as any
+      )
 
     const updateSchema = SqlSchema.findOne({
       Request: Model.update,
@@ -716,11 +730,15 @@ select * from ${sql(options.tableName)} where ${sql(idColumn)} = ${request[idCol
     })
     const update = (
       update: S["update"]["Type"]
-    ): Effect.Effect<S["Type"], Schema.SchemaError, S["DecodingServices"] | S["update"]["EncodingServices"]> =>
+    ): Effect.Effect<
+      S["Type"],
+      Schema.SchemaError | SqlError,
+      S["DecodingServices"] | S["update"]["EncodingServices"]
+    > =>
       updateSchema(update).pipe(
         Effect.catchTag("NoSuchElementError", Effect.die),
         opSpan("update", (update as any)[idColumn])
-      ) as any
+      )
 
     const updateVoidSchema = SqlSchema.void({
       Request: Model.update,
@@ -736,10 +754,10 @@ select * from ${sql(options.tableName)} where ${sql(idColumn)} = ${request[idCol
     })
     const updateVoid = (
       update: S["update"]["Type"]
-    ): Effect.Effect<void, Schema.SchemaError, S["update"]["EncodingServices"]> =>
+    ): Effect.Effect<void, Schema.SchemaError | SqlError, S["update"]["EncodingServices"]> =>
       updateVoidSchema(update).pipe(
         opSpan("updateVoid", (update as any)[idColumn])
-      ) as any
+      )
 
     const findByIdSchema = SqlSchema.findOneOption({
       Request: idSchema,
@@ -750,12 +768,12 @@ select * from ${sql(options.tableName)} where ${sql(idColumn)} = ${request[idCol
       id: S["fields"][Id]["Type"]
     ): Effect.Effect<
       Option.Option<S["Type"]>,
-      Schema.SchemaError,
+      Schema.SchemaError | SqlError,
       S["DecodingServices"] | S["fields"][Id]["EncodingServices"]
     > =>
       findByIdSchema(id).pipe(
         opSpan("findById", id)
-      ) as any
+      )
 
     const deleteSchema = SqlSchema.void({
       Request: idSchema,
@@ -763,10 +781,10 @@ select * from ${sql(options.tableName)} where ${sql(idColumn)} = ${request[idCol
     })
     const delete_ = (
       id: S["fields"][Id]["Type"]
-    ): Effect.Effect<void, Schema.SchemaError, S["fields"][Id]["EncodingServices"]> =>
+    ): Effect.Effect<void, Schema.SchemaError | SqlError, S["fields"][Id]["EncodingServices"]> =>
       deleteSchema(id).pipe(
         opSpan("delete", id)
-      ) as any
+      )
 
     return { insert, insertVoid, update, updateVoid, findById, delete: delete_ } as const
   })
@@ -796,22 +814,22 @@ export const makeDataLoaders = <
       insert: S["insert"]["Type"]
     ) => Effect.Effect<
       S["Type"],
-      Schema.SchemaError,
+      Schema.SchemaError | SqlError,
       S["DecodingServices"] | S["insert"]["EncodingServices"]
     >
     readonly insertVoid: (
       insert: S["insert"]["Type"]
-    ) => Effect.Effect<void, Schema.SchemaError, S["insert"]["EncodingServices"]>
+    ) => Effect.Effect<void, Schema.SchemaError | SqlError, S["insert"]["EncodingServices"]>
     readonly findById: (
       id: S["fields"][Id]["Type"]
     ) => Effect.Effect<
       S["Type"],
-      Schema.SchemaError,
+      Cause.NoSuchElementError | Schema.SchemaError | SqlError,
       S["DecodingServices"] | S["fields"][Id]["EncodingServices"]
     >
     readonly delete: (
       id: S["fields"][Id]["Type"]
-    ) => Effect.Effect<void, Schema.SchemaError, S["fields"][Id]["EncodingServices"]>
+    ) => Effect.Effect<void, Schema.SchemaError | SqlError, S["fields"][Id]["EncodingServices"]>
   },
   never,
   SqlClient | Scope
@@ -858,13 +876,13 @@ select * from ${sql(options.tableName)} where ${sql(idColumn)} = LAST_INSERT_ID(
       insert: S["insert"]["Type"]
     ): Effect.Effect<
       S["Type"],
-      Schema.SchemaError,
+      Schema.SchemaError | SqlError,
       S["DecodingServices"] | S["insert"]["EncodingServices"]
     > =>
       insertExecute(insert).pipe(
         Effect.catchTag("ResultLengthMismatch", Effect.die),
         opSpan("insert")
-      ) as any
+      )
 
     const insertVoidResolver = SqlResolver
       .void({
@@ -879,10 +897,10 @@ select * from ${sql(options.tableName)} where ${sql(idColumn)} = LAST_INSERT_ID(
     const insertVoidExecute = SqlResolver.request(insertVoidResolver)
     const insertVoid = (
       insert: S["insert"]["Type"]
-    ): Effect.Effect<void, Schema.SchemaError, S["insert"]["EncodingServices"]> =>
+    ): Effect.Effect<void, Schema.SchemaError | SqlError, S["insert"]["EncodingServices"]> =>
       insertVoidExecute(insert).pipe(
         opSpan("insertVoid")
-      ) as any
+      )
 
     const findByIdResolver = SqlResolver
       .findById({
@@ -903,12 +921,12 @@ select * from ${sql(options.tableName)} where ${sql(idColumn)} = LAST_INSERT_ID(
       id: S["fields"][Id]["Type"]
     ): Effect.Effect<
       S["Type"],
-      Schema.SchemaError,
+      Cause.NoSuchElementError | Schema.SchemaError | SqlError,
       S["DecodingServices"] | S["fields"][Id]["EncodingServices"]
     > =>
       findByIdExecute(id).pipe(
         opSpan("findById", id)
-      ) as any
+      )
 
     const deleteResolver = SqlResolver
       .void({
@@ -923,10 +941,10 @@ select * from ${sql(options.tableName)} where ${sql(idColumn)} = LAST_INSERT_ID(
     const deleteExecute = SqlResolver.request(deleteResolver)
     const delete_ = (
       id: S["fields"][Id]["Type"]
-    ): Effect.Effect<void, Schema.SchemaError, S["fields"][Id]["EncodingServices"]> =>
+    ): Effect.Effect<void, Schema.SchemaError | SqlError, S["fields"][Id]["EncodingServices"]> =>
       deleteExecute(id).pipe(
         opSpan("delete", id)
-      ) as any
+      )
 
     return { insert, insertVoid, findById, delete: delete_ } as const
   })

--- a/packages/infra/src/Store/SQL.ts
+++ b/packages/infra/src/Store/SQL.ts
@@ -147,7 +147,7 @@ function makeSQLStoreInt(system: DbSystem, dialect: SQLDialect, jsonColumnType: 
             .withTransaction(Effect.forEach(items, (e) => setInternal(e, ns)))
             .pipe(
               Effect.orDie,
-              Effect.map((_) => _ as unknown as NonEmptyReadonlyArray<PM>)
+              Effect.map((_) => _ as NonEmptyReadonlyArray<PM>)
             )
 
         const ctx = yield* Effect.context<R>()
@@ -478,7 +478,7 @@ function makeSQLiteStorePerNs(
             .withTransaction(Effect.forEach(items, (e) => setInternal(e, ns)))
             .pipe(
               Effect.orDie,
-              Effect.map((_) => _ as unknown as NonEmptyReadonlyArray<PM>)
+              Effect.map((_) => _ as NonEmptyReadonlyArray<PM>)
             ))
 
       const ctx = yield* Effect.context<R>()

--- a/packages/infra/src/Store/SQL/Pg.ts
+++ b/packages/infra/src/Store/SQL/Pg.ts
@@ -131,7 +131,7 @@ const makePgStore = Effect.fnUntraced(function*({ prefix }: StorageConfig) {
           .withTransaction(Effect.forEach(items, (e) => setInternal(e, ns)))
           .pipe(
             Effect.orDie,
-            Effect.map((_) => _ as unknown as NonEmptyReadonlyArray<PM>)
+            Effect.map((_) => _ as NonEmptyReadonlyArray<PM>)
           )
 
       const ctx = yield* Effect.context<R>()

--- a/repos/effect/packages/effect/src/Schema.ts
+++ b/repos/effect/packages/effect/src/Schema.ts
@@ -2825,11 +2825,15 @@ export declare namespace Struct {
     F extends Fields,
     O extends keyof F = TypeOptionalKeys<F>,
     M extends keyof F = TypeMutableKeys<F>
-  > =
-    & { readonly [K in keyof F as K extends M | O ? never : K]: F[K]["Type"] }
-    & { readonly [K in keyof F as K extends O ? K extends M ? never : K : never]?: F[K]["Type"] }
-    & { -readonly [K in keyof F as K extends M ? K extends O ? never : K : never]: F[K]["Type"] }
-    & { -readonly [K in keyof F as K extends M & O ? K : never]?: F[K]["Type"] }
+  > = [M] extends [never] ? [O] extends [never] ? { readonly [K in keyof F]: F[K]["Type"] }
+    :
+      & { readonly [K in keyof F as K extends O ? never : K]: F[K]["Type"] }
+      & { readonly [K in keyof F as K extends O ? K : never]?: F[K]["Type"] }
+    :
+      & { readonly [K in keyof F as K extends M | O ? never : K]: F[K]["Type"] }
+      & { readonly [K in keyof F as K extends O ? K extends M ? never : K : never]?: F[K]["Type"] }
+      & { -readonly [K in keyof F as K extends M ? K extends O ? never : K : never]: F[K]["Type"] }
+      & { -readonly [K in keyof F as K extends M & O ? K : never]?: F[K]["Type"] }
 
   /**
    * Computes the decoded object type for a struct field map.
@@ -2842,17 +2846,21 @@ export declare namespace Struct {
    * @category utility types
    * @since 3.10.0
    */
-  export type Type<F extends Fields> = Simplify<Type_<F>>
+  export type Type<F extends Fields> = Type_<F>
 
   type Iso_<
     F extends Fields,
     O extends keyof F = TypeOptionalKeys<F>,
     M extends keyof F = TypeMutableKeys<F>
-  > =
-    & { readonly [K in keyof F as K extends M | O ? never : K]: F[K]["Iso"] }
-    & { readonly [K in keyof F as K extends O ? K extends M ? never : K : never]?: F[K]["Iso"] }
-    & { -readonly [K in keyof F as K extends M ? K extends O ? never : K : never]: F[K]["Iso"] }
-    & { -readonly [K in keyof F as K extends M & O ? K : never]?: F[K]["Iso"] }
+  > = [M] extends [never] ? [O] extends [never] ? { readonly [K in keyof F]: F[K]["Iso"] }
+    :
+      & { readonly [K in keyof F as K extends O ? never : K]: F[K]["Iso"] }
+      & { readonly [K in keyof F as K extends O ? K : never]?: F[K]["Iso"] }
+    :
+      & { readonly [K in keyof F as K extends M | O ? never : K]: F[K]["Iso"] }
+      & { readonly [K in keyof F as K extends O ? K extends M ? never : K : never]?: F[K]["Iso"] }
+      & { -readonly [K in keyof F as K extends M ? K extends O ? never : K : never]: F[K]["Iso"] }
+      & { -readonly [K in keyof F as K extends M & O ? K : never]?: F[K]["Iso"] }
 
   /**
    * Computes the iso object type for a struct field map from each field schema's
@@ -2866,7 +2874,7 @@ export declare namespace Struct {
    * @category utility types
    * @since 4.0.0
    */
-  export type Iso<F extends Fields> = Simplify<Iso_<F>>
+  export type Iso<F extends Fields> = Iso_<F>
 
   type EncodedOptionalKeys<Fields extends Struct.Fields> = {
     [K in keyof Fields]: Fields[K] extends { readonly "~encoded.optionality": "optional" } ? K
@@ -2882,11 +2890,15 @@ export declare namespace Struct {
     F extends Fields,
     O extends keyof F = EncodedOptionalKeys<F>,
     M extends keyof F = EncodedMutableKeys<F>
-  > =
-    & { readonly [K in keyof F as K extends M | O ? never : K]: F[K]["Encoded"] }
-    & { readonly [K in keyof F as K extends O ? K extends M ? never : K : never]?: F[K]["Encoded"] }
-    & { -readonly [K in keyof F as K extends M ? K extends O ? never : K : never]: F[K]["Encoded"] }
-    & { -readonly [K in keyof F as K extends M & O ? K : never]?: F[K]["Encoded"] }
+  > = [M] extends [never] ? [O] extends [never] ? { readonly [K in keyof F]: F[K]["Encoded"] }
+    :
+      & { readonly [K in keyof F as K extends O ? never : K]: F[K]["Encoded"] }
+      & { readonly [K in keyof F as K extends O ? K : never]?: F[K]["Encoded"] }
+    :
+      & { readonly [K in keyof F as K extends M | O ? never : K]: F[K]["Encoded"] }
+      & { readonly [K in keyof F as K extends O ? K extends M ? never : K : never]?: F[K]["Encoded"] }
+      & { -readonly [K in keyof F as K extends M ? K extends O ? never : K : never]: F[K]["Encoded"] }
+      & { -readonly [K in keyof F as K extends M & O ? K : never]?: F[K]["Encoded"] }
 
   /**
    * Computes the encoded object type for a struct field map.
@@ -2900,7 +2912,7 @@ export declare namespace Struct {
    * @category utility types
    * @since 3.10.0
    */
-  export type Encoded<F extends Fields> = Simplify<Encoded_<F>>
+  export type Encoded<F extends Fields> = Encoded_<F>
 
   /**
    * Union of all decoding service requirements needed by the schemas in a struct
@@ -2928,9 +2940,10 @@ export declare namespace Struct {
   type MakeIn_<
     F extends Fields,
     O = TypeOptionalKeys<F> | TypeConstructorDefaultedKeys<F>
-  > =
-    & { readonly [K in keyof F as K extends O ? never : K]: F[K]["~type.make"] }
-    & { readonly [K in keyof F as K extends O ? K : never]?: F[K]["~type.make"] }
+  > = [O] extends [never] ? { readonly [K in keyof F]: F[K]["~type.make"] }
+    :
+      & { readonly [K in keyof F as K extends O ? never : K]: F[K]["~type.make"] }
+      & { readonly [K in keyof F as K extends O ? K : never]?: F[K]["~type.make"] }
 
   /**
    * Computes the input object type accepted when constructing a struct value.
@@ -2943,7 +2956,7 @@ export declare namespace Struct {
    * @category utility types
    * @since 4.0.0
    */
-  export type MakeIn<F extends Fields> = Simplify<MakeIn_<F>>
+  export type MakeIn<F extends Fields> = MakeIn_<F>
 }
 
 /**


### PR DESCRIPTION
## Summary
- reduce Effect struct schema type instantiations by avoiding unnecessary mapped-type simplification and adding common fast paths
- expose SQL repository `SqlError` / `NoSuchElementError` failures instead of relying on casts

## Validation
- `pnpm lint-fix`
- `pnpm check`
- `pnpm --dir packages/effect-app test run test/schema.test.ts`
- `pnpm --dir repos/effect test-types packages/effect/typetest/schema/Struct.tst.ts packages/effect/typetest/schema/toIso.tst.ts packages/effect/typetest/schema/Schema.tst.ts`

## Notes
Measured the linked local Effect source on the struct repro: schema-only instantiations dropped from ~696k to ~633k, and `StructNestedEncoded` dropped from ~699k to ~634k.

I also benchmarked an app-level `Schema.Opaque<..., never>` service-collapse escape hatch in a single-process `tsc --extendedDiagnostics --incremental false` setup. It did not improve instantiations versus inferred Opaque services, so that experiment is intentionally not included.