### PR TITLE
fix(vue-components): export src for workspace, ship dist via publishConfig

### DIFF
--- a/.changeset/vue-components-src-exports.md
+++ b/.changeset/vue-components-src-exports.md
@@ -1,0 +1,5 @@
+---
+"@effect-app/vue-components": patch
+---
+
+Point the package `exports` at `src` (`.vue`/`.ts`) for workspace/source consumption, matching `effect-app` and `@effect-app/vue`. The published package is unchanged — `publishConfig.exports` still ships the built `dist` artifacts, so registry consumers keep getting compiled output. This lets linked/source consumers (e.g. via embedded-source mode) load the components from `src` without a build step; runtime `.vue` is compiled by the consumer's bundler and types resolve via `vue-tsc`.

--- a/packages/vue-components/package.json
+++ b/packages/vue-components/package.json
@@ -56,16 +56,25 @@
     "src",
     "dist"
   ],
-  "module": "./dist/vue-components.es.js",
   "exports": {
     ".": {
-      "types": "./dist/types/index.d.ts",
-      "import": "./dist/vue-components.es.js"
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
     },
-    "./dist/vue-components.css": "./dist/vue-components.css",
-    "./reset.css": {
-      "development": "./src/reset.css",
-      "default": "./dist/reset.css"
+    "./reset.css": "./src/reset.css"
+  },
+  "publishConfig": {
+    "module": "./dist/vue-components.es.js",
+    "exports": {
+      ".": {
+        "types": "./dist/types/index.d.ts",
+        "import": "./dist/vue-components.es.js"
+      },
+      "./dist/vue-components.css": "./dist/vue-components.css",
+      "./reset.css": {
+        "development": "./src/reset.css",
+        "default": "./dist/reset.css"
+      }
     }
   },
   "dependencies": {


### PR DESCRIPTION
## What

Point `@effect-app/vue-components` package `exports` at `src` (`.vue`/`.ts`), mirroring `effect-app` and `@effect-app/vue`. The previous dist entries move to `publishConfig.exports`.

## Why

So linked/source consumers (embedded-source mode in downstream apps) can load the components from `src` without a build step — runtime `.vue` is compiled by the consumer's bundler and types resolve via `vue-tsc`.

The **published package is unchanged**: `publishConfig.exports` still emits the built `dist` artifacts (incl. `dist/vue-components.css` and the `reset.css` dev/default conditions), so registry consumers keep getting compiled output. Hence a `patch` changeset.

## Note for `.vue` + tsc

Consumers must keep this package out of plain-`tsc`/`tsgo` project references — `src` contains `.vue` SFCs that only `vue-tsc` can read. Type resolution works via `exports.types → src/index.ts` under `vue-tsc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)