### PR TITLE
feat(store): typed serializable DatabaseError for adapter failures

### DIFF
--- a/.changeset/typed-database-error.md
+++ b/.changeset/typed-database-error.md
@@ -1,0 +1,8 @@
+---
+"effect-app": minor
+"@effect-app/infra": minor
+---
+
+Add a typed, serializable `DatabaseError { message, transient, cause }` for store adapter failures.
+
+Store adapters wrapped DB calls in bare `Effect.promise` / `.orDie`, so a transient infra failure (request timeout, throttle, 5xx, dropped socket) became a raw-`Error` defect — which `Effect.retry` can't retry and which breaks JSON encoding of a workflow exit cause ("Expected JSON value, got Error"). `DatabaseError` is now exposed on all `Store` and `Repository` method error channels (writes: `OptimisticConcurrencyException | DatabaseError`) and added to `SupportedErrors` so the api/client/FE treat it as a 500-class error. Each adapter wraps its db-call failures into `DatabaseError` with a `transient` flag (timeout/throttle/5xx ⇒ retryable); the `cause` serializes via `Schema.Defect`. Construction/seed/DDL paths stay `orDie`.

--- a/packages/effect-app/src/Model/Repository/Registry.ts
+++ b/packages/effect-app/src/Model/Repository/Registry.ts
@@ -1,8 +1,9 @@
+import type { DatabaseError } from "../../client/errors.js"
 import * as Context from "../../Context.js"
 import * as Effect from "../../Effect.js"
 
 export interface RegisteredRepository {
-  readonly seedNamespace: (namespace: string) => Effect.Effect<void>
+  readonly seedNamespace: (namespace: string) => Effect.Effect<void, DatabaseError>
 }
 
 const make = Effect.sync(() => {
@@ -27,7 +28,7 @@ const make = Effect.sync(() => {
 
 export class RepositoryRegistry extends Context.Opaque<RepositoryRegistry, {
   readonly register: (modelName: string, repo: RegisteredRepository) => void
-  readonly seedNamespace: (namespace: string) => Effect.Effect<void>
+  readonly seedNamespace: (namespace: string) => Effect.Effect<void, DatabaseError>
   readonly entries: ReadonlyMap<string, RegisteredRepository>
 }>()("effect-app/RepositoryRegistry", { make }) {}
 

--- a/packages/effect-app/src/Model/Repository/legacy.ts
+++ b/packages/effect-app/src/Model/Repository/legacy.ts
@@ -1,19 +1,19 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-import type { OptimisticConcurrencyException } from "../../client/errors.js"
+import type { DatabaseError, OptimisticConcurrencyException } from "../../client/errors.js"
 import type * as Effect from "../../Effect.js"
 import type * as Option from "../../Option.js"
 import type * as S from "../../Schema.js"
 
 export interface Mapped1<A, IdKey extends keyof A, R> {
-  all: Effect.Effect<A[], S.SchemaError, R>
-  save: (...xes: readonly A[]) => Effect.Effect<void, OptimisticConcurrencyException | S.SchemaError, R>
-  find: (id: A[IdKey]) => Effect.Effect<Option.Option<A>, S.SchemaError, R>
+  all: Effect.Effect<A[], S.SchemaError | DatabaseError, R>
+  save: (...xes: readonly A[]) => Effect.Effect<void, OptimisticConcurrencyException | S.SchemaError | DatabaseError, R>
+  find: (id: A[IdKey]) => Effect.Effect<Option.Option<A>, S.SchemaError | DatabaseError, R>
 }
 
 // TODO: auto use project, and select fields from the From side of schema only
 export interface Mapped2<A, R> {
-  all: Effect.Effect<A[], S.SchemaError, R>
+  all: Effect.Effect<A[], S.SchemaError | DatabaseError, R>
 }
 
 export interface Mapped<Encoded> {

--- a/packages/effect-app/src/Model/Repository/service.ts
+++ b/packages/effect-app/src/Model/Repository/service.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type * as Scope from "effect/Scope"
-import type { InvalidStateError, NotFoundError, OptimisticConcurrencyException } from "../../client/errors.js"
+import type { DatabaseError, InvalidStateError, NotFoundError, OptimisticConcurrencyException } from "../../client/errors.js"
 import type * as Effect from "../../Effect.js"
 import type * as Option from "../../Option.js"
 import type * as S from "../../Schema.js"
@@ -49,32 +49,32 @@ export interface Repository<
 > {
   readonly itemType: ItemType
   readonly idKey: IdKey
-  readonly find: (id: T[IdKey]) => Effect.Effect<Option.Option<T>, never, RSchema>
-  readonly all: Effect.Effect<T[], never, RSchema>
+  readonly find: (id: T[IdKey]) => Effect.Effect<Option.Option<T>, DatabaseError, RSchema>
+  readonly all: Effect.Effect<T[], DatabaseError, RSchema>
   readonly saveAndPublish: (
     items: Iterable<T>,
     events?: Iterable<Evt>
-  ) => Effect.Effect<void, InvalidStateError | OptimisticConcurrencyException, RSchema | RPublish>
+  ) => Effect.Effect<void, InvalidStateError | OptimisticConcurrencyException | DatabaseError, RSchema | RPublish>
   readonly changeFeed: ChangeFeed<T>
   readonly removeAndPublish: (
     items: Iterable<T>,
     events?: Iterable<Evt>
-  ) => Effect.Effect<void, never, RSchema | RPublish>
+  ) => Effect.Effect<void, DatabaseError, RSchema | RPublish>
 
   readonly removeById: (
     idOrIds: T[IdKey] | ReadonlyArray<T[IdKey]>
-  ) => Effect.Effect<void, never, RSchema>
+  ) => Effect.Effect<void, DatabaseError, RSchema>
 
   readonly queryRaw: <T, Out, R>(
     schema: S.Codec<T, Out, R>,
     raw: RawQuery<Encoded, Out>
-  ) => Effect.Effect<readonly T[], S.SchemaError, R>
+  ) => Effect.Effect<readonly T[], S.SchemaError | DatabaseError, R>
 
   /**
    * Explicitly seed a namespace. Primary is seeded eagerly on initialization.
    * Non-primary namespaces must be seeded explicitly before use.
    */
-  readonly seedNamespace: (namespace: string) => Effect.Effect<void>
+  readonly seedNamespace: (namespace: string) => Effect.Effect<void, DatabaseError>
 
   readonly query: {
     // ending with projection
@@ -91,7 +91,8 @@ export interface Repository<
     ): Effect.Effect<
       TType extends "many" ? readonly A[] : TType extends "count" ? NonNegativeInt : A,
       | (TType extends "many" ? never : NotFoundError<ItemType>)
-      | (TType extends "count" ? never : S.SchemaError),
+      | (TType extends "count" ? never : S.SchemaError)
+      | DatabaseError,
       Exclude<R, RProvided> | RSchema
     >
     <
@@ -111,7 +112,8 @@ export interface Repository<
     ): Effect.Effect<
       TType extends "many" ? readonly A[] : TType extends "count" ? NonNegativeInt : A,
       | (TType extends "many" ? never : NotFoundError<ItemType>)
-      | (TType extends "count" ? never : S.SchemaError),
+      | (TType extends "count" ? never : S.SchemaError)
+      | DatabaseError,
       Exclude<R, RProvided> | RSchema
     >
     <
@@ -133,7 +135,8 @@ export interface Repository<
     ): Effect.Effect<
       TType extends "many" ? readonly A[] : TType extends "count" ? NonNegativeInt : A,
       | (TType extends "many" ? never : NotFoundError<ItemType>)
-      | (TType extends "count" ? never : S.SchemaError),
+      | (TType extends "count" ? never : S.SchemaError)
+      | DatabaseError,
       Exclude<R, RProvided> | RSchema
     >
     <
@@ -157,7 +160,8 @@ export interface Repository<
     ): Effect.Effect<
       TType extends "many" ? readonly A[] : TType extends "count" ? NonNegativeInt : A,
       | (TType extends "many" ? never : NotFoundError<ItemType>)
-      | (TType extends "count" ? never : S.SchemaError),
+      | (TType extends "count" ? never : S.SchemaError)
+      | DatabaseError,
       Exclude<R, RProvided> | RSchema
     >
     <
@@ -183,7 +187,8 @@ export interface Repository<
     ): Effect.Effect<
       TType extends "many" ? readonly A[] : TType extends "count" ? NonNegativeInt : A,
       | (TType extends "many" ? never : NotFoundError<ItemType>)
-      | (TType extends "count" ? never : S.SchemaError),
+      | (TType extends "count" ? never : S.SchemaError)
+      | DatabaseError,
       Exclude<R, RProvided> | RSchema
     >
     <
@@ -209,7 +214,8 @@ export interface Repository<
     ): Effect.Effect<
       TType extends "many" ? readonly A[] : TType extends "count" ? NonNegativeInt : A,
       | (TType extends "many" ? never : NotFoundError<ItemType>)
-      | (TType extends "count" ? never : S.SchemaError),
+      | (TType extends "count" ? never : S.SchemaError)
+      | DatabaseError,
       Exclude<R, RProvided> | RSchema
     >
     <
@@ -237,7 +243,8 @@ export interface Repository<
     ): Effect.Effect<
       TType extends "many" ? readonly A[] : TType extends "count" ? NonNegativeInt : A,
       | (TType extends "many" ? never : NotFoundError<ItemType>)
-      | (TType extends "count" ? never : S.SchemaError),
+      | (TType extends "count" ? never : S.SchemaError)
+      | DatabaseError,
       Exclude<R, RProvided> | RSchema
     >
     <
@@ -267,7 +274,8 @@ export interface Repository<
     ): Effect.Effect<
       TType extends "many" ? readonly A[] : TType extends "count" ? NonNegativeInt : A,
       | (TType extends "many" ? never : NotFoundError<ItemType>)
-      | (TType extends "count" ? never : S.SchemaError),
+      | (TType extends "count" ? never : S.SchemaError)
+      | DatabaseError,
       Exclude<R, RProvided> | RSchema
     >
     <
@@ -299,7 +307,8 @@ export interface Repository<
     ): Effect.Effect<
       TType extends "many" ? readonly A[] : TType extends "count" ? NonNegativeInt : A,
       | (TType extends "many" ? never : NotFoundError<ItemType>)
-      | (TType extends "count" ? never : S.SchemaError),
+      | (TType extends "count" ? never : S.SchemaError)
+      | DatabaseError,
       Exclude<R, RProvided> | RSchema
     >
     <
@@ -333,7 +342,8 @@ export interface Repository<
     ): Effect.Effect<
       TType extends "many" ? readonly A[] : TType extends "count" ? NonNegativeInt : A,
       | (TType extends "many" ? never : NotFoundError<ItemType>)
-      | (TType extends "count" ? never : S.SchemaError),
+      | (TType extends "count" ? never : S.SchemaError)
+      | DatabaseError,
       Exclude<R, RProvided> | RSchema
     >
 
@@ -347,7 +357,7 @@ export interface Repository<
       q: (initial: Query<Encoded>) => QAll<Encoded, EncodedRefined, RefineTHelper<T, EncodedRefined>, R, TType, E>
     ): Effect.Effect<
       TType extends "many" ? DistributeQueryIfExclusiveOnArray<E, T, EncodedRefined> : RefineTHelper<T, EncodedRefined>,
-      TType extends "many" ? never : NotFoundError<ItemType>,
+      (TType extends "many" ? never : NotFoundError<ItemType>) | DatabaseError,
       Exclude<R, RProvided> | RSchema
     >
     <
@@ -363,7 +373,7 @@ export interface Repository<
       ) => QAll<Encoded, EncodedRefined, RefineTHelper<T, EncodedRefined>, R, TType, E>
     ): Effect.Effect<
       TType extends "many" ? DistributeQueryIfExclusiveOnArray<E, T, EncodedRefined> : RefineTHelper<T, EncodedRefined>,
-      TType extends "many" ? never : NotFoundError<ItemType>,
+      (TType extends "many" ? never : NotFoundError<ItemType>) | DatabaseError,
       Exclude<R, RProvided> | RSchema
     >
     <
@@ -383,7 +393,7 @@ export interface Repository<
       ) => QAll<Encoded, EncodedRefined, RefineTHelper<T, EncodedRefined>, R, TType, E>
     ): Effect.Effect<
       TType extends "many" ? DistributeQueryIfExclusiveOnArray<E, T, EncodedRefined> : RefineTHelper<T, EncodedRefined>,
-      TType extends "many" ? never : NotFoundError<ItemType>,
+      (TType extends "many" ? never : NotFoundError<ItemType>) | DatabaseError,
       Exclude<R, RProvided> | RSchema
     >
     <
@@ -403,7 +413,7 @@ export interface Repository<
       ) => QAll<Encoded, EncodedRefined, RefineTHelper<T, EncodedRefined>, R, TType, E>
     ): Effect.Effect<
       TType extends "many" ? DistributeQueryIfExclusiveOnArray<E, T, EncodedRefined> : RefineTHelper<T, EncodedRefined>,
-      TType extends "many" ? never : NotFoundError<ItemType>,
+      (TType extends "many" ? never : NotFoundError<ItemType>) | DatabaseError,
       Exclude<R, RProvided> | RSchema
     >
     <
@@ -425,7 +435,7 @@ export interface Repository<
       ) => QAll<Encoded, EncodedRefined, RefineTHelper<T, EncodedRefined>, R, TType, E>
     ): Effect.Effect<
       TType extends "many" ? DistributeQueryIfExclusiveOnArray<E, T, EncodedRefined> : RefineTHelper<T, EncodedRefined>,
-      TType extends "many" ? never : NotFoundError<ItemType>,
+      (TType extends "many" ? never : NotFoundError<ItemType>) | DatabaseError,
       Exclude<R, RProvided> | RSchema
     >
     <
@@ -449,7 +459,7 @@ export interface Repository<
       ) => QAll<Encoded, EncodedRefined, RefineTHelper<T, EncodedRefined>, R, TType, E>
     ): Effect.Effect<
       TType extends "many" ? DistributeQueryIfExclusiveOnArray<E, T, EncodedRefined> : RefineTHelper<T, EncodedRefined>,
-      TType extends "many" ? never : NotFoundError<ItemType>,
+      (TType extends "many" ? never : NotFoundError<ItemType>) | DatabaseError,
       Exclude<R, RProvided> | RSchema
     >
     <
@@ -475,7 +485,7 @@ export interface Repository<
       ) => QAll<Encoded, EncodedRefined, RefineTHelper<T, EncodedRefined>, R, TType, E>
     ): Effect.Effect<
       TType extends "many" ? DistributeQueryIfExclusiveOnArray<E, T, EncodedRefined> : RefineTHelper<T, EncodedRefined>,
-      TType extends "many" ? never : NotFoundError<ItemType>,
+      (TType extends "many" ? never : NotFoundError<ItemType>) | DatabaseError,
       Exclude<R, RProvided> | RSchema
     >
     <
@@ -504,7 +514,7 @@ export interface Repository<
     ): Effect.Effect<
       TType extends "many" ? DistributeQueryIfExclusiveOnArray<E, T, EncodedRefined>
         : RefineTHelper<T, EncodedRefined>,
-      TType extends "many" ? never : NotFoundError<ItemType>,
+      (TType extends "many" ? never : NotFoundError<ItemType>) | DatabaseError,
       Exclude<R, RProvided> | RSchema
     >
     <
@@ -535,7 +545,7 @@ export interface Repository<
     ): Effect.Effect<
       TType extends "many" ? DistributeQueryIfExclusiveOnArray<E, T, EncodedRefined>
         : RefineTHelper<T, EncodedRefined>,
-      TType extends "many" ? never : NotFoundError<ItemType>,
+      (TType extends "many" ? never : NotFoundError<ItemType>) | DatabaseError,
       Exclude<R, RProvided> | RSchema
     >
     <
@@ -568,7 +578,7 @@ export interface Repository<
     ): Effect.Effect<
       TType extends "many" ? DistributeQueryIfExclusiveOnArray<E, T, EncodedRefined>
         : RefineTHelper<T, EncodedRefined>,
-      TType extends "many" ? never : NotFoundError<ItemType>,
+      (TType extends "many" ? never : NotFoundError<ItemType>) | DatabaseError,
       Exclude<R, RProvided> | RSchema
     >
   }
@@ -585,7 +595,7 @@ export interface Repository<
     percentage?: number
     /** optional maximum number of items to sample */
     maxItems?: number
-  }) => Effect.Effect<ValidationResult, never, RSchema>
+  }) => Effect.Effect<ValidationResult, DatabaseError, RSchema>
 }
 
 type DistributeQueryIfExclusiveOnArray<Exclusive extends boolean, T, EncodedRefined> = [Exclusive] extends [true]

--- a/packages/effect-app/src/Store.ts
+++ b/packages/effect-app/src/Store.ts
@@ -3,7 +3,7 @@ import * as Data from "effect/Data"
 import type * as Redacted from "effect/Redacted"
 import * as Semaphore from "effect/Semaphore"
 import type { NonEmptyReadonlyArray } from "./Array.js"
-import type { OptimisticConcurrencyException } from "./client/errors.js"
+import type { DatabaseError, OptimisticConcurrencyException } from "./client/errors.js"
 import * as Context from "./Context.js"
 import * as Effect from "./Effect.js"
 import * as Layer from "./Layer.js"
@@ -99,30 +99,30 @@ export interface FilterArgs<Encoded extends FieldValues, U extends keyof Encoded
 
 export type FilterFunc<Encoded extends FieldValues> = <U extends keyof Encoded = never>(
   args: FilterArgs<Encoded, U>
-) => Effect.Effect<(U extends undefined ? Encoded : Pick<Encoded, U>)[]>
+) => Effect.Effect<(U extends undefined ? Encoded : Pick<Encoded, U>)[], DatabaseError>
 
 export interface Store<
   IdKey extends keyof Encoded,
   Encoded extends FieldValues,
   PM extends PersistenceModelType<Encoded> = PersistenceModelType<Encoded>
 > {
-  all: Effect.Effect<PM[]>
+  all: Effect.Effect<PM[], DatabaseError>
   filter: FilterFunc<Encoded>
-  find: (id: Encoded[IdKey]) => Effect.Effect<Option.Option<PM>>
-  set: (e: PM) => Effect.Effect<PM, OptimisticConcurrencyException>
+  find: (id: Encoded[IdKey]) => Effect.Effect<Option.Option<PM>, DatabaseError>
+  set: (e: PM) => Effect.Effect<PM, OptimisticConcurrencyException | DatabaseError>
   batchSet: (
     items: NonEmptyReadonlyArray<PM>
-  ) => Effect.Effect<NonEmptyReadonlyArray<PM>, OptimisticConcurrencyException>
+  ) => Effect.Effect<NonEmptyReadonlyArray<PM>, OptimisticConcurrencyException | DatabaseError>
   bulkSet: (
     items: NonEmptyReadonlyArray<PM>
-  ) => Effect.Effect<NonEmptyReadonlyArray<PM>, OptimisticConcurrencyException>
-  batchRemove: (ids: NonEmptyReadonlyArray<Encoded[IdKey]>, partitionKey?: string) => Effect.Effect<void>
-  queryRaw: <Out>(query: RawQuery<Encoded, Out>) => Effect.Effect<readonly Out[]>
+  ) => Effect.Effect<NonEmptyReadonlyArray<PM>, OptimisticConcurrencyException | DatabaseError>
+  batchRemove: (ids: NonEmptyReadonlyArray<Encoded[IdKey]>, partitionKey?: string) => Effect.Effect<void, DatabaseError>
+  queryRaw: <Out>(query: RawQuery<Encoded, Out>) => Effect.Effect<readonly Out[], DatabaseError>
   /**
    * Explicitly seed a namespace. Primary is seeded eagerly on initialization.
    * Non-primary namespaces must be seeded explicitly before use.
    */
-  seedNamespace: (namespace: string) => Effect.Effect<void>
+  seedNamespace: (namespace: string) => Effect.Effect<void, DatabaseError>
 }
 
 export class StoreMaker extends Context.Opaque<StoreMaker, {

--- a/packages/effect-app/src/client/errors.ts
+++ b/packages/effect-app/src/client/errors.ts
@@ -157,6 +157,45 @@ export class OptimisticConcurrencyException extends TaggedErrorClass<OptimisticC
   }
 }
 
+/**
+ * Raised by a store adapter when a database operation fails for an
+ * infrastructure reason (request timeout, throttle, 5xx, dropped socket, or any
+ * non-conflict error). Distinct from `OptimisticConcurrencyException`, which is
+ * an expected etag conflict.
+ *
+ * `transient` is set by the adapter for failures worth retrying (timeout /
+ * throttle / 5xx / network). `cause` is the underlying adapter error, carried
+ * through a `Defect` schema so it serializes (an `Error` encodes to
+ * `{ name, message, cause }`) instead of breaking JSON encoding of the channel.
+ *
+ * Treated by the api/client/FE machinery like an unexpected (500-class) error.
+ */
+export class DatabaseError extends TaggedErrorClass<DatabaseError>()(
+  "DatabaseError",
+  {
+    message: S.String,
+    transient: S.Boolean,
+    cause: S.optional(S.Defect())
+  }
+) {
+  constructor(
+    args: { message?: string; transient?: boolean; cause?: unknown },
+    disableValidation?: boolean
+  ) {
+    super(
+      {
+        message: args.message ?? "Database operation failed",
+        transient: args.transient ?? false,
+        cause: args.cause
+      },
+      disableValidation as any
+    )
+  }
+  override toString() {
+    return `DatabaseError: ${this.message}`
+  }
+}
+
 const MutationOnlyErrors = [
   InvalidStateError,
   OptimisticConcurrencyException
@@ -168,7 +207,8 @@ const GeneralErrors = [
   LoginError,
   UnauthorizedError,
   ValidationError,
-  ServiceUnavailableError
+  ServiceUnavailableError,
+  DatabaseError
 ] as const
 
 export const SupportedErrors = S.Union([

--- a/packages/infra/src/Store/Cosmos.ts
+++ b/packages/infra/src/Store/Cosmos.ts
@@ -15,7 +15,7 @@ import { pipe } from "effect/Function"
 import * as Redacted from "effect/Redacted"
 import * as Struct from "effect/Struct"
 import { CosmosClient, CosmosClientLayer } from "../cosmos-client.js"
-import { OptimisticConcurrencyException } from "../errors.js"
+import { DatabaseError, OptimisticConcurrencyException } from "../errors.js"
 import { InfraLogger } from "../logger.js"
 import { annotateCosmosResponse, annotateDb } from "../otel.js"
 import { buildWhereCosmosQuery3, logQuery } from "./Cosmos/query.js"
@@ -30,9 +30,34 @@ const makeReverseMapId =
   ({ id, ...t }: PersistenceModelType<Omit<Encoded, IdKey> & { id: string }>) =>
     ({ ...t, [idKey]: id }) as any as PersistenceModelType<Encoded>
 
-class CosmosDbOperationError {
-  constructor(readonly message: string, readonly raw?: unknown) {}
-} // TODO: Retry operation when running into RU limit.
+// Cosmos statuses worth retrying: request timeout, throttle, retry-with,
+// internal, and service unavailable.
+const RETRYABLE_COSMOS_STATUS = new Set([408, 429, 449, 500, 503])
+const statusIsTransient = (code: number) => RETRYABLE_COSMOS_STATUS.has(code)
+
+// A thrown SDK error is transient if its status/code is retryable or its message
+// looks like a timeout / throttle / dropped connection.
+const thrownIsTransient = (e: unknown): boolean => {
+  const code = (e as any)?.code ?? (e as any)?.statusCode
+  if (typeof code === "number" && RETRYABLE_COSMOS_STATUS.has(code)) return true
+  const msg = e instanceof Error ? e.message : String(e)
+  return /request timed out|timed out|\btimeout\b|ETIMEDOUT|ECONNRESET|ECONNREFUSED|EAI_AGAIN|socket hang up|ServiceUnavailable|RequestTimeout|TooManyRequests|throttl/i
+    .test(msg)
+}
+
+// Wrap a Cosmos SDK promise so a rejection becomes a typed, serializable
+// `DatabaseError` (transient-classified) instead of a bare-`Error` defect — the
+// latter both bypasses retry and breaks JSON encoding of the failure channel.
+const tryCosmos = <A>(f: () => Promise<A>): Effect.Effect<A, DatabaseError> =>
+  Effect.tryPromise({
+    try: f,
+    catch: (e) =>
+      new DatabaseError({
+        message: `Cosmos request failed: ${e instanceof Error ? e.message : String(e)}`,
+        transient: thrownIsTransient(e),
+        cause: e
+      })
+  })
 
 const respBytes = (
   resp: { diagnostics?: { clientSideRequestStatistics?: { totalResponsePayloadLengthInBytes?: number } } }
@@ -209,8 +234,7 @@ const makeCosmosStore = Effect.fnUntraced(function*({ prefix }: StorageConfig) {
               batches
                 .map((x, i) => [i, x] as const),
               ([i, batch]) =>
-                Effect
-                  .promise(() => bulk(batch.map(([, op]) => op)))
+                tryCosmos(() => bulk(batch.map(([, op]) => op)))
                   .pipe(
                     Effect
                       .delay(Duration.millis(i === 0 ? 0 : 150)),
@@ -236,23 +260,21 @@ const makeCosmosStore = Effect.fnUntraced(function*({ prefix }: StorageConfig) {
                             (x) => x.statusCode !== 424 && (x.statusCode > 299 || x.statusCode < 200)
                           )
                           if (r2) {
-                            return yield* Effect.die(
-                              new CosmosDbOperationError(
-                                "not able to update records: " + r2.statusCode,
-                                responses
-                              )
-                            )
+                            return yield* new DatabaseError({
+                              message: "not able to update records: " + r2.statusCode,
+                              transient: statusIsTransient(r2.statusCode),
+                              cause: responses
+                            })
                           }
                           const r3 = responses.find(
                             (x) => x.statusCode > 299 || x.statusCode < 200
                           )
                           if (r3) {
-                            return yield* Effect.die(
-                              new CosmosDbOperationError(
-                                "not able to update records: " + r3.statusCode,
-                                responses
-                              )
-                            )
+                            return yield* new DatabaseError({
+                              message: "not able to update records: " + r3.statusCode,
+                              transient: statusIsTransient(r3.statusCode),
+                              cause: responses
+                            })
                           }
                           return batch.map(([e], i) => ({
                             ...e,
@@ -317,8 +339,7 @@ const makeCosmosStore = Effect.fnUntraced(function*({ prefix }: StorageConfig) {
 
                 const ex = batch.map(([, c]) => c)
 
-                return Effect
-                  .promise(() => execBatch(ex, ex[0]?.resourceBody._partitionKey))
+                return tryCosmos(() => execBatch(ex, ex[0]?.resourceBody._partitionKey))
                   .pipe(Effect.flatMap(Effect.fnUntraced(function*(x) {
                     const result = x.result ?? []
                     const firstFailed = result.find(
@@ -330,9 +351,11 @@ const makeCosmosStore = Effect.fnUntraced(function*({ prefix }: StorageConfig) {
                         return yield* new OptimisticConcurrencyException({ type: name, id: "batch", code })
                       }
 
-                      return yield* Effect.die(
-                        new CosmosDbOperationError("not able to update record: " + code)
-                      )
+                      return yield* new DatabaseError({
+                        message: "not able to update record: " + code,
+                        transient: statusIsTransient(code),
+                        cause: x
+                      })
                     }
 
                     return batch.map(([e], i) => ({
@@ -362,7 +385,7 @@ const makeCosmosStore = Effect.fnUntraced(function*({ prefix }: StorageConfig) {
               Effect.flatMap(({ ns, q }) =>
                 Effect
                   .gen(function*() {
-                    const response = yield* Effect.promise(() =>
+                    const response = yield* tryCosmos(() =>
                       container.items.query<Out>(q, { partitionKey: nsBasePartitionKey(ns) }).fetchAll()
                     )
                     yield* annotateFeed(response)
@@ -384,8 +407,7 @@ const makeCosmosStore = Effect.fnUntraced(function*({ prefix }: StorageConfig) {
             ),
         batchRemove: (ids, partitionKey?: string) =>
           resolveNamespace.pipe(Effect.flatMap((ns) =>
-            Effect
-              .promise(() =>
+            tryCosmos(() =>
                 execBatch(
                   mutable(ids.map((id) =>
                     dropUndefinedT({
@@ -421,7 +443,7 @@ const makeCosmosStore = Effect.fnUntraced(function*({ prefix }: StorageConfig) {
             Effect.flatMap(({ ns, q }) =>
               Effect
                 .gen(function*() {
-                  const response = yield* Effect.promise(() =>
+                  const response = yield* tryCosmos(() =>
                     container.items.query<PMCosmos>(q, { partitionKey: nsBasePartitionKey(ns) }).fetchAll()
                   )
                   yield* annotateFeed(response)
@@ -482,7 +504,7 @@ const makeCosmosStore = Effect.fnUntraced(function*({ prefix }: StorageConfig) {
                   Effect
                     .gen(function*() {
                       if (f.select) {
-                        const response = yield* Effect.promise(() =>
+                        const response = yield* tryCosmos(() =>
                           container.items.query<M>(q, { partitionKey: nsBasePartitionKey(ns) }).fetchAll()
                         )
                         yield* annotateFeed(response)
@@ -494,7 +516,7 @@ const makeCosmosStore = Effect.fnUntraced(function*({ prefix }: StorageConfig) {
                           ...mapReverseId(_ as any)
                         }))
                       }
-                      const response = yield* Effect.promise(() =>
+                      const response = yield* tryCosmos(() =>
                         container.items.query<{ f: M }>(q, { partitionKey: nsBasePartitionKey(ns) }).fetchAll()
                       )
                       yield* annotateFeed(response)
@@ -517,7 +539,7 @@ const makeCosmosStore = Effect.fnUntraced(function*({ prefix }: StorageConfig) {
           resolveNamespace.pipe(Effect.flatMap((ns) =>
             Effect
               .gen(function*() {
-                const response = yield* Effect.promise(() =>
+                const response = yield* tryCosmos(() =>
                   container
                     .item(id, nsPartitionValue(ns, { [idKey]: id } as Encoded))
                     .read<Encoded>()
@@ -541,20 +563,20 @@ const makeCosmosStore = Effect.fnUntraced(function*({ prefix }: StorageConfig) {
           )),
         set: (e) =>
           resolveNamespace.pipe(Effect.flatMap((ns) =>
-            Option
-              .match(
-                Option
-                  .fromNullishOr(e._etag),
-                {
-                  onNone: () =>
-                    Effect.promise(() =>
+            // Annotate the result so the create/replace promise union collapses to
+            // one type (otherwise `A` infers as `unknown` and the chain degrades).
+            tryCosmos((): Promise<{ statusCode: number; etag: string }> =>
+              Option
+                .match(
+                  Option
+                    .fromNullishOr(e._etag),
+                  {
+                    onNone: () =>
                       container.items.create({
                         ...mapId(e),
                         _partitionKey: nsPartitionValue(ns, e)
-                      })
-                    ),
-                  onSome: (eTag) =>
-                    Effect.promise(() =>
+                      }),
+                    onSome: (eTag) =>
                       container.item(e[idKey], nsPartitionValue(ns, e)).replace(
                         { ...mapId(e), _partitionKey: nsPartitionValue(ns, e) },
                         {
@@ -564,22 +586,24 @@ const makeCosmosStore = Effect.fnUntraced(function*({ prefix }: StorageConfig) {
                           }
                         }
                       )
-                    )
-                }
-              )
+                  }
+                )
+            )
               .pipe(
                 Effect
-                  .flatMap((x) => {
+                  .flatMap((x): Effect.Effect<PM, OptimisticConcurrencyException | DatabaseError> => {
                     if (x.statusCode === 412 || x.statusCode === 404 || x.statusCode === 409) {
                       return Effect.fail(
                         new OptimisticConcurrencyException({ type: name, id: e[idKey], code: x.statusCode })
                       )
                     }
                     if (x.statusCode > 299 || x.statusCode < 200) {
-                      return Effect.die(
-                        new CosmosDbOperationError(
-                          "not able to update record: " + x.statusCode
-                        )
+                      return Effect.fail(
+                        new DatabaseError({
+                          message: "not able to update record: " + x.statusCode,
+                          transient: statusIsTransient(x.statusCode),
+                          cause: x
+                        })
                       )
                     }
                     return Effect.sync(() => ({

--- a/packages/infra/src/Store/Cosmos.ts
+++ b/packages/infra/src/Store/Cosmos.ts
@@ -408,18 +408,18 @@ const makeCosmosStore = Effect.fnUntraced(function*({ prefix }: StorageConfig) {
         batchRemove: (ids, partitionKey?: string) =>
           resolveNamespace.pipe(Effect.flatMap((ns) =>
             tryCosmos(() =>
-                execBatch(
-                  mutable(ids.map((id) =>
-                    dropUndefinedT({
-                      operationType: "Delete" as const,
-                      id
-                      // don't use this or we get an error that the request and some item partition key dont match - makese no sense
-                      // partitionKey: config?.partitionValue({ [idKey]: id } as Encoded)
-                    })
-                  )),
-                  partitionKey ?? nsBasePartitionKey(ns)
-                )
+              execBatch(
+                mutable(ids.map((id) =>
+                  dropUndefinedT({
+                    operationType: "Delete" as const,
+                    id
+                    // don't use this or we get an error that the request and some item partition key dont match - makese no sense
+                    // partitionKey: config?.partitionValue({ [idKey]: id } as Encoded)
+                  })
+                )),
+                partitionKey ?? nsBasePartitionKey(ns)
               )
+            )
               .pipe(
                 annotateDb({
                   operation: "batchRemove",

--- a/packages/infra/src/Store/Disk.ts
+++ b/packages/infra/src/Store/Disk.ts
@@ -175,7 +175,9 @@ export function makeDiskStore({ prefix }: StorageConfig, dir: string) {
         seed?: Effect.Effect<Iterable<Encoded>, E, R>,
         config?: StoreConfig<Encoded>
       ) {
-        const primary = yield* makeDiskStoreInt(prefix, idKey, "primary", dir, name, seed, config?.defaultValues)
+        const primary = yield* makeDiskStoreInt(prefix, idKey, "primary", dir, name, seed, config?.defaultValues).pipe(
+          Effect.orDie
+        )
         const stores = new Map<string, Store<IdKey, Encoded>>([["primary", primary]])
         const ctx = yield* Effect.context<R>()
         const semaphores = new Map<string, Semaphore.Semaphore>()

--- a/packages/infra/src/Store/SQL.ts
+++ b/packages/infra/src/Store/SQL.ts
@@ -12,11 +12,19 @@ import * as Layer from "effect/Layer"
 import * as LayerMap from "effect/LayerMap"
 import * as Struct from "effect/Struct"
 import { SqlClient } from "effect/unstable/sql"
-import { OptimisticConcurrencyException } from "../errors.js"
+import { DatabaseError, OptimisticConcurrencyException } from "../errors.js"
 import { InfraLogger } from "../logger.js"
 import { annotateDb, type DbSystem } from "../otel.js"
 import { buildWhereSQLQuery, logQuery, type SQLDialect, sqliteDialect } from "./SQL/query.js"
 import { makeETag } from "./utils.js"
+
+const sqlErrorMessage = (e: unknown) => (e as any)?.message ? String((e as any).message) : String(e)
+const sqlIsTransient = (e: unknown) =>
+  /timeout|ETIMEDOUT|ECONNRESET|ECONNREFUSED|connection|deadlock|too many connections/i.test(sqlErrorMessage(e))
+// Map a SqlError into a typed, serializable DatabaseError (instead of `.orDie`,
+// which would turn it into an opaque, non-serializable defect).
+const toDatabaseError = (e: unknown) =>
+  new DatabaseError({ message: `SQL request failed: ${sqlErrorMessage(e)}`, transient: sqlIsTransient(e), cause: e })
 
 export type WithNsTransactionFn = <A, E, R>(effect: Effect.Effect<A, E, R>) => Effect.Effect<A, E, R>
 
@@ -101,7 +109,8 @@ function makeSQLStoreInt(system: DbSystem, dialect: SQLDialect, jsonColumnType: 
           return { id, _etag: newE._etag!, data, item: newE }
         }
 
-        const exec = (query: string, params?: readonly unknown[]) => sql.unsafe(query, params as any).pipe(Effect.orDie)
+        const exec = (query: string, params?: readonly unknown[]) =>
+          sql.unsafe(query, params as any).pipe(Effect.mapError(toDatabaseError))
 
         const setInternal = Effect.fnUntraced(function*(e: PM, ns: string) {
           const row = toRow(e)
@@ -151,7 +160,7 @@ function makeSQLStoreInt(system: DbSystem, dialect: SQLDialect, jsonColumnType: 
             )
 
         const ctx = yield* Effect.context<R>()
-        const seedCache = new Map<string, Effect.Effect<void>>()
+        const seedCache = new Map<string, Effect.Effect<void, DatabaseError>>()
         const makeSeedEffect = Effect.fnUntraced(function*(ns: string) {
           yield* ensureTable
           if (!seed) return
@@ -365,8 +374,10 @@ function makeSQLStoreInt(system: DbSystem, dialect: SQLDialect, jsonColumnType: 
             )
         }
 
-        // Eagerly seed primary namespace on initialization
-        yield* seedNamespace("primary")
+        // Eagerly seed primary namespace on initialization. A seed failure at
+        // construction is fatal (orDie); the per-call `seedNamespace` still
+        // surfaces DatabaseError to callers.
+        yield* seedNamespace("primary").pipe(Effect.orDie)
 
         return s
       })
@@ -412,7 +423,7 @@ function makeSQLiteStorePerNs(
       }
 
       const exec = (ns: string, query: string, params?: readonly unknown[]) =>
-        withNsSql(ns, (sql) => sql.unsafe(query, params as any).pipe(Effect.orDie))
+        withNsSql(ns, (sql) => sql.unsafe(query, params as any).pipe(Effect.mapError(toDatabaseError)))
 
       const ensureTable = (ns: string) =>
         withNsSql(ns, (sql) =>
@@ -482,7 +493,7 @@ function makeSQLiteStorePerNs(
             ))
 
       const ctx = yield* Effect.context<R>()
-      const seedCache = new Map<string, Effect.Effect<void>>()
+      const seedCache = new Map<string, Effect.Effect<void, DatabaseError>>()
       const makeSeedEffect = Effect.fnUntraced(function*(ns: string) {
         yield* ensureTable(ns)
         if (!seed) return
@@ -696,7 +707,7 @@ function makeSQLiteStorePerNs(
           )
       }
 
-      yield* seedNamespace("primary")
+      yield* seedNamespace("primary").pipe(Effect.orDie)
 
       return s
     })


### PR DESCRIPTION
## Problem

Store adapters wrap their DB calls in bare `Effect.promise` (Cosmos) / `.orDie` (SQL). So a **transient** infrastructure failure — request timeout, throttle, 5xx, dropped socket — becomes a raw-`Error` **defect**:

- `Effect.retry` only retries the typed error channel, never a defect → a single blip can't be ridden out.
- Encoding a workflow exit `Cause` through a JsonValue schema chokes on a raw `Error` → `Expected JSON value, got Error … ["cause"]["failures"][0]["defect"]`.

Net: one transient Cosmos hiccup can permanently strand a durable saga.

## Change

Introduce a typed, serializable `DatabaseError`:

```ts
class DatabaseError extends TaggedErrorClass<DatabaseError>()("DatabaseError", {
  message: S.String,
  transient: S.Boolean,      // timeout / throttle / 5xx / network => retryable
  cause: S.optional(S.Defect())  // Error encodes to { name, message, cause }
})
```

- Added to `SupportedErrors` → api client / controllers / FE treat it like a 500/unexpected error.
- Exposed on **all** `Store` and `Repository` method error channels (reads included); writes are `OptimisticConcurrencyException | DatabaseError`.
- Each adapter wraps its db-call failures into `DatabaseError`, classifying `transient`:
  - **Cosmos**: `tryCosmos` wraps every runtime SDK call; status-code branches map to `DatabaseError` (408/429/449/500/503 = transient). `CosmosDbOperationError` removed.
  - **SQL**: `exec` maps `SqlError` → `DatabaseError`.
  - Construction / seed / DDL paths stay `orDie` (fatal at init); per-call `seedNamespace` surfaces `DatabaseError`.

## Why it fixes the root issue

A Cosmos timeout is now a typed `DatabaseError` in the failure channel — retryable (`Effect.retry` works) and serializable (its schema, with `Defect`-encoded `cause`). The raw-`Error`-defect path and the "Expected JSON value, got Error" encode failure no longer occur for DB errors. The `transient` flag lets callers/retry key off `error.transient` instead of string-matching.

## Validation

- Full libs `pnpm check` (tsgo --build) green.
- `packages/infra` tests: 217 passed, 26 skipped.

## Follow-ups (not here)
- Engine-level `Schema.Defect()` hardening for *non-DB* raw defects.
- Downstream: publish, bump consumers' `@effect-app/*`; the scanner OnePick retry band-aid can then simplify to `e._tag === "DatabaseError" && e.transient`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)