### PR TITLE
feat(vue): add atom query APIs with TanStack legacy engine toggle

### DIFF
--- a/.changeset/atom-query-vue.md
+++ b/.changeset/atom-query-vue.md
@@ -3,4 +3,4 @@
 "@effect-app/vue": patch
 ---
 
-Add Atom-native Vue query APIs with a TanStack-backed legacy query engine toggle.
+Add Atom-native Vue query APIs, stream query pull atoms, and a TanStack-backed legacy query engine toggle.

--- a/.changeset/atom-query-vue.md
+++ b/.changeset/atom-query-vue.md
@@ -1,0 +1,6 @@
+---
+"effect-app": patch
+"@effect-app/vue": patch
+---
+
+Add Atom-native Vue query APIs with a TanStack-backed legacy query engine toggle.

--- a/packages/effect-app/src/client/clientFor.ts
+++ b/packages/effect-app/src/client/clientFor.ts
@@ -99,6 +99,7 @@ export interface RequestHandlerWithInput<I, A, E, R, Request extends Req, Id ext
   id: Id
   options?: ClientForOptions
   Request: Request
+  queryKeyProjectionHash?: string
 }
 
 /** Type alias: a no-input handler is simply `RequestHandlerWithInput<void, …>`. */

--- a/packages/effect-app/src/client/makeClient.ts
+++ b/packages/effect-app/src/client/makeClient.ts
@@ -54,14 +54,13 @@ type InvalidationResources = Record<string, Record<string, unknown>>
  * An invalidation instruction returned from `invalidatesQueries`. One of:
  *  - a raw query key (`ReadonlyArray<string>`)
  *  - an RPC handler object (`{ id, options? }`) — query key derived from `id`
- *  - the raw `{ filters, options }` tanstack-query shape
+ *  - a compatibility `{ filters: { queryKey }, options? }` shape
  *
- * `Filters` / `Options` are widened to `Record<string, unknown>` by default so
- * the effect-app core has no dependency on `@tanstack/vue-query`. The vue
- * adapter narrows them via the `InvalidationEntry` alias.
+ * Predicate filters are intentionally not represented: atom invalidation is keyed by
+ * concrete query keys.
  */
 export type InvalidateQueryInstruction<
-  Filters = Record<string, unknown>,
+  Filters = { readonly queryKey: ReadonlyArray<unknown> },
   Options = Record<string, unknown>
 > =
   | ReadonlyArray<string>
@@ -70,7 +69,7 @@ export type InvalidateQueryInstruction<
     readonly options?: ClientForOptions
   }
   | {
-    readonly filters?: Filters
+    readonly filters: Filters
     readonly options?: Options
   }
 

--- a/packages/vue/docs/atom-query-api-redesign.md
+++ b/packages/vue/docs/atom-query-api-redesign.md
@@ -102,8 +102,12 @@ Options that affect a single observer should wrap the shared raw atom rather tha
 ```ts
 const raw = family(input)
 const selected = select ? Atom.mapResult(raw, select) : raw
-const refreshed = refreshEvery ? Atom.withRefresh(refreshEvery)(selected) : selected
-const viewed = Atom.swr({ staleTime, revalidateOnFocus, focusSignal })(refreshed)
+const refreshed = refreshEvery
+  ? Atom.withRefresh(refreshEvery)(selected)
+  : selected
+const viewed = Atom.swr({ staleTime, revalidateOnFocus, focusSignal })(
+  refreshed
+)
 ```
 
 TTL is the awkward option. If TTL is part of the base atom, it should be a client/default policy, not the first observer's option. For old APIs, keep accepting `gcTime`, but normalize it into a base-atom policy that cannot be captured accidentally by the first observer. For new APIs, prefer an atom-native `idleTTL` or `timeToLive` name.

--- a/packages/vue/docs/atom-query-api-redesign.md
+++ b/packages/vue/docs/atom-query-api-redesign.md
@@ -1,0 +1,185 @@
+# Atom query API redesign
+
+This branch can stop treating Effect atoms as an implementation detail hidden behind a TanStack-shaped API. The useful durable primitive is the atom; Vue refs, suspense promises, refetch helpers, and future hydration should all be adapters around it.
+
+## Source findings
+
+Relevant upstream Effect v4 atom APIs checked locally:
+
+- `repos/effect/packages/effect/src/unstable/reactivity/Atom.ts`
+  - `AtomRuntime.atom` turns an `Effect` into `Atom<AsyncResult<A, E>>`.
+  - `Atom.family` gives structural cache identity by input.
+  - `Atom.swr`, `Atom.withRefresh`, `Atom.setIdleTTL`, and `Atom.keepAlive` already model stale reads, polling, idle lifetime, and keep-alive.
+  - `Atom.mapResult` and `Atom.transform` are the right composition layer for `select` and derived queries.
+  - `Atom.optimistic` / `Atom.optimisticFn` can replace our current no-op optimistic `useUpdateQuery` facade.
+  - `Atom.toStreamResult`, `Atom.getResult`, `Atom.refresh`, and `Atom.mount` provide Effect-native conversion points.
+- `repos/effect/packages/effect/src/unstable/reactivity/AtomRegistry.ts`
+  - `getResult(registry, atom, { suspendOnWaiting: true })` is the precise operation we need for awaitable refetch and Vue suspense.
+  - Registries are independent; relying on the module-global `defaultRegistry` leaks a policy decision into the query engine.
+- `repos/effect/packages/effect/src/unstable/reactivity/AtomRpc.ts`
+  - Upstream RPC integration exposes `query(tag, payload)` as an atom and `mutation(tag)` as an atom result function. This is the shape we should mirror for effect-app clients.
+- `repos/effect/packages/effect/src/unstable/reactivity/Hydration.ts`
+  - Serializable atoms support `dehydrate` / `hydrate`; Nuxt SSR can use that later without inventing query-specific prefetch state.
+- `repos/effect/packages/atom/vue/src/index.ts`
+  - Vue integration is intentionally thin: `useAtomValue`, `useAtom`, `injectRegistry`, `registryKey`.
+  - There is no special query abstraction upstream; the app layer should own the ergonomic client API.
+
+## Current problems
+
+- `query.ts` still exposes TanStack vocabulary and types: `UseQueryReturnType`, `QueryObserverResult`, `RefetchOptions`, `initialData`, `placeholderData`, `gcTime`, `refetchInterval`, and tuple returns.
+- The raw query atom is hidden in the fourth tuple slot. That makes composition awkward and encourages helper APIs to tunnel through private handles.
+- Query family identity must be stable by query key plus projection hash, while observer options stay outside the family. Otherwise projected and unprojected clients can accidentally share a base atom.
+- `useUpdateQuery` accepts an updater but cannot apply it because query atoms are read-only derived atoms there; it currently refreshes and ignores the updater.
+- Stream queries are collapsed into `Stream.runCollect`, so a streaming query behaves like a slow normal query rather than a pull/incremental atom.
+- The default atom registry is used in invalidation-await logic. That works for today but blocks scoped registries, SSR hydration, and tests that provide a custom registry.
+
+## Compatibility boundary
+
+Keep the existing public APIs intact while the internals move to atom-native composition:
+
+- `client.X.query(...)` keeps its current tuple return shape.
+- `client.X.suspense(...)` keeps returning a Promise of that tuple shape.
+- Existing options remain accepted on old APIs, but their behavior should be fixed internally. In particular, handler-global base atoms should be shared, while observer-specific behavior such as `select`, polling, SWR/focus policy, and structural sharing is layered on top.
+
+Only expose breaking or meaningfully different APIs under new names:
+
+- `client.X.atom(input, options?)`
+- `client.X.queryNew(input, options?)`
+- `client.X.suspenseNew(input, options?)`
+
+This lets the app test the new shape in real call sites without forcing a broad migration, and lets old API users benefit from the internal option-sharing fix.
+
+## Target client shape
+
+Keep query helpers on the typed clients, like mutations:
+
+```ts
+const atom = client.Carts.List.atom(input, options)
+const query = client.Carts.List.queryNew(input, options)
+const suspense = await client.Carts.List.suspenseNew(input, options)
+```
+
+`suspenseNew` stays a `Promise`, because Vue setup / Suspense wants a Promise boundary.
+
+The proposed breaking return shape is an object:
+
+```ts
+interface QueryView<A, E> {
+  readonly result: ComputedRef<AsyncResult.AsyncResult<A, E>>
+  readonly data: ComputedRef<A | undefined>
+  readonly atom: ComputedRef<Atom.Atom<AsyncResult.AsyncResult<A, E>>>
+  readonly awaitResult: () => Effect.Effect<A, E, never>
+  readonly refetch: () => Effect.Effect<A, E, never>
+  readonly refresh: () => void
+}
+
+interface SuspenseQueryView<A, E> extends Omit<QueryView<A, E>, "data"> {
+  readonly data: ComputedRef<A>
+}
+```
+
+`queryNew()` returns `QueryView<A, E>`. `suspenseNew()` returns `Promise<SuspenseQueryView<A, E>>`.
+
+This removes tuple slot meaning, makes `refetch` obviously awaitable, and exposes the atom for composition.
+
+## Atom-first internals
+
+Split the implementation into two layers:
+
+- `atomQuery.ts`: build and compose atoms.
+  - `queryAtom(handler, input, options)` returns `Atom<AsyncResult<A, E>>`.
+  - `queryFamily(handler)` is stable by query key plus projection hash and does not capture observer options.
+  - `awaitQueryAtom(registry, atom)` delegates to `AtomRegistry.getResult`.
+  - `refreshQueryAtom(registry, atom)` delegates to `registry.refresh`.
+- `query.ts`: Vue adapter only.
+  - Resolve refs/getters/options.
+  - Call `useAtomValue`.
+  - Return `QueryView` / `SuspenseQueryView`.
+  - Convert to Promise only inside `useSuspenseQuery`.
+
+Options that affect a single observer should wrap the shared raw atom rather than mutate handler-family identity:
+
+```ts
+const raw = family(input)
+const selected = select ? Atom.mapResult(raw, select) : raw
+const refreshed = refreshEvery ? Atom.withRefresh(refreshEvery)(selected) : selected
+const viewed = Atom.swr({ staleTime, revalidateOnFocus, focusSignal })(refreshed)
+```
+
+TTL is the awkward option. If TTL is part of the base atom, it should be a client/default policy, not the first observer's option. For old APIs, keep accepting `gcTime`, but normalize it into a base-atom policy that cannot be captured accidentally by the first observer. For new APIs, prefer an atom-native `idleTTL` or `timeToLive` name.
+
+## Option names
+
+Use atom-native names on the new APIs. Keep old option names on old APIs:
+
+- `gcTime` -> `idleTTL` or `timeToLive`
+- `refetchInterval` -> `refreshEvery`
+- `refetchOnWindowFocus` -> `revalidateOnFocus`
+- `select` can stay; it is a familiar projection name and maps cleanly to `Atom.mapResult`.
+- Drop `initialData` and `placeholderData` from the new core API. Keep them accepted by old APIs if compatibility requires it, but implement them as wrappers/fallbacks over atoms rather than query-engine state.
+
+## Composition API
+
+Expose enough atoms that app code can compose before Vue refs:
+
+```ts
+const cartsAtom = client.Carts.List.atom(undefined)
+const spotsAtom = client.Spots.List.atom(undefined)
+
+const pageAtom = Atom.make((get) => ({
+  carts: get.result(cartsAtom, { suspendOnWaiting: true }),
+  spots: get.result(spotsAtom, { suspendOnWaiting: true })
+}))
+```
+
+For plain result composition, add an atom-native replacement for `composeQueries`:
+
+```ts
+const combined = composeQueryAtoms({
+  carts: client.Carts.List.atom(undefined),
+  spots: client.Spots.List.atom(undefined)
+})
+```
+
+The existing `composeQueries` can remain as a Vue-ref convenience wrapper during migration.
+
+## Optimistic updates
+
+Replace `useUpdateQuery(query, input, updater)` with atom-level helpers:
+
+```ts
+const carts = client.Carts.List.optimistic(input)
+const updateCart = client.Carts.Update.optimistic(carts, reducer)
+```
+
+Internally this should use `Atom.optimistic` / `Atom.optimisticFn`, not a manual cache patch. The mutation can still invalidate reactivity keys after success; optimistic atoms handle temporary UI state and rollback.
+
+## Registry and full-stack notes
+
+- The frontend plugin should provide an app-level `AtomRegistry` via `registryKey` instead of relying on `@effect/atom-vue`'s fallback `defaultRegistry`.
+- `invalidateAndAwait` should await against the active registry, not a module global. A registry-aware mutation layer is cleaner than hidden global state.
+- Serializable query atoms can unlock Nuxt SSR hydration later:
+  - mark query atoms with `Atom.serializable` using request schema + stable input key,
+  - dehydrate after server setup,
+  - hydrate the client registry before mounting.
+- Stream query clients should expose pull atoms for real progress:
+  - `client.Progress.Stream.atom(input)` returns `Atom.Writable<Atom.PullResult<A, E>, void>`,
+  - Vue adapters decide whether to accumulate chunks, show latest chunk, or expose a `pull()` command.
+
+## Migration plan
+
+1. Refactor internals so a base query atom is shared per handler+input, then old and new APIs layer observer options on top. This fixes old API behavior without changing old API shape.
+2. Add `client.X.atom(input, options?)`, `client.X.queryNew(input, options?)`, and `client.X.suspenseNew(input, options?)`. Update type tests to assert atom exposure and object-return typing.
+3. Keep `.query()` and `.suspense()` as compatibility APIs. They can delegate to the new internal engine and adapt the result back to tuple shape.
+4. Add one or two real frontend example conversions to `queryNew` / `suspenseNew`, preferably places that exercise:
+   - a suspense read with `data` and `result`,
+   - an awaitable `refetch`,
+   - optionally `atom` composition if a small call site exists.
+5. Keep most frontend call sites on the old tuple APIs so both surfaces are exercised during the transition.
+6. Replace `useUpdateQuery` call sites with atom refresh or optimistic helpers after the new query surface proves out.
+7. Convert stream query handling from collect-to-array to pull/accumulating atom APIs.
+8. Add registry provider + hydration experiments after the client API is stable.
+
+## Recommendation
+
+Do direct atom exposure and the breaking object API together, but under additive names first. Keep `suspense()` as the compatibility Promise tuple and add `suspenseNew()` as the Promise object API. The Promise should remain a framework boundary over `AtomRegistry.getResult`, not the internal shape. The API should make the atom visible, because that is where Effect v4 gives us composition, refresh, hydration, streams, and optimistic state.

--- a/packages/vue/docs/atom-query-api-redesign.md
+++ b/packages/vue/docs/atom-query-api-redesign.md
@@ -30,7 +30,7 @@ Relevant upstream Effect v4 atom APIs checked locally:
 - The raw query atom is hidden in the fourth tuple slot. That makes composition awkward and encourages helper APIs to tunnel through private handles.
 - Query family identity must be stable by query key plus projection hash, while observer options stay outside the family. Otherwise projected and unprojected clients can accidentally share a base atom.
 - `useUpdateQuery` accepts an updater but cannot apply it because query atoms are read-only derived atoms there; it currently refreshes and ignores the updater.
-- Stream queries are collapsed into `Stream.runCollect`, so a streaming query behaves like a slow normal query rather than a pull/incremental atom.
+- Legacy stream query `.query()` is still collapsed into `Stream.runCollect`, so the compatibility API behaves like a slow normal query. Stream query clients now also expose atom-native `.atom()`, `.family()`, and `.queryNew()` helpers backed by `Atom.pull`, so new call sites can observe incremental pull state without waiting for stream completion.
 - The default atom registry is used in invalidation-await logic. That works for today but blocks scoped registries, SSR hydration, and tests that provide a custom registry.
 
 ## Compatibility boundary
@@ -166,9 +166,11 @@ Internally this should use `Atom.optimistic` / `Atom.optimisticFn`, not a manual
   - mark query atoms with `Atom.serializable` using request schema + stable input key,
   - dehydrate after server setup,
   - hydrate the client registry before mounting.
-- Stream query clients should expose pull atoms for real progress:
+- Stream query clients expose pull atoms for real progress:
   - `client.Progress.Stream.atom(input)` returns `Atom.Writable<Atom.PullResult<A, E>, void>`,
-  - Vue adapters decide whether to accumulate chunks, show latest chunk, or expose a `pull()` command.
+  - `client.Progress.Stream.family()` returns the reusable atom family,
+  - `client.Progress.Stream.queryNew(input)` returns a Vue view with `result`, `items`, `latest`, `done`, `pull`, and `pullAndAwait`.
+  - Legacy `.query()` remains collect-to-array compatibility until call sites migrate.
 
 ## Migration plan
 
@@ -181,7 +183,7 @@ Internally this should use `Atom.optimistic` / `Atom.optimisticFn`, not a manual
    - optionally `atom` composition if a small call site exists.
 5. Keep most frontend call sites on the old tuple APIs so both surfaces are exercised during the transition.
 6. Replace `useUpdateQuery` call sites with atom refresh or optimistic helpers after the new query surface proves out.
-7. Convert stream query handling from collect-to-array to pull/accumulating atom APIs.
+7. Convert legacy stream query call sites from collect-to-array `.query()` to pull/accumulating `.queryNew()` / `.atom()` APIs.
 8. Add registry provider + hydration experiments after the client API is stable.
 
 ## Recommendation

--- a/packages/vue/src/atomQuery.ts
+++ b/packages/vue/src/atomQuery.ts
@@ -25,6 +25,7 @@ import * as Duration from "effect/Duration"
 import * as Equal from "effect/Equal"
 import * as Hash from "effect/Hash"
 import type * as Layer from "effect/Layer"
+import * as Stream from "effect/Stream"
 import { isHttpClientError } from "effect/unstable/http/HttpClientError"
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult"
 import * as Atom from "effect/unstable/reactivity/Atom"
@@ -70,6 +71,17 @@ const trackByKeys =
       }
       return get(atom)
     }, { initialValueTarget: atom })
+
+const trackWritableByKeys =
+  (keys: ReadonlyArray<ReadonlyArray<unknown>>) =>
+  <A, E, W>(atom: Atom.Writable<AsyncResult.AsyncResult<A, E>, W>): Atom.Writable<AsyncResult.AsyncResult<A, E>, W> => {
+    const tracked = trackByKeys(keys)(atom)
+    return Atom.writable(
+      (get) => get(tracked),
+      (ctx, value) => ctx.set(atom, value),
+      (refresh) => refresh(tracked)
+    )
+  }
 
 const atomsForKeys = (keys: ReadonlyArray<unknown>): ReadonlyArray<Atom.Atom<AsyncResult.AsyncResult<any, any>>> => {
   const atoms = new Set<Atom.Atom<AsyncResult.AsyncResult<any, any>>>()
@@ -310,6 +322,35 @@ export const buildQueryFamily = <I, A, E>(
     // idle window, letting invalidation reach a cached-but-unmounted query.
     atom = Atom.setIdleTTL(atom, defaults.gcTime)
     return Atom.withLabel(`query:${self.id}`)(atom)
+  })
+}
+
+export const buildStreamQueryFamily = <I, A, E>(
+  rt: AtomClientRuntime,
+  self: {
+    readonly id: string
+    readonly handler: (i: I) => Stream.Stream<A, E, any>
+    readonly options?: ClientForOptions
+    readonly queryKeyProjectionHash?: string
+  }
+) => {
+  const baseKey = makeQueryKey(self)
+
+  return Atom.family((input: I) => {
+    let atom = rt.runtime.pull(
+      self.handler(input).pipe(
+        Stream.tapCause((cause) => Cause.hasDies(cause) ? reportRuntimeError(cause) : Effect.void)
+      )
+    )
+    const fullKey = [...baseKey, input]
+    const projectedFullKey = self.queryKeyProjectionHash === undefined
+      ? fullKey
+      : [...baseKey, self.queryKeyProjectionHash, input]
+    const reactivityKeys = uniqueKeys([...prefixesOf(fullKey), ...prefixesOf(projectedFullKey)])
+    atom = rt.factory.withReactivity(reactivityKeys)(atom)
+    atom = trackWritableByKeys(reactivityKeys)(atom)
+    atom = Atom.setIdleTTL(atom, defaults.gcTime)
+    return Atom.withLabel(`stream-query:${self.id}`)(atom)
   })
 }
 

--- a/packages/vue/src/atomQuery.ts
+++ b/packages/vue/src/atomQuery.ts
@@ -1,0 +1,321 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/**
+ * Shared atom core for the query/mutation engine (used by query.ts + mutate.ts).
+ *
+ * Replaces the @tanstack/vue-query engine with Effect `Atom`, keeping the public
+ * `.query()/.suspense()/.mutate()` contract unchanged:
+ *   - cache identity   = the atom reference (one per [handler, input], via Atom.family)
+ *   - invalidation key = reactivity keys (= the app's existing namespace query keys)
+ *   - SWR + focus      = Atom.swr (+ windowFocusSignal)
+ *   - gcTime           = Atom.setIdleTTL / Atom.keepAlive
+ *   - retry            = Effect.retry inside the atom effect
+ *
+ * Built over the app's RPC client through the existing `RequestHandlerWithInput`
+ * abstraction (mirrors AtomRpc's recipe; see docs/atom-query-plan.md).
+ */
+import { makeQueryKey } from "effect-app/client"
+import type { ClientForOptions } from "effect-app/client/clientFor"
+import { ServiceUnavailableError } from "effect-app/client/errors"
+import * as Effect from "effect-app/Effect"
+import * as Option from "effect-app/Option"
+import * as S from "effect-app/Schema"
+import { defaultRegistry } from "@effect/atom-vue"
+import * as Cause from "effect/Cause"
+import * as Duration from "effect/Duration"
+import * as Equal from "effect/Equal"
+import * as Hash from "effect/Hash"
+import type * as Layer from "effect/Layer"
+import { isHttpClientError } from "effect/unstable/http/HttpClientError"
+import * as AsyncResult from "effect/unstable/reactivity/AsyncResult"
+import * as Atom from "effect/unstable/reactivity/Atom"
+import * as AtomRegistry from "effect/unstable/reactivity/AtomRegistry"
+import * as Reactivity from "effect/unstable/reactivity/Reactivity"
+import { reportRuntimeError } from "./lib.ts"
+
+/** All non-empty prefixes of a key, longest last. `[a,b,c]` -> `[[a],[a,b],[a,b,c]]`. */
+const prefixesOf = (key: ReadonlyArray<unknown>): ReadonlyArray<ReadonlyArray<unknown>> =>
+  key.map((_, i) => key.slice(0, i + 1))
+
+const uniqueKeys = (keys: ReadonlyArray<ReadonlyArray<unknown>>): ReadonlyArray<ReadonlyArray<unknown>> => {
+  const out: Array<ReadonlyArray<unknown>> = []
+  const seen = new Set<number>()
+  for (const key of keys) {
+    const hash = Hash.hash(key)
+    if (seen.has(hash)) continue
+    seen.add(hash)
+    out.push(key)
+  }
+  return out
+}
+
+// --- awaitable invalidation -------------------------------------------------------------------
+// keyHash -> live query atoms registered under that key. A query atom is tracked while it is alive
+// in the registry (mounted OR cached within idle-ttl) and removed on GC, so invalidation reaches
+// cached-but-unmounted queries too (e.g. a list you navigated away from).
+const keyAtoms = new Map<number, Set<Atom.Atom<AsyncResult.AsyncResult<any, any>>>>()
+
+const trackByKeys =
+  (keys: ReadonlyArray<ReadonlyArray<unknown>>) =>
+  <A, E>(atom: Atom.Atom<AsyncResult.AsyncResult<A, E>>): Atom.Atom<AsyncResult.AsyncResult<A, E>> =>
+    Atom.transform(atom, (get) => {
+      for (const key of keys) {
+        const h = Hash.hash(key)
+        let set = keyAtoms.get(h)
+        if (!set) keyAtoms.set(h, set = new Set())
+        set.add(atom)
+        get.addFinalizer(() => {
+          set.delete(atom)
+          if (set.size === 0) keyAtoms.delete(h)
+        })
+      }
+      return get(atom)
+    }, { initialValueTarget: atom })
+
+const atomsForKeys = (keys: ReadonlyArray<unknown>): ReadonlyArray<Atom.Atom<AsyncResult.AsyncResult<any, any>>> => {
+  const atoms = new Set<Atom.Atom<AsyncResult.AsyncResult<any, any>>>()
+  for (const key of keys) {
+    const set = keyAtoms.get(Hash.hash(key))
+    if (set) for (const a of set) atoms.add(a)
+  }
+  return [...atoms]
+}
+
+/**
+ * Invalidate the given keys and AWAIT the result. The invalidation (refetch trigger) goes through
+ * the built-in `Reactivity` service — the same one query atoms register against via
+ * `factory.withReactivity`, shared via the runtime memoMap. The await uses our own `keyAtoms`
+ * tracking + `awaitAtomResult`, since `Reactivity.invalidate` returns void and can't be awaited.
+ *
+ * Resolves once the affected queries have settled, so a mutation can `yield*` this and know the
+ * affected queries are fresh. (The await reads via the module-global default registry — the one the
+ * vue composables resolve via `injectRegistry`'s fallback.)
+ */
+export const invalidateAndAwait = (keys: ReadonlyArray<unknown>): Effect.Effect<void, never, Reactivity.Reactivity> =>
+  Effect.gen(function*() {
+    yield* Reactivity.invalidate(keys) // invalidates everything but only refreshes what's mounted
+    const atoms = atomsForKeys(keys)
+//    for (const a of atoms) defaultRegistry.refresh(a) // refreshes everything even when not mounted
+    if (atoms.length === 0) return
+    yield* Effect.forEach(atoms, (a) => awaitAtomResult(defaultRegistry, a).pipe(Effect.exit))
+  })
+
+const isPlainObject = (o: unknown): o is Record<string, unknown> => {
+  if (typeof o !== "object" || o === null) return false
+  const proto = Object.getPrototypeOf(o)
+  return proto === Object.prototype || proto === null
+}
+
+/**
+ * Structural sharing (tanstack `replaceEqualDeep`): walk `next` against `prev` and reuse `prev`'s
+ * reference for any unchanged array/object sub-tree, so unchanged data keeps referential identity
+ * (Vue skips re-rendering it). Leaves — including decoded Schema CLASS INSTANCES — are compared with
+ * Effect `Equal.equals` (structural), which reuses equal instances that tanstack's `===` could not.
+ */
+const replaceEqualDeep = (prev: any, next: any): any => {
+  if (prev === next) return prev
+  const bothArrays = Array.isArray(prev) && Array.isArray(next)
+  if (bothArrays || (isPlainObject(prev) && isPlainObject(next))) {
+    const a: Record<PropertyKey, any> = prev
+    const b: Record<PropertyKey, any> = next
+    const copy: Record<PropertyKey, any> = bothArrays ? [] : {}
+    const nextKeys: Array<PropertyKey> = bothArrays ? (b as Array<any>).map((_, i) => i) : Object.keys(b)
+    const nextSize = nextKeys.length
+    const prevSize = bothArrays ? (a as Array<any>).length : Object.keys(a).length
+    let equalItems = 0
+    for (let i = 0; i < nextSize; i++) {
+      const key = nextKeys[i]!
+      copy[key] = replaceEqualDeep(a[key], b[key])
+      if (copy[key] === a[key] && a[key] !== undefined) equalItems++
+    }
+    return prevSize === nextSize && equalItems === prevSize ? prev : copy
+  }
+  return Equal.equals(prev, next) ? prev : next
+}
+
+/** Atom combinator: share each new `Success` value structurally against the previous one. */
+const structuralShare = <A, E>(
+  self: Atom.Atom<AsyncResult.AsyncResult<A, E>>
+): Atom.Atom<AsyncResult.AsyncResult<A, E>> =>
+  Atom.transform(self, (get) => {
+    const next = get(self)
+    if (next._tag !== "Success") return next
+    const prev = Option.flatMap(get.self<AsyncResult.AsyncResult<A, E>>(), AsyncResult.value)
+    if (Option.isNone(prev)) return next
+    const shared = replaceEqualDeep(prev.value, next.value)
+    return shared === next.value
+      ? next
+      : AsyncResult.success(shared, { waiting: next.waiting, timestamp: next.timestamp })
+  }, { initialValueTarget: self })
+
+export interface AtomClientRuntime {
+  readonly runtime: Atom.AtomRuntime<any, never>
+  readonly factory: Atom.RuntimeFactory
+}
+
+/**
+ * Build one AtomRuntime (and its factory) from an already-built app context.
+ * Shares the ManagedRuntime's `memoMap` so layers are not built twice, and so
+ * query-registration and mutation-invalidation resolve the SAME `Reactivity`.
+ */
+export const makeAtomClientRuntime = (
+  getContext: () => Layer.Layer<any, never, never>,
+  memoMap: Layer.MemoMap
+): AtomClientRuntime => {
+  const factory = Atom.context({ memoMap })
+  const runtime = factory((_get) => getContext())
+  return { runtime, factory }
+}
+
+const isRetryable = (e: unknown): boolean =>
+  isHttpClientError(e)
+  || S.is(ServiceUnavailableError)(e)
+  || (typeof e === "object" && e !== null && (e as any)._tag === "RpcClientError")
+
+export interface AtomQueryOptions {
+  /** background-refresh threshold (TanStack staleTime; default 5s) */
+  readonly staleTime?: Duration.Input
+  /** dispose-when-idle (TanStack gcTime; default 5min). "infinity" => keepAlive */
+  readonly gcTime?: Duration.Input | "infinity"
+  /**
+   * Revalidate a stale query on window focus AND on network reconnect (default on, matching
+   * tanstack refetchOnWindowFocus + refetchOnReconnect).
+   */
+  readonly revalidateOnFocus?: boolean
+  /**
+   * Reuse references of unchanged sub-trees across refetches (default on, matching tanstack
+   * structuralSharing). Uses Effect `Equal` so decoded Schema instances share too — more effective
+   * than tanstack's `===`, but a deep compare per refetch (O(rows·fields)). Set `false` for very
+   * large or mostly-changing result sets where the compare costs more than the saved re-renders.
+   */
+  readonly structuralSharing?: boolean
+  /** poll: re-fetch every N ms (tanstack refetchInterval). */
+  readonly refetchInterval?: number
+}
+
+const defaults = { staleTime: Duration.seconds(5), gcTime: Duration.minutes(5) }
+
+/** Exported so the vue hook can do refetch-on-mount-per-observer with the same rule as swr. */
+export const isStaleResult = (r: AsyncResult.AsyncResult<any, any>, staleTimeMs: number): boolean => {
+  if (r.waiting) return false
+  const ts = r._tag === "Success"
+    ? r.timestamp
+    : r._tag === "Failure"
+    ? Option.getOrUndefined(Option.map(r.previousSuccess, (s) => s.timestamp))
+    : undefined
+  if (ts === undefined) return r._tag !== "Initial"
+  return Date.now() - ts >= staleTimeMs
+}
+
+export const staleTimeMsOf = (opts: AtomQueryOptions): number =>
+  Duration.toMillis(Duration.fromInputUnsafe(opts.staleTime ?? defaults.staleTime))
+
+export const withQueryOptions = <A, E>(
+  self: Atom.Atom<AsyncResult.AsyncResult<A, E>>,
+  opts: AtomQueryOptions = {}
+): Atom.Atom<AsyncResult.AsyncResult<A, E>> => {
+  const staleTime: Duration.Input = opts.staleTime ?? defaults.staleTime
+  const gcTime = opts.gcTime === "infinity"
+    ? "infinity" as const
+    : Duration.fromInputUnsafe(opts.gcTime ?? defaults.gcTime)
+  let atom = self
+  const revalidateOnFocus = opts.revalidateOnFocus ?? true
+  atom = Atom.swr({
+    staleTime,
+    revalidateOnFocus,
+    focusSignal: revalidateOnFocus ? focusOrReconnectSignal : undefined
+  })(atom)
+  if (opts.refetchInterval) atom = Atom.withRefresh(Duration.millis(opts.refetchInterval))(atom)
+  if (opts.structuralSharing ?? true) atom = structuralShare(atom)
+  return gcTime === "infinity" ? Atom.keepAlive(atom) : Atom.setIdleTTL(atom, gcTime)
+}
+
+/** Constant atom for disabled / `mode:"optional"`-None queries: stays Initial, never fetches. */
+export const disabledQueryAtom: Atom.Atom<AsyncResult.AsyncResult<any, any>> = Atom.readable(() =>
+  AsyncResult.initial(false)
+)
+
+/**
+ * Bumps when the browser regains connectivity (the `online` event) — the tanstack
+ * `refetchOnReconnect` trigger. One shared listener (module-level). SSR-guarded.
+ */
+const onlineSignal: Atom.Atom<number> = Atom.readable((get) => {
+  let count = 0
+  if (typeof window === "undefined") return count
+  const update = () => {
+    if (navigator.onLine) get.setSelf(++count)
+  }
+  window.addEventListener("online", update)
+  get.addFinalizer(() => window.removeEventListener("online", update))
+  return count
+})
+
+/**
+ * Focus OR reconnect, as a single signal for `swr` — both should stale-revalidate a query.
+ * swr takes one `focusSignal`, so we fold window-focus + reconnect into one derived atom;
+ * a bump from either triggers swr's stale check.
+ */
+const focusOrReconnectSignal: Atom.Atom<number> = Atom.make((get) => get(Atom.windowFocusSignal) + get(onlineSignal))
+
+/**
+ * Build the per-input atom family for a request handler — the query CACHE IDENTITY.
+ *
+ * This is the TanStack `queryKey = [handler, input]` equivalent and the piece that makes
+ * caching cross-component: `Atom.family` memoizes one atom per structurally-distinct input
+ * (v4 hashes the input via Hash/Equal), so every component querying the same handler+input
+ * reads the SAME atom instance => one fetch, one shared result in the global registry,
+ * ref-counted and GC'd on idle ttl. (The registry + ttl give lifetime; reactivity keys give
+ * invalidation; the family gives identity/sharing — all three are needed.)
+ *
+ * The family is created once per handler (see query.ts's per-handler cache), so it is shared
+ * process-wide via the registry.
+ *
+ * Invalidation is hierarchical: each atom registers under EVERY prefix of its full key
+ * `[...makeQueryKey(self), input]`. Since reactivity matches keys by exact hash, registering
+ * all prefixes means `invalidate(P)` refreshes every atom whose key starts with `P` — e.g.
+ * `["$X"]` refreshes all inputs, `["$X","$List",input]` only that input. (`makeQueryKey`'s
+ * collapsed form `getQueryKey` — what mutations invalidate by default — is one of the prefixes.)
+ */
+export const buildQueryFamily = <I, A, E>(
+  rt: AtomClientRuntime,
+  self: {
+    readonly id: string
+    readonly handler: (i: I) => Effect.Effect<A, E, any>
+    readonly options?: ClientForOptions
+    readonly queryKeyProjectionHash?: string
+  }
+) => {
+  const baseKey = makeQueryKey(self) // hierarchical, input-independent
+
+  return Atom.family((input: I) => {
+    let atom: Atom.Atom<AsyncResult.AsyncResult<A, E>> = rt.runtime.atom(
+      self
+        .handler(input)
+        .pipe(
+          Effect.retry({ times: 5, while: isRetryable }),
+          Effect.tapCauseIf(Cause.hasDies, (cause) => reportRuntimeError(cause)),
+          Effect.withSpan(`query ${self.id}`, {}, { captureStackTrace: false })
+        )
+    )
+    // Register under every prefix of the full key => hierarchical (prefix) invalidation. Two roles:
+    //   - withReactivity: `Reactivity.invalidate(key)` refreshes this atom (the actual refetch).
+    //   - trackByKeys:    records the atom in `keyAtoms` so the mutation can AWAIT its settle.
+    const fullKey = [...baseKey, input]
+    const projectedFullKey = self.queryKeyProjectionHash === undefined
+      ? fullKey
+      : [...baseKey, self.queryKeyProjectionHash, input]
+    const reactivityKeys = uniqueKeys([...prefixesOf(fullKey), ...prefixesOf(projectedFullKey)])
+    atom = rt.factory.withReactivity(reactivityKeys)(atom)
+    atom = trackByKeys(reactivityKeys)(atom)
+    // gcTime LAST so the whole chain (incl. the registration + tracking) stays alive through the
+    // idle window, letting invalidation reach a cached-but-unmounted query.
+    atom = Atom.setIdleTTL(atom, defaults.gcTime)
+    return Atom.withLabel(`query:${self.id}`)(atom)
+  })
+}
+
+/** Await the first resolved (non-Waiting) result of an atom. Failing query results fail the Effect. */
+export const awaitAtomResult = <A, E>(
+  registry: AtomRegistry.AtomRegistry,
+  atom: Atom.Atom<AsyncResult.AsyncResult<A, E>>
+) =>
+  AtomRegistry.getResult(registry, atom, { suspendOnWaiting: true })

--- a/packages/vue/src/atomQuery.ts
+++ b/packages/vue/src/atomQuery.ts
@@ -13,13 +13,13 @@
  * Built over the app's RPC client through the existing `RequestHandlerWithInput`
  * abstraction (mirrors AtomRpc's recipe; see docs/atom-query-plan.md).
  */
+import { defaultRegistry } from "@effect/atom-vue"
 import { makeQueryKey } from "effect-app/client"
 import type { ClientForOptions } from "effect-app/client/clientFor"
 import { ServiceUnavailableError } from "effect-app/client/errors"
 import * as Effect from "effect-app/Effect"
 import * as Option from "effect-app/Option"
 import * as S from "effect-app/Schema"
-import { defaultRegistry } from "@effect/atom-vue"
 import * as Cause from "effect/Cause"
 import * as Duration from "effect/Duration"
 import * as Equal from "effect/Equal"
@@ -75,7 +75,7 @@ const atomsForKeys = (keys: ReadonlyArray<unknown>): ReadonlyArray<Atom.Atom<Asy
   const atoms = new Set<Atom.Atom<AsyncResult.AsyncResult<any, any>>>()
   for (const key of keys) {
     const set = keyAtoms.get(Hash.hash(key))
-    if (set) for (const a of set) atoms.add(a)
+    if (set) { for (const a of set) atoms.add(a) }
   }
   return [...atoms]
 }
@@ -94,7 +94,7 @@ export const invalidateAndAwait = (keys: ReadonlyArray<unknown>): Effect.Effect<
   Effect.gen(function*() {
     yield* Reactivity.invalidate(keys) // invalidates everything but only refreshes what's mounted
     const atoms = atomsForKeys(keys)
-//    for (const a of atoms) defaultRegistry.refresh(a) // refreshes everything even when not mounted
+    //    for (const a of atoms) defaultRegistry.refresh(a) // refreshes everything even when not mounted
     if (atoms.length === 0) return
     yield* Effect.forEach(atoms, (a) => awaitAtomResult(defaultRegistry, a).pipe(Effect.exit))
   })
@@ -317,5 +317,4 @@ export const buildQueryFamily = <I, A, E>(
 export const awaitAtomResult = <A, E>(
   registry: AtomRegistry.AtomRegistry,
   atom: Atom.Atom<AsyncResult.AsyncResult<A, E>>
-) =>
-  AtomRegistry.getResult(registry, atom, { suspendOnWaiting: true })
+) => AtomRegistry.getResult(registry, atom, { suspendOnWaiting: true })

--- a/packages/vue/src/internal/tanstackQuery.ts
+++ b/packages/vue/src/internal/tanstackQuery.ts
@@ -1,7 +1,5 @@
-import {
-  QueryClient,
-  useQuery as useTanstackQuery
-} from "@tanstack/vue-query"
+import { injectRegistry } from "@effect/atom-vue"
+import { QueryClient, useQuery as useTanstackQuery } from "@tanstack/vue-query"
 import { makeQueryKey, type Req } from "effect-app/client"
 import type { RequestHandlerWithInput } from "effect-app/client/clientFor"
 import { CauseException, ServiceUnavailableError } from "effect-app/client/errors"
@@ -10,23 +8,13 @@ import * as Effect from "effect-app/Effect"
 import * as Option from "effect-app/Option"
 import * as S from "effect-app/Schema"
 import * as Cause from "effect/Cause"
+import { isHttpClientError } from "effect/unstable/http/HttpClientError"
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult"
 import * as Atom from "effect/unstable/reactivity/Atom"
-import { isHttpClientError } from "effect/unstable/http/HttpClientError"
-import { computed, type MaybeRefOrGetter, shallowRef, toValue, type WatchSource, watch } from "vue"
-import { injectRegistry } from "@effect/atom-vue"
-import type {
-  CustomDefinedInitialQueryOptions,
-  CustomDefinedPlaceholderQueryOptions,
-  CustomUndefinedInitialQueryOptions,
-  CustomUseQueryOptions,
-  MakeQuery2,
-  QueryHandle,
-  QueryObserverResult,
-  RefetchOptions,
-} from "../query.ts"
+import { computed, type MaybeRefOrGetter, shallowRef, toValue, watch, type WatchSource } from "vue"
 import { reportRuntimeError } from "../lib.ts"
 import type { QueryInvalidator } from "../mutate.ts"
+import type { CustomDefinedInitialQueryOptions, CustomDefinedPlaceholderQueryOptions, CustomUndefinedInitialQueryOptions, CustomUseQueryOptions, MakeQuery2, QueryHandle, QueryObserverResult, RefetchOptions } from "../query.ts"
 import { makeRunPromise } from "../runtime.ts"
 
 const swrToQuery = <E, A>(r: {
@@ -62,8 +50,7 @@ const isRetryable = (error: unknown) => {
   return false
 }
 
-const isInputOption = <I>(value: I | Option.Option<I> | undefined): value is Option.Option<I> =>
-  Option.isOption(value)
+const isInputOption = <I>(value: I | Option.Option<I> | undefined): value is Option.Option<I> => Option.isOption(value)
 
 const resolveInput = <I>(
   arg: I | WatchSource<I> | undefined | WatchSource<Option.Option<I>>,

--- a/packages/vue/src/internal/tanstackQuery.ts
+++ b/packages/vue/src/internal/tanstackQuery.ts
@@ -1,0 +1,234 @@
+import {
+  QueryClient,
+  useQuery as useTanstackQuery
+} from "@tanstack/vue-query"
+import { makeQueryKey, type Req } from "effect-app/client"
+import type { RequestHandlerWithInput } from "effect-app/client/clientFor"
+import { CauseException, ServiceUnavailableError } from "effect-app/client/errors"
+import type * as Context from "effect-app/Context"
+import * as Effect from "effect-app/Effect"
+import * as Option from "effect-app/Option"
+import * as S from "effect-app/Schema"
+import * as Cause from "effect/Cause"
+import * as AsyncResult from "effect/unstable/reactivity/AsyncResult"
+import * as Atom from "effect/unstable/reactivity/Atom"
+import { isHttpClientError } from "effect/unstable/http/HttpClientError"
+import { computed, type MaybeRefOrGetter, shallowRef, toValue, type WatchSource, watch } from "vue"
+import { injectRegistry } from "@effect/atom-vue"
+import type {
+  CustomDefinedInitialQueryOptions,
+  CustomDefinedPlaceholderQueryOptions,
+  CustomUndefinedInitialQueryOptions,
+  CustomUseQueryOptions,
+  MakeQuery2,
+  QueryHandle,
+  QueryObserverResult,
+  RefetchOptions,
+} from "../query.ts"
+import { reportRuntimeError } from "../lib.ts"
+import type { QueryInvalidator } from "../mutate.ts"
+import { makeRunPromise } from "../runtime.ts"
+
+const swrToQuery = <E, A>(r: {
+  readonly error: CauseException<E> | null | undefined
+  readonly data: A | undefined
+  readonly isValidating: boolean
+}): AsyncResult.AsyncResult<A, E> => {
+  if (r.error !== undefined && r.error !== null) {
+    return AsyncResult.failureWithPrevious(
+      r.error.originalCause,
+      {
+        previous: r.data === undefined ? Option.none() : Option.some(AsyncResult.success(r.data)),
+        waiting: r.isValidating
+      }
+    )
+  }
+  if (r.data !== undefined) {
+    return AsyncResult.success<A, E>(r.data, { waiting: r.isValidating })
+  }
+
+  return AsyncResult.initial(r.isValidating)
+}
+
+const recoverCauseException = <A, E>(error: unknown): Effect.Effect<A, E> =>
+  error instanceof CauseException
+    ? Effect.failCause(error.originalCause)
+    : Effect.die(error)
+
+const isRetryable = (error: unknown) => {
+  if (error instanceof CauseException) {
+    return isHttpClientError(error.cause) || S.is(ServiceUnavailableError)(error.cause)
+  }
+  return false
+}
+
+const isInputOption = <I>(value: I | Option.Option<I> | undefined): value is Option.Option<I> =>
+  Option.isOption(value)
+
+const resolveInput = <I>(
+  arg: I | WatchSource<I> | undefined | WatchSource<Option.Option<I>>,
+  mode: "optional" | undefined
+): I | undefined => {
+  if (mode === "optional") {
+    const option = toValue(arg)
+    return isInputOption(option) && Option.isSome(option) ? option.value : undefined
+  }
+  const value = toValue(arg)
+  return isInputOption(value) ? undefined : value
+}
+
+const resolveEnabled = <I>(
+  arg: I | WatchSource<I> | undefined | WatchSource<Option.Option<I>>,
+  options: {
+    readonly mode?: "optional" | undefined
+    readonly enabled?: MaybeRefOrGetter<boolean | undefined> | undefined
+  } | undefined
+) => {
+  if (options?.mode === "optional") {
+    return computed(() => {
+      const option = toValue(arg)
+      return Option.isSome(option)
+    })
+  }
+  return computed(() => {
+    const enabled = options?.enabled
+    if (enabled === undefined) return true
+    return !!toValue(enabled)
+  })
+}
+
+type LegacyTanstackOptions<A, E, TData> =
+  & (
+    | CustomUndefinedInitialQueryOptions<A, E, TData>
+    | CustomDefinedInitialQueryOptions<A, E, TData>
+    | CustomDefinedPlaceholderQueryOptions<A, E, TData>
+    | CustomUseQueryOptions<A, E, TData>
+  )
+  & { readonly mode?: "optional" | undefined }
+
+export const makeTanstackQueryClient = () => new QueryClient()
+
+export const makeTanstackQueryInvalidator = (queryClient: QueryClient): QueryInvalidator => ({
+  invalidateAndAwait: (keys) =>
+    Effect.forEach(
+      keys,
+      (queryKey) => Effect.promise(() => queryClient.invalidateQueries({ queryKey })),
+      { discard: true, concurrency: "inherit" }
+    )
+})
+
+export const makeTanstackQuery = <R>(
+  getRuntime: () => Context.Context<R>,
+  queryClient: QueryClient
+): MakeQuery2<R> => {
+  const useQuery: MakeQuery2<R> = <I, A, E, Request extends Req, Name extends string>(
+    q: RequestHandlerWithInput<I, A, E, R, Request, Name>
+  ) =>
+  <TData = A>(
+    arg: I | WatchSource<I> | undefined | WatchSource<Option.Option<I>>,
+    options?: LegacyTanstackOptions<A, CauseException<E>, TData>
+  ) => {
+    const runPromise = makeRunPromise(getRuntime())
+    const queryKey = makeQueryKey(q)
+    const projectionHash = q.queryKeyProjectionHash
+    const enabled = resolveEnabled(arg, options)
+    const tanstackOptions = {
+      ...(options?.staleTime !== undefined ? { staleTime: options.staleTime } : {}),
+      ...(typeof options?.gcTime === "number" ? { gcTime: options.gcTime } : {}),
+      ...(options?.refetchOnWindowFocus !== undefined ? { refetchOnWindowFocus: options.refetchOnWindowFocus } : {}),
+      ...(options?.structuralSharing !== undefined ? { structuralSharing: options.structuralSharing } : {}),
+      ...(options?.refetchInterval !== undefined ? { refetchInterval: options.refetchInterval } : {}),
+      ...(options?.select !== undefined ? { select: options.select } : {})
+    }
+    const tanstack = useTanstackQuery<A, CauseException<E>, TData>({
+      ...tanstackOptions,
+      enabled,
+      throwOnError: false,
+      retry: (retryCount: number, error: unknown) => isRetryable(error) && retryCount < 5,
+      queryKey: computed(() => {
+        const input = resolveInput(arg, options?.mode)
+        return projectionHash === undefined ? [...queryKey, input] : [...queryKey, projectionHash, input]
+      }),
+      queryFn: ({ signal }: { readonly signal: AbortSignal }) =>
+        runPromise(
+          q
+            .handler(resolveInput(arg, options?.mode)!)
+            .pipe(
+              Effect.tapCauseIf(Cause.hasDies, (cause) => reportRuntimeError(cause)),
+              Effect.withSpan(`query ${q.id}`, {}, { captureStackTrace: false })
+            ),
+          { signal }
+        )
+    }, queryClient)
+
+    const latestSuccess = shallowRef<TData>()
+    const result = computed((): AsyncResult.AsyncResult<TData, E> =>
+      swrToQuery({
+        error: tanstack.error.value,
+        data: tanstack.data.value === undefined ? latestSuccess.value : tanstack.data.value,
+        isValidating: tanstack.isFetching.value
+      })
+    )
+    watch(result, (value) => latestSuccess.value = Option.getOrUndefined(AsyncResult.value(value)), { immediate: true })
+
+    const registry = injectRegistry()
+    const latestSuccessRef = computed(() => latestSuccess.value)
+    const atom = computed<Atom.Atom<AsyncResult.AsyncResult<TData, E>>>(() => Atom.readable(() => result.value))
+
+    const awaitResult = (): Effect.Effect<TData, E> =>
+      Effect
+        .tryPromise({
+          try: async () => {
+            const queryResult = await tanstack.suspense()
+            const data = queryResult.data
+            if (data === undefined) {
+              throw new Error("TanStack query resolved without data")
+            }
+            return data
+          },
+          catch: (error) => error
+        })
+        .pipe(
+          Effect.catch((error) => recoverCauseException<TData, E>(error))
+        )
+
+    const refetch = (): Effect.Effect<TData, E> =>
+      Effect
+        .tryPromise({
+          try: async () => {
+            const queryResult = await tanstack.refetch({ throwOnError: true })
+            const data = queryResult.data
+            if (data === undefined) {
+              throw new Error("TanStack query refetched without data")
+            }
+            return data
+          },
+          catch: (error) => error
+        })
+        .pipe(
+          Effect.catch((error) => recoverCauseException<TData, E>(error))
+        )
+
+    const handle: QueryHandle<TData, E> = {
+      awaitResult,
+      refetch,
+      refresh: () => {
+        void tanstack.refetch()
+      },
+      registry,
+      atom
+    }
+
+    const fetch = (_options?: RefetchOptions): Effect.Effect<QueryObserverResult<TData, CauseException<E>>> =>
+      refetch().pipe(Effect.exit, Effect.map(AsyncResult.fromExit))
+
+    return [
+      result,
+      latestSuccessRef,
+      fetch,
+      handle
+    ] as const
+  }
+
+  return useQuery
+}

--- a/packages/vue/src/makeClient.ts
+++ b/packages/vue/src/makeClient.ts
@@ -23,7 +23,7 @@ import { makeTanstackQuery, makeTanstackQueryClient, makeTanstackQueryInvalidato
 import { type I18n } from "./intl.ts"
 import { type CommanderResolved, makeUseCommand } from "./makeUseCommand.ts"
 import { atomQueryInvalidator, combineQueryInvalidators, type InvalidationEntry, makeMutation, makeStreamMutation2, type MutationOptionsBase, type QueryInvalidator, useMakeMutation } from "./mutate.ts"
-import { type AtomQueryNewOptions, type CustomUndefinedInitialQueryOptions, makeQuery, makeQueryAtom, makeQueryFamily, makeQueryNew, makeStreamQuery, type QueryObserverResult, type RefetchOptions, type SuspenseQueryView, type UseQueryReturnType } from "./query.ts"
+import { type AtomQueryNewOptions, type CustomUndefinedInitialQueryOptions, makeQuery, makeQueryAtom, makeQueryFamily, makeQueryNew, makeStreamQuery, makeStreamQueryAtom, makeStreamQueryFamily, makeStreamQueryNew, type QueryObserverResult, type RefetchOptions, type StreamQueryAtomFamily, type SuspenseQueryView, type UseQueryReturnType } from "./query.ts"
 import { makeRunPromise } from "./runtime.ts"
 import { type Toast } from "./toast.ts"
 
@@ -215,6 +215,12 @@ declare const useSuspenseQueryNew_: QueryImpl<any>["useSuspenseQueryNew"]
 declare const useSuspenseQuery_: QueryImpl<any>["useSuspenseQuery"]
 // eslint-disable-next-line unused-imports/no-unused-vars
 declare const useStreamQuery_: QueryImpl<any>["useStreamQuery"]
+// eslint-disable-next-line unused-imports/no-unused-vars
+declare const useStreamQueryFamily_: QueryImpl<any>["useStreamQueryFamily"]
+// eslint-disable-next-line unused-imports/no-unused-vars
+declare const useStreamQueryAtom_: QueryImpl<any>["useStreamQueryAtom"]
+// eslint-disable-next-line unused-imports/no-unused-vars
+declare const useStreamQueryNew_: QueryImpl<any>["useStreamQueryNew"]
 
 export interface ProjectResult<RT, I, B, E, R, Request extends Req, Id extends string> {
   request: (i: I) => Effect.Effect<B, E, R>
@@ -304,18 +310,30 @@ export type Queries<RT, Req> = Req extends
   : never
 
 export interface StreamQueryExtensions<Request extends Req, Id extends string, I, A, E> {
+  atom: ReturnType<typeof useStreamQueryAtom_<I, E, A, Request, Id>>
+  family: StreamQueryAtomFamily<I, A, E>
   /**
    * Stream helper for query-stream requests.
-   * Runs as a tracked Vue Query and returns reactive state with accumulated chunks.
-   * Data is an array of all chunks received so far.
+   * Legacy compatibility helper. Collects the whole stream into an array before
+   * publishing data.
    * When `I = void` the input argument may be omitted.
    */
   query: ReturnType<typeof useStreamQuery_<I, E, A, Request, Id>>
+  /**
+   * Atom-native stream query helper. Exposes incremental pull state and a `pull`
+   * command instead of collecting the whole stream first.
+   */
+  queryNew: ReturnType<typeof useStreamQueryNew_<I, E, A, Request, Id>>
 }
 export type StreamQueries<RT, HandlerReq> = HandlerReq extends
   RequestStreamHandlerWithInput<infer I, infer A, infer E, infer R, infer Request, infer Id, infer _Final>
   ? Exclude<R, RT> extends never ? StreamQueryExtensions<Request, Id, I, A, E>
-  : { query: MissingDependencies<RT, R> & {} }
+  : {
+    atom: MissingDependencies<RT, R> & {}
+    family: MissingDependencies<RT, R> & {}
+    query: MissingDependencies<RT, R> & {}
+    queryNew: MissingDependencies<RT, R> & {}
+  }
   : never
 
 const _useMutation = makeMutation(atomQueryInvalidator)
@@ -393,6 +411,9 @@ export class QueryImpl<R> {
     this.useQueryAtom = makeQueryAtom(this.getRuntime, getAtomRt)
     this.useQueryFamily = makeQueryFamily(this.getRuntime, getAtomRt)
     this.useStreamQuery = makeStreamQuery(this.getRuntime, getAtomRt)
+    this.useStreamQueryFamily = makeStreamQueryFamily(this.getRuntime, getAtomRt)
+    this.useStreamQueryAtom = makeStreamQueryAtom(this.getRuntime, getAtomRt)
+    this.useStreamQueryNew = makeStreamQueryNew(this.getRuntime, getAtomRt)
   }
   /**
    * Effect results are passed to the caller, including errors.
@@ -411,6 +432,12 @@ export class QueryImpl<R> {
    * @deprecated use client helpers instead (.query())
    */
   readonly useStreamQuery: ReturnType<typeof makeStreamQuery<R>>
+
+  readonly useStreamQueryFamily: ReturnType<typeof makeStreamQueryFamily<R>>
+
+  readonly useStreamQueryAtom: ReturnType<typeof makeStreamQueryAtom<R>>
+
+  readonly useStreamQueryNew: ReturnType<typeof makeStreamQueryNew<R>>
 
   /**
    * The difference with useQuery is that this function will return a Promise you can await in the Setup,
@@ -685,9 +712,15 @@ export const makeClient = <RT_, RTHooks>(
   const useSuspenseQuery = query.useSuspenseQuery
   const useSuspenseQueryNew = query.useSuspenseQueryNew
   const useStreamQuery = query.useStreamQuery
+  const useStreamQueryFamily = query.useStreamQueryFamily
+  const useStreamQueryAtom = query.useStreamQueryAtom
+  const useStreamQueryNew = query.useStreamQueryNew
 
   const isQueryHandler = <H extends { readonly Request: Req }>(handler: H): handler is QueryHandler<H> =>
     handler.Request.type === "query" && !handler.Request.stream
+
+  const isStreamQueryHandler = <H extends { readonly Request: Req }>(handler: H): handler is QueryStreamHandler<H> =>
+    handler.Request.type === "query" && handler.Request.stream
 
   const queryHelpersFor = <I, A, E, Request extends Req, Name extends string>(
     handler: RequestHandlerWithInput<I, A, E, RT, Request, Name>
@@ -698,6 +731,15 @@ export const makeClient = <RT_, RTHooks>(
     queryNew: useQueryNew(handler),
     suspense: useSuspenseQuery(handler),
     suspenseNew: useSuspenseQueryNew(handler)
+  })
+
+  const streamQueryHelpersFor = <I, A, E, Request extends Req, Name extends string>(
+    handler: RequestStreamHandlerWithInput<I, A, E, RT, Request, Name>
+  ) => ({
+    family: useStreamQueryFamily(handler),
+    atom: useStreamQueryAtom(handler),
+    query: useStreamQuery(handler),
+    queryNew: useStreamQueryNew(handler)
   })
 
   const projectQueryFor = <I, A, E, Request extends Req, Name extends string>(
@@ -765,8 +807,6 @@ export const makeClient = <RT_, RTHooks>(
     const queries = Struct.keys(client).reduce(
       (acc, key) => {
         const handler = client[key]
-        const requestType = handler.Request.type
-        const isStream = handler.Request.stream
         if (isQueryHandler(handler)) {
           Object.assign(acc, {
             [camelCase(key) + "QueryFamily"]: Object.assign(useQueryFamily(handler), {
@@ -788,9 +828,18 @@ export const makeClient = <RT_, RTHooks>(
               id: client[key].id
             }
           )
-        } else if (requestType === "query" && isStream) {
-          ;(acc as any)[camelCase(key) + "Query"] = Object.assign(useStreamQuery(client[key] as any), {
-            id: client[key].id
+        } else if (isStreamQueryHandler(handler)) {
+          const streamHelpers = streamQueryHelpersFor(handler)
+          Object.assign(acc, {
+            [camelCase(key) + "QueryFamily"]: Object.assign(streamHelpers.family, {
+              id: client[key].id
+            }),
+            [camelCase(key) + "Query"]: Object.assign(streamHelpers.query, {
+              id: client[key].id
+            }),
+            [camelCase(key) + "QueryNew"]: Object.assign(streamHelpers.queryNew, {
+              id: client[key].id
+            })
           })
         }
         return acc
@@ -838,8 +887,20 @@ export const makeClient = <RT_, RTHooks>(
         & {
           [
             Key in keyof typeof client as QueryStreamHandler<typeof client[Key]> extends never ? never
+              : `${ToCamel<string & Key>}QueryFamily`
+          ]: StreamQueries<RT, QueryStreamHandler<typeof client[Key]>>["family"]
+        }
+        & {
+          [
+            Key in keyof typeof client as QueryStreamHandler<typeof client[Key]> extends never ? never
               : `${ToCamel<string & Key>}Query`
           ]: StreamQueries<RT, QueryStreamHandler<typeof client[Key]>>["query"]
+        }
+        & {
+          [
+            Key in keyof typeof client as QueryStreamHandler<typeof client[Key]> extends never ? never
+              : `${ToCamel<string & Key>}QueryNew`
+          ]: StreamQueries<RT, QueryStreamHandler<typeof client[Key]>>["queryNew"]
         }
     )
     return queries
@@ -964,11 +1025,11 @@ export const makeClient = <RT_, RTHooks>(
               ...queryHelpersFor(handler),
               project: projectQueryFor(handler)
             }
-            : requestType === "query" && isStream
+            : isStreamQueryHandler(handler)
             ? {
               ...client[key],
               request,
-              query: useStreamQuery(client[key] as any)
+              ...streamQueryHelpersFor(handler)
             }
             : requestType === "command" && isStream
             ? (() => {

--- a/packages/vue/src/makeClient.ts
+++ b/packages/vue/src/makeClient.ts
@@ -17,25 +17,13 @@ import * as Struct from "effect/Struct"
 import type * as AsyncResult from "effect/unstable/reactivity/AsyncResult"
 import * as Reactivity from "effect/unstable/reactivity/Reactivity"
 import { computed, type ComputedRef, onBeforeUnmount, ref, type WatchSource } from "vue"
+import { type AtomClientRuntime, invalidateAndAwait, makeAtomClientRuntime } from "./atomQuery.ts"
 import { type Commander, CommanderStatic, type Progress } from "./commander.ts"
+import { makeTanstackQuery, makeTanstackQueryClient, makeTanstackQueryInvalidator } from "./internal/tanstackQuery.ts"
 import { type I18n } from "./intl.ts"
 import { type CommanderResolved, makeUseCommand } from "./makeUseCommand.ts"
 import { atomQueryInvalidator, combineQueryInvalidators, type InvalidationEntry, makeMutation, makeStreamMutation2, type MutationOptionsBase, type QueryInvalidator, useMakeMutation } from "./mutate.ts"
-import { type AtomClientRuntime, invalidateAndAwait, makeAtomClientRuntime } from "./atomQuery.ts"
-import { makeTanstackQuery, makeTanstackQueryClient, makeTanstackQueryInvalidator } from "./internal/tanstackQuery.ts"
-import {
-  type AtomQueryNewOptions,
-  type CustomUndefinedInitialQueryOptions,
-  makeQuery,
-  makeQueryAtom,
-  makeQueryFamily,
-  makeQueryNew,
-  makeStreamQuery,
-  type QueryObserverResult,
-  type RefetchOptions,
-  type SuspenseQueryView,
-  type UseQueryReturnType
-} from "./query.ts"
+import { type AtomQueryNewOptions, type CustomUndefinedInitialQueryOptions, makeQuery, makeQueryAtom, makeQueryFamily, makeQueryNew, makeStreamQuery, type QueryObserverResult, type RefetchOptions, type SuspenseQueryView, type UseQueryReturnType } from "./query.ts"
 import { makeRunPromise } from "./runtime.ts"
 import { type Toast } from "./toast.ts"
 
@@ -556,15 +544,18 @@ export class QueryImpl<R> {
           registry: view.registry,
           atom: view.atom
         }
-        return Object.assign([
-          view.result,
-          data,
-          fetch,
-          handle
-        ] as const, {
-          ...view,
-          data
-        })
+        return Object.assign(
+          [
+            view.result,
+            data,
+            fetch,
+            handle
+          ] as const,
+          {
+            ...view,
+            data
+          }
+        )
       })
 
       return runPromise(eff)
@@ -666,8 +657,8 @@ export const makeClient = <RT_, RTHooks>(
   // one AtomRuntime for the query engine, built lazily from the live app context;
   // shares the ManagedRuntime memoMap so layers + Reactivity are the same instances.
   let atomRt: AtomClientRuntime | undefined
-  const getAtomRt = () =>
-    (atomRt ??= makeAtomClientRuntime(() => Layer.succeedContext(getBaseRt()), getBaseMrt().memoMap))
+  const getAtomRt =
+    () => (atomRt ??= makeAtomClientRuntime(() => Layer.succeedContext(getBaseRt()), getBaseMrt().memoMap))
 
   const legacyQueryEngine = options?.legacyQueryEngine ?? "tanstack"
   let tanstackQueryClient: ReturnType<typeof makeTanstackQueryClient> | undefined

--- a/packages/vue/src/makeClient.ts
+++ b/packages/vue/src/makeClient.ts
@@ -1,12 +1,12 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { isCancelledError, type QueryObserverResult, type RefetchOptions, type UseQueryReturnType } from "@tanstack/vue-query"
 import { camelCase } from "change-case"
 import { type ApiClientFactory, type Req } from "effect-app/client"
 import type { ExtractModuleName, HandlerInput, RequestHandlers, RequestHandlerWithInput, RequestsAny, RequestStreamHandlerWithInput } from "effect-app/client/clientFor"
+import type { CauseException } from "effect-app/client/errors"
 import type { InvalidationCallback } from "effect-app/client/makeClient"
-import type * as Context from "effect-app/Context"
+import * as Context from "effect-app/Context"
 import * as Effect from "effect-app/Effect"
-import type * as Layer from "effect-app/Layer"
+import * as Layer from "effect-app/Layer"
 import * as S from "effect-app/Schema"
 import * as Exit from "effect/Exit"
 import { type Fiber } from "effect/Fiber"
@@ -14,28 +14,42 @@ import * as Hash from "effect/Hash"
 import type * as ManagedRuntime from "effect/ManagedRuntime"
 import type * as Stream from "effect/Stream"
 import * as Struct from "effect/Struct"
-import * as AsyncResult from "effect/unstable/reactivity/AsyncResult"
-import { type ComputedRef, onBeforeUnmount, ref, type WatchSource } from "vue"
+import type * as AsyncResult from "effect/unstable/reactivity/AsyncResult"
+import * as Reactivity from "effect/unstable/reactivity/Reactivity"
+import { computed, type ComputedRef, onBeforeUnmount, ref, type WatchSource } from "vue"
 import { type Commander, CommanderStatic, type Progress } from "./commander.ts"
 import { type I18n } from "./intl.ts"
 import { type CommanderResolved, makeUseCommand } from "./makeUseCommand.ts"
-import { type InvalidationEntry, makeMutation, makeStreamMutation2, type MutationOptionsBase, useMakeMutation } from "./mutate.ts"
-import { type CustomUndefinedInitialQueryOptions, makeQuery, makeStreamQuery } from "./query.ts"
+import { atomQueryInvalidator, combineQueryInvalidators, type InvalidationEntry, makeMutation, makeStreamMutation2, type MutationOptionsBase, type QueryInvalidator, useMakeMutation } from "./mutate.ts"
+import { type AtomClientRuntime, invalidateAndAwait, makeAtomClientRuntime } from "./atomQuery.ts"
+import { makeTanstackQuery, makeTanstackQueryClient, makeTanstackQueryInvalidator } from "./internal/tanstackQuery.ts"
+import {
+  type AtomQueryNewOptions,
+  type CustomUndefinedInitialQueryOptions,
+  makeQuery,
+  makeQueryAtom,
+  makeQueryFamily,
+  makeQueryNew,
+  makeStreamQuery,
+  type QueryObserverResult,
+  type RefetchOptions,
+  type SuspenseQueryView,
+  type UseQueryReturnType
+} from "./query.ts"
 import { makeRunPromise } from "./runtime.ts"
-import { awaitResolvedSuspenseResult } from "./suspense.ts"
 import { type Toast } from "./toast.ts"
 
 export type { Progress }
 
 // TODO: optimize - work from encoded shape directly
-const projectHandler = (
-  handler: (i: any) => Effect.Effect<any, any, any>,
+const projectHandler = <I, A, E, R, ProjSchema extends S.Decoder<unknown, never>>(
+  handler: (i: I) => Effect.Effect<A, E, R>,
   successSchema: S.Top,
-  projectionSchema: S.Top
+  projectionSchema: ProjSchema
 ) => {
-  const encode = S.encodeEffect(successSchema)
-  const decode = S.decodeEffectConcurrently(projectionSchema)
-  return (i: any) => handler(i).pipe(Effect.flatMap(encode), Effect.flatMap(decode))
+  const encode = S.encodeSync(successSchema as S.Encoder<A>)
+  const decode = S.decodeSync(projectionSchema)
+  return (i: I) => handler(i).pipe(Effect.map((value) => decode(encode(value))))
 }
 
 const projectionSchemaHash = (schema: S.Top) => String(Hash.hash(schema.ast))
@@ -202,15 +216,31 @@ export type StreamMutation2WithExtensions<RT, Req> = Req extends
 // eslint-disable-next-line unused-imports/no-unused-vars
 declare const useQuery_: QueryImpl<any>["useQuery"]
 // eslint-disable-next-line unused-imports/no-unused-vars
+declare const useQueryNew_: QueryImpl<any>["useQueryNew"]
+// eslint-disable-next-line unused-imports/no-unused-vars
+declare const useQueryAtom_: QueryImpl<any>["useQueryAtom"]
+// eslint-disable-next-line unused-imports/no-unused-vars
+declare const useQueryFamily_: QueryImpl<any>["useQueryFamily"]
+// eslint-disable-next-line unused-imports/no-unused-vars
+declare const useSuspenseQueryNew_: QueryImpl<any>["useSuspenseQueryNew"]
+// eslint-disable-next-line unused-imports/no-unused-vars
 declare const useSuspenseQuery_: QueryImpl<any>["useSuspenseQuery"]
 // eslint-disable-next-line unused-imports/no-unused-vars
 declare const useStreamQuery_: QueryImpl<any>["useStreamQuery"]
 
 export interface ProjectResult<RT, I, B, E, R, Request extends Req, Id extends string> {
   request: (i: I) => Effect.Effect<B, E, R>
+  family: Exclude<R, RT> extends never ? ReturnType<typeof useQueryFamily_<I, E, B, Request, Id>>
+    : MissingDependencies<RT, R> & {}
   query: Exclude<R, RT> extends never ? ReturnType<typeof useQuery_<I, E, B, Request, Id>>
     : MissingDependencies<RT, R> & {}
+  queryNew: Exclude<R, RT> extends never ? ReturnType<typeof useQueryNew_<I, E, B, Request, Id>>
+    : MissingDependencies<RT, R> & {}
   suspense: Exclude<R, RT> extends never ? ReturnType<typeof useSuspenseQuery_<I, E, B, Request, Id>>
+    : MissingDependencies<RT, R> & {}
+  suspenseNew: Exclude<R, RT> extends never ? ReturnType<typeof useSuspenseQueryNew_<I, E, B, Request, Id>>
+    : MissingDependencies<RT, R> & {}
+  atom: Exclude<R, RT> extends never ? ReturnType<typeof useQueryAtom_<I, E, B, Request, Id>>
     : MissingDependencies<RT, R> & {}
 }
 
@@ -240,12 +270,30 @@ export interface QueryResultExtensions<Request extends Req, Id extends string, I
    * When `I = void` the input argument may be omitted.
    */
   query: ReturnType<typeof useQuery_<I, E, A, Request, Id>>
+  /**
+   * Atom-native query helper with object return shape.
+   * Additive migration surface; `.query()` remains the compatibility tuple API.
+   */
+  queryNew: ReturnType<typeof useQueryNew_<I, E, A, Request, Id>>
   // TODO or suspense as Option?
   /**
    * Like `.query`, but returns a Promise for setup-time awaiting.
    * Use this when integrating with Vue Suspense / error boundaries.
    */
   suspense: ReturnType<typeof useSuspenseQuery_<I, E, A, Request, Id>>
+  /**
+   * Promise-based setup helper with object return shape.
+   * Additive migration surface; `.suspense()` remains the compatibility tuple API.
+   */
+  suspenseNew: ReturnType<typeof useSuspenseQueryNew_<I, E, A, Request, Id>>
+  /**
+   * Raw query atom for composition outside Vue refs.
+   */
+  atom: ReturnType<typeof useQueryAtom_<I, E, A, Request, Id>>
+  /**
+   * Raw query atom family for composing query graphs before choosing a Vue observer.
+   */
+  family: ReturnType<typeof useQueryFamily_<I, E, A, Request, Id>>
 }
 
 export type MissingDependencies<RT, R> = {
@@ -256,7 +304,14 @@ export type MissingDependencies<RT, R> = {
 export type Queries<RT, Req> = Req extends
   RequestHandlerWithInput<infer I, infer A, infer E, infer R, infer Request, infer Id>
   ? Request["type"] extends "query" ? Exclude<R, RT> extends never ? QueryResultExtensions<Request, Id, I, A, E>
-    : { query: MissingDependencies<RT, R> & {}; suspense: MissingDependencies<RT, R> & {} }
+    : {
+      atom: MissingDependencies<RT, R> & {}
+      family: MissingDependencies<RT, R> & {}
+      query: MissingDependencies<RT, R> & {}
+      queryNew: MissingDependencies<RT, R> & {}
+      suspense: MissingDependencies<RT, R> & {}
+      suspenseNew: MissingDependencies<RT, R> & {}
+    }
   : never
   : never
 
@@ -275,7 +330,7 @@ export type StreamQueries<RT, HandlerReq> = HandlerReq extends
   : { query: MissingDependencies<RT, R> & {} }
   : never
 
-const _useMutation = makeMutation()
+const _useMutation = makeMutation(atomQueryInvalidator)
 
 const wrapWithSpan = (self: { id: string }, mut: any) => {
   const span = (eff: Effect.Effect<any, any, any>) =>
@@ -308,8 +363,8 @@ export const useMutation: typeof _useMutation = (<
  * Executes query cache invalidation based on default rules or provided option.
  * adds a span with the mutation id
  */
-export const useMutationInt = (): typeof _useMutation => {
-  const _useMutation = useMakeMutation()
+export const useMutationInt = (queryInvalidator: QueryInvalidator): typeof _useMutation => {
+  const _useMutation = useMakeMutation(queryInvalidator)
   return (<
     I,
     E,
@@ -328,19 +383,40 @@ export const useMutationInt = (): typeof _useMutation => {
 
 export type ClientFrom<M extends RequestsAny> = RequestHandlers<never, never, M, ExtractModuleName<M>>
 
+export interface MakeClientOptions {
+  /**
+   * Selects the engine behind legacy `.query()` / `.suspense()` helpers.
+   * Atom-native `.atom()` / `.family()` / `.queryNew()` / `.suspenseNew()` always use Atom.
+   */
+  readonly legacyQueryEngine?: "atom" | "tanstack"
+}
+
 export class QueryImpl<R> {
   readonly getRuntime: () => Context.Context<R>
 
-  constructor(getRuntime: () => Context.Context<R>) {
+  constructor(
+    getRuntime: () => Context.Context<R>,
+    getAtomRt: () => AtomClientRuntime,
+    legacyUseQuery?: ReturnType<typeof makeQuery<R>>
+  ) {
     this.getRuntime = getRuntime
-    this.useQuery = makeQuery(this.getRuntime)
-    this.useStreamQuery = makeStreamQuery(this.getRuntime)
+    this.useQuery = legacyUseQuery ?? makeQuery(this.getRuntime, getAtomRt)
+    this.useQueryNew = makeQueryNew(this.getRuntime, getAtomRt)
+    this.useQueryAtom = makeQueryAtom(this.getRuntime, getAtomRt)
+    this.useQueryFamily = makeQueryFamily(this.getRuntime, getAtomRt)
+    this.useStreamQuery = makeStreamQuery(this.getRuntime, getAtomRt)
   }
   /**
    * Effect results are passed to the caller, including errors.
    * @deprecated use client helpers instead (.query())
    */
   readonly useQuery: ReturnType<typeof makeQuery<R>>
+
+  readonly useQueryNew: ReturnType<typeof makeQueryNew<R>>
+
+  readonly useQueryAtom: ReturnType<typeof makeQueryAtom<R>>
+
+  readonly useQueryFamily: ReturnType<typeof makeQueryFamily<R>>
 
   /**
    * Stream results are accumulated as an array of chunks and returned as reactive state.
@@ -370,7 +446,10 @@ export class QueryImpl<R> {
     >(
       self: RequestHandlerWithInput<I, A, E, R, Request, Name>
     ): {
-      <TData = A>(arg: I | WatchSource<I>, options?: CustomUndefinedInitialQueryOptions<A, E, TData>): Promise<
+      <TData = A>(
+        arg: I | WatchSource<I>,
+        options?: CustomUndefinedInitialQueryOptions<A, CauseException<E>, TData>
+      ): Promise<
         readonly [
           ComputedRef<AsyncResult.AsyncResult<TData, E>>,
           ComputedRef<TData>,
@@ -385,10 +464,19 @@ export class QueryImpl<R> {
     self: RequestHandlerWithInput<I, A, E, R, Request, Name>
   ) => {
     const runPromise = makeRunPromise(this.getRuntime())
-    const q = this.useQuery(self as any) as any
-    return (argOrOptions?: any, options?: any) => {
-      const [resultRef, latestRef, fetch, uqrt] = q(argOrOptions, { ...options, suspense: true } // experimental_prefetchInRender: true }
-      )
+    const q = this.useQuery(self)
+    return <TData = A>(
+      argOrOptions: I | WatchSource<I>,
+      options?: CustomUndefinedInitialQueryOptions<A, CauseException<E>, TData>
+    ) => {
+      const [resultRef, latestRef, fetch, uqrt] = q<TData>(argOrOptions, options)
+      const latestDefinedRef = computed<TData>(() => {
+        const latest = latestRef.value
+        if (latest === undefined) {
+          throw new Error("Internal Error: suspense resolved without a latest value")
+        }
+        return latest
+      })
 
       const isMounted = ref(true)
       onBeforeUnmount(() => {
@@ -397,36 +485,86 @@ export class QueryImpl<R> {
 
       // @effect-diagnostics effect/missingEffectError:off
       const eff = Effect.gen(function*() {
-        // we want to throw on error so that we can catch cancelled error and skip handling it
-        // what's the difference with just calling `fetch` ?
-        // we will receive a CancelledError which we will have to ignore in our ErrorBoundary, otherwise the user ends up on an error page even if the user e.g cancelled a navigation
-        const r = yield* Effect.tryPromise(() => uqrt.suspense()).pipe(
-          Effect.catchTag("UnknownError", (err) =>
-            isCancelledError(err.cause)
-              ? Effect.interrupt
-              : Effect.die(err.cause))
-        )
+        const exit = yield* uqrt.awaitResult().pipe(Effect.exit)
         if (!isMounted.value) {
           return yield* Effect.interrupt
         }
-        const result = yield* awaitResolvedSuspenseResult(resultRef)
-        if (AsyncResult.isInitial(result)) {
-          console.error("Internal Error: Promise should be resolved already", {
-            self,
-            argOrOptions,
-            options,
-            r,
-            resultRef
-          })
-          return yield* Effect.die(
-            "Internal Error: Promise should be resolved already"
-          )
-        }
-        if (AsyncResult.isFailure(result)) {
-          return yield* Exit.failCause(result.cause)
+        if (Exit.isFailure(exit)) {
+          return yield* Exit.failCause(exit.cause)
         }
 
-        return [resultRef, latestRef, fetch, uqrt] as const
+        return [resultRef, latestDefinedRef, fetch, uqrt] as const
+      })
+
+      return runPromise(eff)
+    }
+  }
+
+  readonly useSuspenseQueryNew: {
+    <
+      I,
+      E,
+      A,
+      Request extends Req,
+      Name extends string
+    >(
+      self: RequestHandlerWithInput<I, A, E, R, Request, Name>
+    ): {
+      <TData = A>(
+        arg: I | WatchSource<I>,
+        options?: AtomQueryNewOptions<A, TData>
+      ): Promise<SuspenseQueryView<TData, E>>
+    }
+  } = <I, E, A, Request extends Req, Name extends string>(
+    self: RequestHandlerWithInput<I, A, E, R, Request, Name>
+  ) => {
+    const runPromise = makeRunPromise(this.getRuntime())
+    const q = this.useQueryNew(self)
+    return <TData = A>(
+      argOrOptions: I | WatchSource<I>,
+      options?: AtomQueryNewOptions<A, TData>
+    ) => {
+      const view = q<TData>(argOrOptions, options)
+      const data = computed<TData>(() => {
+        const latest = view.data.value
+        if (latest === undefined) {
+          throw new Error("Internal Error: suspenseNew resolved without a latest value")
+        }
+        return latest
+      })
+
+      const isMounted = ref(true)
+      onBeforeUnmount(() => {
+        isMounted.value = false
+      })
+
+      // @effect-diagnostics effect/missingEffectError:off
+      const eff = Effect.gen(function*() {
+        const exit = yield* view.awaitResult().pipe(Effect.exit)
+        if (!isMounted.value) {
+          return yield* Effect.interrupt
+        }
+        if (Exit.isFailure(exit)) {
+          return yield* Exit.failCause(exit.cause)
+        }
+
+        const fetch = (_options?: RefetchOptions) => view.refetch()
+        const handle = {
+          awaitResult: view.awaitResult,
+          refetch: view.refetch,
+          refresh: view.refresh,
+          registry: view.registry,
+          atom: view.atom
+        }
+        return Object.assign([
+          view.result,
+          data,
+          fetch,
+          handle
+        ] as const, {
+          ...view,
+          data
+        })
       })
 
       return runPromise(eff)
@@ -493,11 +631,31 @@ type ClientForArgs<
     >
   ]
 
+const makeResolvedAtomQueryInvalidator = <R>(getContext: () => Context.Context<R>): QueryInvalidator => {
+  let reactivity: Context.Service.Shape<typeof Reactivity.Reactivity> | undefined
+  const getReactivity = () => {
+    if (reactivity !== undefined) return reactivity
+    const service = Context.getOrUndefined(getContext(), Reactivity.Reactivity)
+    if (service === undefined) {
+      throw new Error("Reactivity service is missing from the client runtime")
+    }
+    return reactivity = service
+  }
+
+  return {
+    invalidateAndAwait: (keys) =>
+      invalidateAndAwait(keys).pipe(
+        Effect.provideService(Reactivity.Reactivity, getReactivity())
+      )
+  }
+}
+
 export const makeClient = <RT_, RTHooks>(
   // global, but only accessible after startup has completed
   getBaseMrt: () => ManagedRuntime.ManagedRuntime<RT_ | Mix, never>,
   clientFor_: ReturnType<typeof ApiClientFactory["makeFor"]>,
-  rtHooks: Layer.Layer<RTHooks, never, Mix>
+  rtHooks: Layer.Layer<RTHooks, never, Mix>,
+  options?: MakeClientOptions
 ) => {
   type RT = RT_ | Mix
   const getBaseRt = () => managedRuntimeRt(getBaseMrt())
@@ -505,16 +663,76 @@ export const makeClient = <RT_, RTHooks>(
   let cmd: Effect.Success<typeof makeCommand>
   const useCommand = () => cmd ??= getBaseMrt().runSync(makeCommand)
 
+  // one AtomRuntime for the query engine, built lazily from the live app context;
+  // shares the ManagedRuntime memoMap so layers + Reactivity are the same instances.
+  let atomRt: AtomClientRuntime | undefined
+  const getAtomRt = () =>
+    (atomRt ??= makeAtomClientRuntime(() => Layer.succeedContext(getBaseRt()), getBaseMrt().memoMap))
+
+  const legacyQueryEngine = options?.legacyQueryEngine ?? "tanstack"
+  let tanstackQueryClient: ReturnType<typeof makeTanstackQueryClient> | undefined
+  const getTanstackQueryClient = () => tanstackQueryClient ??= makeTanstackQueryClient()
+  const atomInvalidator = makeResolvedAtomQueryInvalidator(getBaseRt)
+  const queryInvalidator = legacyQueryEngine === "tanstack"
+    ? combineQueryInvalidators(atomInvalidator, makeTanstackQueryInvalidator(getTanstackQueryClient()))
+    : atomInvalidator
+
   let m: ReturnType<typeof useMutationInt>
-  const useMutation = () => m ??= useMutationInt()
+  const useMutation = () => m ??= useMutationInt(queryInvalidator)
 
   let sm2: ReturnType<typeof makeStreamMutation2>
-  const useStreamMutation2 = () => sm2 ??= makeStreamMutation2()
+  const useStreamMutation2 = () => sm2 ??= makeStreamMutation2(queryInvalidator)
 
-  const query = new QueryImpl(getBaseRt)
+  const legacyUseQuery = legacyQueryEngine === "tanstack"
+    ? makeTanstackQuery(getBaseRt, getTanstackQueryClient())
+    : undefined
+  const query = new QueryImpl(getBaseRt, getAtomRt, legacyUseQuery)
   const useQuery = query.useQuery
+  const useQueryNew = query.useQueryNew
+  const useQueryAtom = query.useQueryAtom
+  const useQueryFamily = query.useQueryFamily
   const useSuspenseQuery = query.useSuspenseQuery
+  const useSuspenseQueryNew = query.useSuspenseQueryNew
   const useStreamQuery = query.useStreamQuery
+
+  const isQueryHandler = <H extends { readonly Request: Req }>(handler: H): handler is QueryHandler<H> =>
+    handler.Request.type === "query" && !handler.Request.stream
+
+  const queryHelpersFor = <I, A, E, Request extends Req, Name extends string>(
+    handler: RequestHandlerWithInput<I, A, E, RT, Request, Name>
+  ) => ({
+    family: useQueryFamily(handler),
+    atom: useQueryAtom(handler),
+    query: useQuery(handler),
+    queryNew: useQueryNew(handler),
+    suspense: useSuspenseQuery(handler),
+    suspenseNew: useSuspenseQueryNew(handler)
+  })
+
+  const projectQueryFor = <I, A, E, Request extends Req, Name extends string>(
+    handler: RequestHandlerWithInput<I, A, E, RT, Request, Name>
+  ) =>
+  <ProjSchema extends S.Decoder<unknown, never>>(projectionSchema: ProjSchema) => {
+    const successSchema = handler.Request.success
+    const projectionHash = projectionSchemaHash(projectionSchema)
+    const projected = projectHandler(handler.handler, successSchema, projectionSchema)
+    const projectedHandler = {
+      handler: projected,
+      id: handler.id,
+      Request: handler.Request,
+      queryKeyProjectionHash: projectionHash
+    }
+    if (handler.options) {
+      return {
+        request: projected,
+        ...queryHelpersFor({ ...projectedHandler, options: handler.options })
+      }
+    }
+    return {
+      request: projected,
+      ...queryHelpersFor(projectedHandler)
+    }
+  }
 
   const mergeInvalidation = (
     a?: MutationOptionsBase["queryInvalidation"],
@@ -555,15 +773,30 @@ export const makeClient = <RT_, RTHooks>(
   ) => {
     const queries = Struct.keys(client).reduce(
       (acc, key) => {
-        const requestType = client[key].Request.type
-        const isStream = client[key].Request.stream
-        if (requestType === "query" && !isStream) {
-          ;(acc as any)[camelCase(key) + "Query"] = Object.assign(useQuery(client[key] as any), {
+        const handler = client[key]
+        const requestType = handler.Request.type
+        const isStream = handler.Request.stream
+        if (isQueryHandler(handler)) {
+          Object.assign(acc, {
+            [camelCase(key) + "QueryFamily"]: Object.assign(useQueryFamily(handler), {
+              id: client[key].id
+            })
+          })
+          ;(acc as any)[camelCase(key) + "Query"] = Object.assign(useQuery(handler), {
             id: client[key].id
           })
-          ;(acc as any)[camelCase(key) + "SuspenseQuery"] = Object.assign(useSuspenseQuery(client[key] as any), {
+          ;(acc as any)[camelCase(key) + "QueryNew"] = Object.assign(useQueryNew(handler), {
             id: client[key].id
           })
+          ;(acc as any)[camelCase(key) + "SuspenseQuery"] = Object.assign(useSuspenseQuery(handler), {
+            id: client[key].id
+          })
+          ;(acc as any)[camelCase(key) + "SuspenseQueryNew"] = Object.assign(
+            useSuspenseQueryNew(handler),
+            {
+              id: client[key].id
+            }
+          )
         } else if (requestType === "query" && isStream) {
           ;(acc as any)[camelCase(key) + "Query"] = Object.assign(useStreamQuery(client[key] as any), {
             id: client[key].id
@@ -573,11 +806,23 @@ export const makeClient = <RT_, RTHooks>(
       },
       {} as
         & {
+          [
+            Key in keyof typeof client as QueryHandler<typeof client[Key]> extends never ? never
+              : `${ToCamel<string & Key>}QueryFamily`
+          ]: Queries<RT, QueryHandler<typeof client[Key]>>["family"]
+        }
+        & {
           // apparently can't get JSDoc in here..
           [
             Key in keyof typeof client as QueryHandler<typeof client[Key]> extends never ? never
               : `${ToCamel<string & Key>}Query`
           ]: Queries<RT, QueryHandler<typeof client[Key]>>["query"]
+        }
+        & {
+          [
+            Key in keyof typeof client as QueryHandler<typeof client[Key]> extends never ? never
+              : `${ToCamel<string & Key>}QueryNew`
+          ]: Queries<RT, QueryHandler<typeof client[Key]>>["queryNew"]
         }
         // todo: or suspense as an Option?
         & {
@@ -589,6 +834,15 @@ export const makeClient = <RT_, RTHooks>(
             RT,
             QueryHandler<typeof client[Key]>
           >["suspense"]
+        }
+        & {
+          [
+            Key in keyof typeof client as QueryHandler<typeof client[Key]> extends never ? never
+              : `${ToCamel<string & Key>}SuspenseQueryNew`
+          ]: Queries<
+            RT,
+            QueryHandler<typeof client[Key]>
+          >["suspenseNew"]
         }
         & {
           [
@@ -705,35 +959,19 @@ export const makeClient = <RT_, RTHooks>(
     const queryResources = makeQueryResources(invalidationResources)
     const extended = Struct.keys(client).reduce(
       (acc, key) => {
-        const requestType = client[key].Request.type
-        const isStream = client[key].Request.stream
+        const handler = client[key]
+        const requestType = handler.Request.type
+        const isStream = handler.Request.stream
         const fn = Command.fn(client[key].id)
-        const h_ = client[key].handler
+        const h_ = handler.handler
         const request = h_
         ;(acc as any)[key] = Object.assign(
-          requestType === "query" && !isStream
+          isQueryHandler(handler)
             ? {
-              ...client[key],
+              ...handler,
               request,
-              query: useQuery(client[key] as any),
-              suspense: useSuspenseQuery(client[key] as any),
-              project: (projectionSchema: any) => {
-                const successSchema = client[key].Request.success
-                const projectionHash = projectionSchemaHash(projectionSchema)
-                const projected = projectHandler(h_ as any, successSchema, projectionSchema)
-                const fakeHandler = {
-                  handler: projected,
-                  id: client[key].id,
-                  Request: client[key].Request,
-                  options: client[key].options,
-                  queryKeyProjectionHash: projectionHash
-                }
-                return {
-                  request: projected,
-                  query: useQuery(fakeHandler as any),
-                  suspense: useSuspenseQuery(fakeHandler as any)
-                }
-              }
+              ...queryHelpersFor(handler),
+              project: projectQueryFor(handler)
             }
             : requestType === "query" && isStream
             ? {
@@ -911,7 +1149,8 @@ export const makeClient = <RT_, RTHooks>(
   return {
     Command,
     useCommand,
-    clientFor
+    clientFor,
+    tanstackQueryClient: getTanstackQueryClient()
   }
 }
 

--- a/packages/vue/src/mutate.ts
+++ b/packages/vue/src/mutate.ts
@@ -1,6 +1,4 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { matchQuery } from "@tanstack/query-core"
-import { type InvalidateOptions, type InvalidateQueryFilters, type QueryClient, useQueryClient } from "@tanstack/vue-query"
 import { type InvalidationKey, InvalidationKeysFromServer, makeInvalidationKeysService, makeQueryKey, type Req } from "effect-app/client"
 import type { ClientForOptions, RequestHandlerWithInput } from "effect-app/client/clientFor"
 import type { InvalidateQueryInstruction } from "effect-app/client/makeClient"
@@ -8,11 +6,14 @@ import * as Effect from "effect-app/Effect"
 import { tuple } from "effect-app/Function"
 import * as Option from "effect-app/Option"
 import type * as Cause from "effect/Cause"
+import { isReadonlyArrayNonEmpty } from "effect/Array"
 import * as Exit from "effect/Exit"
 import * as Ref from "effect/Ref"
 import * as Stream from "effect/Stream"
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult"
+import type * as Reactivity from "effect/unstable/reactivity/Reactivity"
 import { computed, type ComputedRef, shallowRef } from "vue"
+import { invalidateAndAwait } from "./atomQuery.ts"
 
 export type GetQueryKey = (h: { id: string; options?: ClientForOptions }) => string[]
 
@@ -103,11 +104,45 @@ export function make<A, E, R>(self: Effect.Effect<A, E, R>) {
 }
 
 /**
- * An entry for `queryInvalidation`. Narrowed alias of effect-app's
- * `InvalidateQueryInstruction` with tanstack-query's `InvalidateQueryFilters`
- * and `InvalidateOptions` substituted for the structural defaults.
+ * An entry for `queryInvalidation`: a raw query key, an `{ id }` handler ref, or a
+ * `{ filters }` shape. The atom engine acts on entries that carry a concrete query
+ * key: raw arrays, handler refs, or `{ filters: { queryKey } }`. Predicate-only
+ * filters have no exact-key reactivity equivalent and fail fast.
  */
-export type InvalidationEntry = InvalidateQueryInstruction<InvalidateQueryFilters, InvalidateOptions>
+export type QueryKeyInvalidationFilters = {
+  readonly queryKey: ReadonlyArray<unknown>
+}
+export type InvalidationEntry = InvalidateQueryInstruction<QueryKeyInvalidationFilters>
+export type QueryInvalidationEffect<R = never> = (keys: ReadonlyArray<ReadonlyArray<unknown>>) => Effect.Effect<void, never, R>
+export interface QueryInvalidator<R = never> {
+  readonly invalidateAndAwait: QueryInvalidationEffect<R>
+}
+
+export const atomQueryInvalidator: QueryInvalidator<Reactivity.Reactivity> = {
+  invalidateAndAwait
+}
+
+export const combineQueryInvalidators = <R>(...invalidators: ReadonlyArray<QueryInvalidator<R>>): QueryInvalidator<R> => ({
+  invalidateAndAwait: (keys) =>
+    Effect.forEach(
+      invalidators,
+      (invalidator) => invalidator.invalidateAndAwait(keys),
+      { discard: true, concurrency: "inherit" }
+    )
+})
+
+const isRecord = (value: unknown): value is { readonly [key: string]: unknown } =>
+  typeof value === "object" && value !== null
+
+const isQueryKey = (entry: InvalidationEntry): entry is ReadonlyArray<string> => Array.isArray(entry)
+
+const queryKeyFromFilters = (entry: Exclude<InvalidationEntry, ReadonlyArray<string>>): ReadonlyArray<unknown> | undefined => {
+  if (!("filters" in entry)) return undefined
+  const filters = entry.filters
+  if (!isRecord(filters)) return undefined
+  const queryKey = filters["queryKey"]
+  return Array.isArray(queryKey) ? queryKey : undefined
+}
 
 export interface MutationOptionsBase<A = unknown, B = A, E2 = never, R2 = never> {
   /**
@@ -220,56 +255,42 @@ export const asStreamResult = <Args extends readonly any[], A, E, R>(
   return tuple(computed(() => state.value), act) as any
 }
 
-const buildInvalidateCache = (
-  queryClient: QueryClient,
+const buildInvalidateCache = <RInvalidator>(
   self: { id: string; options?: ClientForOptions },
-  queryInvalidation?: MutationOptionsBase["queryInvalidation"]
+  queryInvalidation: MutationOptionsBase["queryInvalidation"] | undefined,
+  queryInvalidator: QueryInvalidator<RInvalidator>
 ) => {
-  type InvalidationTarget = {
-    readonly filters: InvalidateQueryFilters | undefined
-    readonly options: InvalidateOptions | undefined
-  }
-
-  const invalidateQueriesFn = (
-    filters?: InvalidateQueryFilters,
-    options?: InvalidateOptions
-  ) =>
-    Effect.currentSpan.pipe(
-      Effect.orElseSucceed(() => null),
-      Effect.flatMap((span) =>
-        Effect.promise(() => queryClient.invalidateQueries(filters, { ...options, updateMeta: { span } }))
-      )
-    )
-
-  const getClientInvalidationTargets = (
+  // Concrete reactivity keys to invalidate: a raw query key, one derived from an `{ id }`
+  // entry, or a compatibility `{ filters: { queryKey } }` entry.
+  // Predicate-only `{ filters }` entries have no exact-key reactivity equivalent and throw.
+  const getClientInvalidationKeys = (
     input: unknown,
     output: Exit.Exit<unknown, unknown>
-  ): ReadonlyArray<InvalidationTarget> => {
+  ): ReadonlyArray<ReadonlyArray<unknown>> => {
     const queryKey = getQueryKey(self)
 
     if (queryInvalidation) {
-      return queryInvalidation(queryKey, self.id, input, output).map((entry): InvalidationTarget => {
-        if (Array.isArray(entry)) {
-          return { filters: { queryKey: entry }, options: undefined }
+      const keys: Array<ReadonlyArray<unknown>> = []
+      for (const entry of queryInvalidation(queryKey, self.id, input, output)) {
+        if (isQueryKey(entry)) {
+          keys.push(entry)
+          continue
         }
-        const obj = entry as Exclude<InvalidationEntry, ReadonlyArray<string>>
-        if ("id" in obj) {
-          return {
-            filters: {
-              queryKey: makeQueryKey(obj.options ? { id: obj.id, options: obj.options } : { id: obj.id })
-            },
-            options: undefined
-          }
+        if ("id" in entry) {
+          keys.push(makeQueryKey(entry.options ? { id: entry.id, options: entry.options } : { id: entry.id }))
+          continue
         }
-        return { filters: obj.filters, options: obj.options }
-      })
+        const filterQueryKey = queryKeyFromFilters(entry)
+        if (filterQueryKey !== undefined) {
+          keys.push(filterQueryKey)
+          continue
+        }
+        throw new Error("Unsupported query invalidation filter: only filters.queryKey is supported")
+      }
+      return keys
     }
 
-    if (!queryKey) {
-      return []
-    }
-
-    return [{ filters: { queryKey }, options: undefined }]
+    return queryKey ? [queryKey] : []
   }
 
   const invalidateCache = (
@@ -278,57 +299,22 @@ const buildInvalidateCache = (
     serverKeys: ReadonlyArray<InvalidationKey>
   ) =>
     Effect.suspend(() => {
-      const clientTargets = getClientInvalidationTargets(input, output)
-      const serverTargets: ReadonlyArray<InvalidationTarget> = serverKeys.map((queryKey) => ({
-        filters: { queryKey },
-        options: undefined
-      }))
-      const allTargets: ReadonlyArray<InvalidationTarget> = [...clientTargets, ...serverTargets]
+      const clientKeys = getClientInvalidationKeys(input, output)
+      // Invalidate exact reactivity keys (= the prefixes query atoms register under). Each key
+      // array is hashed structurally, matching the query-side registration.
+      const keys: ReadonlyArray<ReadonlyArray<unknown>> = [...clientKeys, ...serverKeys]
 
-      if (!allTargets.length) return Effect.void
-
-      // Group targets by refetchType + options so each group can be merged into a single
-      // invalidateQueries call using a predicate, reducing N calls to 1 in the common case.
-      type Group = {
-        targets: Array<InvalidationTarget>
-        refetchType: InvalidateQueryFilters["refetchType"]
-        options: InvalidateOptions | undefined
-      }
-      const groups = new Map<string, Group>()
-      for (const target of allTargets) {
-        const key = `${target.filters?.refetchType ?? ""}|${target.options?.cancelRefetch ?? ""}|${
-          target.options?.throwOnError?.toString() ?? ""
-        }`
-        const existing = groups.get(key)
-        if (existing) {
-          existing.targets.push(target)
-        } else {
-          groups.set(key, { targets: [target], refetchType: target.filters?.refetchType, options: target.options })
-        }
-      }
+      if (!isReadonlyArrayNonEmpty(keys)) return Effect.void
 
       return Effect
         .andThen(
-          Effect.annotateCurrentSpan({ clientTargets, serverKeys }),
-          Effect.forEach(
-            groups.values(),
-            ({ options, refetchType, targets }) =>
-              invalidateQueriesFn(
-                {
-                  ...(refetchType !== undefined ? { refetchType } : {}),
-                  predicate: (query) => targets.some((t) => t.filters ? matchQuery(t.filters, query) : true)
-                },
-                options
-              ),
-            { discard: true, concurrency: "inherit" }
-          )
+          Effect.annotateCurrentSpan({ clientKeys, serverKeys }),
+          // refetch + AWAIT every live query registered under these keys, so by the time the
+          // mutation resolves the affected queries are fresh.
+          queryInvalidator.invalidateAndAwait(keys)
         )
         .pipe(
-          Effect.tap(
-            // hand over control back to the event loop so that state can be updated..
-            // TODO: should we do this in general on any mutation, regardless of invalidation?
-            Effect.sleep(0)
-          ),
+          Effect.tap(Effect.sleep(0.1)), // allow for refs to update etc
           Effect.withSpan("client.query.invalidation", {}, { captureStackTrace: false })
         )
     })
@@ -336,12 +322,12 @@ const buildInvalidateCache = (
   return invalidateCache
 }
 
-export const invalidateQueries = (
-  queryClient: QueryClient,
+export const invalidateQueries = <RInvalidator>(
   self: { id: string; options?: ClientForOptions },
-  options?: MutationOptionsBase
+  options: MutationOptionsBase | undefined,
+  queryInvalidator: QueryInvalidator<RInvalidator>
 ) => {
-  const invalidateCache = buildInvalidateCache(queryClient, self, options?.queryInvalidation)
+  const invalidateCache = buildInvalidateCache(self, options?.queryInvalidation, queryInvalidator)
 
   const select = options?.select
 
@@ -384,7 +370,7 @@ export interface MutationFn<I, A, E, R, Id extends string> {
   readonly id: Id
 }
 
-export const makeMutation = () => {
+export const makeMutation = <RInvalidator>(queryInvalidator: QueryInvalidator<RInvalidator>) => {
   /**
    * Pass a function that returns an Effect, e.g from a client action.
    * Executes query cache invalidation based on default rules or provided option.
@@ -393,17 +379,13 @@ export const makeMutation = () => {
   const useMutation = <I, E, A, R, Request extends Req, Id extends string>(
     self: RequestHandlerWithInput<I, A, E, R, Request, Id>
   ): MutationFn<I, A, E, R, Id> => {
-    const queryClient = useQueryClient()
-    const r = (i: I, options?: MutationOptionsBase) => invalidateQueries(queryClient, self, options)(self.handler(i), i)
+    const r = (i: I, options?: MutationOptionsBase) => invalidateQueries(self, options, queryInvalidator)(self.handler(i), i)
     return Object.assign(r, { id: self.id }) as any
   }
   return useMutation
 }
 
-// calling hooks in the body
-export const useMakeMutation = () => {
-  const queryClient = useQueryClient()
-
+export const useMakeMutation = <RInvalidator>(queryInvalidator: QueryInvalidator<RInvalidator>) => {
   /**
    * Pass a function that returns an Effect, e.g from a client action.
    * Executes query cache invalidation based on default rules or provided option.
@@ -412,7 +394,7 @@ export const useMakeMutation = () => {
   const useMutation = <I, E, A, R, Request extends Req, Id extends string>(
     self: RequestHandlerWithInput<I, A, E, R, Request, Id>
   ): MutationFn<I, A, E, R, Id> => {
-    const r = (i: I, options?: MutationOptionsBase) => invalidateQueries(queryClient, self, options)(self.handler(i), i)
+    const r = (i: I, options?: MutationOptionsBase) => invalidateQueries(self, options, queryInvalidator)(self.handler(i), i)
     return Object.assign(r, { id: self.id }) as any
   }
   return useMutation
@@ -425,12 +407,8 @@ export const useMakeMutation = () => {
  *
  * Use with `streamFn` / `Command.streamFn(id)(mutateHandler, ...combinators)` so that
  * the command manages its own reactive state internally.
- *
- * Must be called inside a Vue setup context (uses `useQueryClient` internally).
  */
-export const makeStreamMutation2 = () => {
-  const queryClient = useQueryClient()
-
+export const makeStreamMutation2 = <RInvalidator>(queryInvalidator: QueryInvalidator<RInvalidator>) => {
   return (
     self: {
       id: string
@@ -439,12 +417,17 @@ export const makeStreamMutation2 = () => {
     },
     mergedInvalidation?: MutationOptionsBase["queryInvalidation"]
   ) => {
-    const invCache = buildInvalidateCache(queryClient, self, mergedInvalidation)
+    const invCache = buildInvalidateCache(self, mergedInvalidation, queryInvalidator)
 
     const makeInvocationEffect = (input: unknown, source: Stream.Stream<any, any, any>) =>
       Effect.gen(function*() {
         const keysRef = yield* Ref.make<ReadonlyArray<InvalidationKey>>([])
-        const invKeys = makeInvalidationKeysService(keysRef, (key) => invCache(input, Exit.succeed(undefined), [key]))
+        const invKeys = makeInvalidationKeysService(
+          keysRef,
+          // Stream invalidation is sequenced by the injected query invalidator; this callback
+          // returns void to keep the server-side invalidation service effect-free.
+          (key) => invCache(input, Exit.succeed(undefined), [key]) as Effect.Effect<void>
+        )
         const lastRef = yield* Ref.make<any>(undefined)
         return source.pipe(
           Stream.provideService(InvalidationKeysFromServer, invKeys),

--- a/packages/vue/src/mutate.ts
+++ b/packages/vue/src/mutate.ts
@@ -5,8 +5,8 @@ import type { InvalidateQueryInstruction } from "effect-app/client/makeClient"
 import * as Effect from "effect-app/Effect"
 import { tuple } from "effect-app/Function"
 import * as Option from "effect-app/Option"
-import type * as Cause from "effect/Cause"
 import { isReadonlyArrayNonEmpty } from "effect/Array"
+import type * as Cause from "effect/Cause"
 import * as Exit from "effect/Exit"
 import * as Ref from "effect/Ref"
 import * as Stream from "effect/Stream"
@@ -113,7 +113,9 @@ export type QueryKeyInvalidationFilters = {
   readonly queryKey: ReadonlyArray<unknown>
 }
 export type InvalidationEntry = InvalidateQueryInstruction<QueryKeyInvalidationFilters>
-export type QueryInvalidationEffect<R = never> = (keys: ReadonlyArray<ReadonlyArray<unknown>>) => Effect.Effect<void, never, R>
+export type QueryInvalidationEffect<R = never> = (
+  keys: ReadonlyArray<ReadonlyArray<unknown>>
+) => Effect.Effect<void, never, R>
 export interface QueryInvalidator<R = never> {
   readonly invalidateAndAwait: QueryInvalidationEffect<R>
 }
@@ -122,7 +124,9 @@ export const atomQueryInvalidator: QueryInvalidator<Reactivity.Reactivity> = {
   invalidateAndAwait
 }
 
-export const combineQueryInvalidators = <R>(...invalidators: ReadonlyArray<QueryInvalidator<R>>): QueryInvalidator<R> => ({
+export const combineQueryInvalidators = <R>(
+  ...invalidators: ReadonlyArray<QueryInvalidator<R>>
+): QueryInvalidator<R> => ({
   invalidateAndAwait: (keys) =>
     Effect.forEach(
       invalidators,
@@ -136,7 +140,9 @@ const isRecord = (value: unknown): value is { readonly [key: string]: unknown } 
 
 const isQueryKey = (entry: InvalidationEntry): entry is ReadonlyArray<string> => Array.isArray(entry)
 
-const queryKeyFromFilters = (entry: Exclude<InvalidationEntry, ReadonlyArray<string>>): ReadonlyArray<unknown> | undefined => {
+const queryKeyFromFilters = (
+  entry: Exclude<InvalidationEntry, ReadonlyArray<string>>
+): ReadonlyArray<unknown> | undefined => {
   if (!("filters" in entry)) return undefined
   const filters = entry.filters
   if (!isRecord(filters)) return undefined
@@ -379,7 +385,8 @@ export const makeMutation = <RInvalidator>(queryInvalidator: QueryInvalidator<RI
   const useMutation = <I, E, A, R, Request extends Req, Id extends string>(
     self: RequestHandlerWithInput<I, A, E, R, Request, Id>
   ): MutationFn<I, A, E, R, Id> => {
-    const r = (i: I, options?: MutationOptionsBase) => invalidateQueries(self, options, queryInvalidator)(self.handler(i), i)
+    const r = (i: I, options?: MutationOptionsBase) =>
+      invalidateQueries(self, options, queryInvalidator)(self.handler(i), i)
     return Object.assign(r, { id: self.id }) as any
   }
   return useMutation
@@ -394,7 +401,8 @@ export const useMakeMutation = <RInvalidator>(queryInvalidator: QueryInvalidator
   const useMutation = <I, E, A, R, Request extends Req, Id extends string>(
     self: RequestHandlerWithInput<I, A, E, R, Request, Id>
   ): MutationFn<I, A, E, R, Id> => {
-    const r = (i: I, options?: MutationOptionsBase) => invalidateQueries(self, options, queryInvalidator)(self.handler(i), i)
+    const r = (i: I, options?: MutationOptionsBase) =>
+      invalidateQueries(self, options, queryInvalidator)(self.handler(i), i)
     return Object.assign(r, { id: self.id }) as any
   }
   return useMutation

--- a/packages/vue/src/query.ts
+++ b/packages/vue/src/query.ts
@@ -11,12 +11,13 @@ import { type CauseException } from "effect-app/client/errors"
 import type * as Context from "effect-app/Context"
 import * as Effect from "effect-app/Effect"
 import * as Option from "effect-app/Option"
+import type * as Cause from "effect/Cause"
 import * as Exit from "effect/Exit"
 import * as Stream from "effect/Stream"
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult"
-import type * as Atom from "effect/unstable/reactivity/Atom"
+import * as Atom from "effect/unstable/reactivity/Atom"
 import { computed, type ComputedRef, type MaybeRefOrGetter, onBeforeUnmount, onMounted, ref, toValue, type WatchSource } from "vue"
-import { type AtomClientRuntime, type AtomQueryOptions, awaitAtomResult, buildQueryFamily, disabledQueryAtom, isStaleResult, staleTimeMsOf, withQueryOptions } from "./atomQuery.ts"
+import { type AtomClientRuntime, type AtomQueryOptions, awaitAtomResult, buildQueryFamily, buildStreamQueryFamily, disabledQueryAtom, isStaleResult, staleTimeMsOf, withQueryOptions } from "./atomQuery.ts"
 
 // --- minimal local types (replacing the former @tanstack/vue-query type imports) ---
 type DefaultError = Error
@@ -58,10 +59,18 @@ export type SuspenseQueryView<A, E> =
   & SuspenseQueryTuple<A, E>
 
 export type QueryAtomFamily<I, A, E> = (input: I) => Atom.Atom<AsyncResult.AsyncResult<A, E>>
+export type StreamQueryAtomFamily<I, A, E> = (input: I) => Atom.Writable<Atom.PullResult<A, E>, void>
 
 interface QueryFamilyDescriptor<I, A, E> {
   readonly id: string
   readonly handler: (i: I) => Effect.Effect<A, E, any>
+  readonly options?: ClientForOptions
+  readonly queryKeyProjectionHash?: string
+}
+
+interface StreamQueryFamilyDescriptor<I, A, E> {
+  readonly id: string
+  readonly handler: (i: I) => Stream.Stream<A, E, any>
   readonly options?: ClientForOptions
   readonly queryKeyProjectionHash?: string
 }
@@ -84,6 +93,20 @@ const getQueryFamily = <I, A, E>(
   if (!f) {
     f = buildQueryFamily(rt, q)
     queryFamilyByKey.set(key, f)
+  }
+  return f
+}
+
+const streamQueryFamilyByKey = new Map<string, any>()
+const getStreamQueryFamily = <I, A, E>(
+  rt: AtomClientRuntime,
+  q: StreamQueryFamilyDescriptor<I, A, E>
+): StreamQueryAtomFamily<I, A, E> => {
+  const key = queryFamilyCacheKey(q)
+  let f = streamQueryFamilyByKey.get(key)
+  if (!f) {
+    f = buildStreamQueryFamily(rt, q)
+    streamQueryFamilyByKey.set(key, f)
   }
   return f
 }
@@ -159,6 +182,16 @@ export interface AtomQueryNewOptions<TQueryFnData = unknown, TData = TQueryFnDat
   readonly refreshEvery?: number
   readonly refetchInterval?: number
   readonly select?: (data: TQueryFnData) => TData
+}
+
+export interface AtomStreamQueryOptions {
+  readonly staleTime?: number
+  readonly idleTTL?: number | "infinity"
+  readonly gcTime?: number | "infinity"
+  readonly revalidateOnFocus?: boolean
+  readonly refetchOnWindowFocus?: boolean
+  readonly refreshEvery?: number
+  readonly refetchInterval?: number
 }
 
 const normalizeQueryOptions = (options?: {
@@ -267,6 +300,67 @@ export const useAtomSuspense = <A, E>(
   return Effect.runPromise(eff)
 }
 
+export type StreamQueryPullValue<A> = {
+  readonly done: boolean
+  readonly items: ReadonlyArray<A>
+}
+
+export interface StreamQueryView<A, E> {
+  readonly result: ComputedRef<Atom.PullResult<A, E>>
+  readonly items: ComputedRef<ReadonlyArray<A>>
+  readonly latest: ComputedRef<A | undefined>
+  readonly done: ComputedRef<boolean>
+  readonly awaitResult: () => Effect.Effect<StreamQueryPullValue<A>, E | Cause.NoSuchElementError, never>
+  readonly pull: () => void
+  readonly pullAndAwait: () => Effect.Effect<StreamQueryPullValue<A>, E | Cause.NoSuchElementError, never>
+  readonly refresh: () => void
+  readonly registry: ReturnType<typeof injectRegistry>
+  readonly atom: ComputedRef<Atom.Writable<Atom.PullResult<A, E>, void>>
+}
+
+export const useAtomStreamQuery = <A, E>(
+  atom: () => Atom.Writable<Atom.PullResult<A, E>, void>
+): StreamQueryView<A, E> => {
+  const registry = injectRegistry()
+  const atomRef = computed(atom)
+  const atomResult = useAtomValue(() => atomRef.value)
+  const result = computed(() => atomResult.value)
+  const pull = () => registry.set(atomRef.value, void 0)
+  const refresh = () => registry.refresh(atomRef.value)
+  const awaitResult = () => awaitAtomResult(registry, atomRef.value)
+  const pullAndAwait = () =>
+    Effect.gen(function*() {
+      pull()
+      return yield* awaitResult()
+    })
+  const items = computed(() =>
+    Option.getOrElse(
+      Option.map(AsyncResult.value(result.value), (_) => _.items),
+      () => []
+    )
+  )
+  const latest = computed(() => items.value.at(-1))
+  const done = computed(() =>
+    Option.getOrElse(
+      Option.map(AsyncResult.value(result.value), (_) => _.done),
+      () => false
+    )
+  )
+
+  return {
+    result,
+    items,
+    latest,
+    done,
+    awaitResult,
+    pull,
+    pullAndAwait,
+    refresh,
+    registry,
+    atom: atomRef
+  }
+}
+
 const optionValue = <I>(
   arr: I | WatchSource<I> | undefined | WatchSource<Option.Option<I>>,
   options?: { readonly mode?: "optional"; readonly enabled?: MaybeRefOrGetter<boolean | undefined> }
@@ -310,6 +404,19 @@ const observedAtom = <A, E>(
     readonly refreshEvery?: number
   }
 ): Atom.Atom<AsyncResult.AsyncResult<A, E>> => withQueryOptions(atom, normalizeQueryOptions(options))
+
+const observedStreamAtom = <A, E>(
+  atom: Atom.Writable<Atom.PullResult<A, E>, void>,
+  options?: AtomStreamQueryOptions
+): Atom.Writable<Atom.PullResult<A, E>, void> => {
+  let next = atom
+  const refetchInterval = options?.refreshEvery ?? options?.refetchInterval
+  if (refetchInterval !== undefined) next = Atom.withRefresh(refetchInterval)(next)
+  const gcTime = options?.idleTTL ?? options?.gcTime
+  if (gcTime === "infinity") return Atom.keepAlive(next)
+  if (gcTime !== undefined) return Atom.setIdleTTL(next, gcTime)
+  return next
+}
 
 const queryAtomFor = <I, A, E, TData>(
   rt: AtomClientRuntime,
@@ -554,6 +661,55 @@ export const makeQuery = <R>(_getRuntime: () => Context.Context<R>, getAtomRt: (
 
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface MakeQuery2<R> extends ReturnType<typeof makeQuery<R>> {}
+
+const streamQueryAtomFor = <I, A, E>(
+  rt: AtomClientRuntime,
+  q: StreamQueryFamilyDescriptor<I, A, E>,
+  arg: I,
+  options?: AtomStreamQueryOptions
+): Atom.Writable<Atom.PullResult<A, E>, void> => {
+  const family = getStreamQueryFamily(rt, q)
+  return observedStreamAtom(family(arg), options)
+}
+
+export const makeStreamQueryFamily = <R>(_getRuntime: () => Context.Context<R>, getAtomRt: () => AtomClientRuntime) => {
+  const useStreamQueryFamily: {
+    <I, E, A, Request extends Req, Name extends string>(
+      q: RequestStreamHandlerWithInput<I, A, E, R, Request, Name>
+    ): StreamQueryAtomFamily<I, A, E>
+  } = <I, E, A, Request extends Req, Name extends string>(
+    q: RequestStreamHandlerWithInput<I, A, E, R, Request, Name>
+  ) => getStreamQueryFamily(getAtomRt(), q)
+
+  return useStreamQueryFamily
+}
+
+export const makeStreamQueryAtom = <R>(_getRuntime: () => Context.Context<R>, getAtomRt: () => AtomClientRuntime) => {
+  const useStreamQueryAtom: {
+    <I, E, A, Request extends Req, Name extends string>(
+      q: RequestStreamHandlerWithInput<I, A, E, R, Request, Name>
+    ): (arg: I, options?: AtomStreamQueryOptions) => Atom.Writable<Atom.PullResult<A, E>, void>
+  } = <I, E, A, Request extends Req, Name extends string>(
+    q: RequestStreamHandlerWithInput<I, A, E, R, Request, Name>
+  ) =>
+  (arg: I, options?: AtomStreamQueryOptions) => streamQueryAtomFor(getAtomRt(), q, arg, options)
+
+  return useStreamQueryAtom
+}
+
+export const makeStreamQueryNew = <R>(_getRuntime: () => Context.Context<R>, getAtomRt: () => AtomClientRuntime) => {
+  const useStreamQueryNew: {
+    <I, E, A, Request extends Req, Name extends string>(
+      q: RequestStreamHandlerWithInput<I, A, E, R, Request, Name>
+    ): (arg: MaybeRefOrGetter<I>, options?: AtomStreamQueryOptions) => StreamQueryView<A, E>
+  } = <I, E, A, Request extends Req, Name extends string>(
+    q: RequestStreamHandlerWithInput<I, A, E, R, Request, Name>
+  ) =>
+  (arg: MaybeRefOrGetter<I>, options?: AtomStreamQueryOptions) =>
+    useAtomStreamQuery(() => streamQueryAtomFor(getAtomRt(), q, toValue(arg), options))
+
+  return useStreamQueryNew
+}
 
 type StreamQueryResult<A, E> = readonly [
   ComputedRef<AsyncResult.AsyncResult<A[], E>>,

--- a/packages/vue/src/query.ts
+++ b/packages/vue/src/query.ts
@@ -3,44 +3,113 @@
 /* eslint-disable @typescript-eslint/no-unsafe-return */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
-import { type DefaultError, type Enabled, experimental_streamedQuery as streamedQuery, type InitialDataFunction, type NonUndefinedGuard, type PlaceholderDataFunction, type QueryKey, type QueryObserverOptions, type QueryObserverResult, type RefetchOptions, useQuery as useTanstackQuery, useQueryClient, type UseQueryDefinedReturnType, type UseQueryReturnType } from "@tanstack/vue-query"
 import * as Array from "effect-app/Array"
 import { makeQueryKey, type Req } from "effect-app/client"
-import type { RequestHandlerWithInput, RequestStreamHandlerWithInput } from "effect-app/client/clientFor"
-import { CauseException, ServiceUnavailableError } from "effect-app/client/errors"
+import type { ClientForOptions, RequestHandlerWithInput, RequestStreamHandlerWithInput } from "effect-app/client/clientFor"
+import { type CauseException } from "effect-app/client/errors"
 import type * as Context from "effect-app/Context"
 import * as Effect from "effect-app/Effect"
 import * as Option from "effect-app/Option"
-import * as S from "effect-app/Schema"
-import * as Cause from "effect/Cause"
-import * as Channel from "effect/Channel"
 import * as Exit from "effect/Exit"
-import * as Pull from "effect/Pull"
-import * as Scope from "effect/Scope"
-import type * as Stream from "effect/Stream"
-import { type Span } from "effect/Tracer"
-import { isHttpClientError } from "effect/unstable/http/HttpClientError"
+import * as Stream from "effect/Stream"
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult"
-import { computed, type ComputedRef, type MaybeRefOrGetter, ref, shallowRef, watch, type WatchSource } from "vue"
-import { reportRuntimeError } from "./lib.ts"
-import { makeRunPromise } from "./runtime.ts"
+import * as Atom from "effect/unstable/reactivity/Atom"
+import { computed, type ComputedRef, type MaybeRefOrGetter, onBeforeUnmount, onMounted, ref, toValue, type WatchSource } from "vue"
+import { injectRegistry, useAtomValue } from "@effect/atom-vue"
+import { type AtomClientRuntime, type AtomQueryOptions, awaitAtomResult, buildQueryFamily, disabledQueryAtom, isStaleResult, staleTimeMsOf, withQueryOptions } from "./atomQuery.ts"
 
-// we must use interface extends, or we get the dreaded typescript error of isn't portable blabla @tanstack/vue-query/build/modern/types.js
-// but because how they are dealing with some extends clause, we loose all properties except initialData
-// so we actually reconstruct the interfaces here from the ground up :/
+// --- minimal local types (replacing the former @tanstack/vue-query type imports) ---
+type DefaultError = Error
+type QueryKey = ReadonlyArray<unknown>
+/** Options accepted by `refetch()` — kept for source compatibility; the atom path ignores them. */
+export interface RefetchOptions {
+  readonly cancelRefetch?: boolean
+  readonly throwOnError?: boolean
+}
+/** The 4th tuple element: private atom/registry handle for client helpers. */
+export interface QueryHandle<A = unknown, E = unknown> {
+  readonly awaitResult: () => Effect.Effect<A, E, never>
+  readonly refetch: () => Effect.Effect<A, E, never>
+  readonly refresh: () => void
+  readonly registry: ReturnType<typeof injectRegistry>
+  readonly atom: ComputedRef<Atom.Atom<AsyncResult.AsyncResult<A, E>>>
+}
+export interface QueryView<A, E> extends QueryHandle<A, E> {
+  readonly result: ComputedRef<AsyncResult.AsyncResult<A, E>>
+  readonly data: ComputedRef<A | undefined>
+}
+
+// retained generic aliases so the exported option-interface arity is unchanged for consumers
+export type UseQueryReturnType<A = any, E = any> = QueryHandle<A, E>
+export type UseQueryDefinedReturnType<A = any, E = any> = QueryHandle<A, E>
+export type QueryObserverResult<A = any, _E = any> = AsyncResult.AsyncResult<A, any>
+export type SuspenseQueryTuple<A, E> = readonly [
+  ComputedRef<AsyncResult.AsyncResult<A, E>>,
+  ComputedRef<A>,
+  (options?: RefetchOptions) => Effect.Effect<A, E, never>,
+  QueryHandle<A, E>
+]
+
+export type SuspenseQueryView<A, E> =
+  & Omit<QueryView<A, E>, "data">
+  & {
+    readonly data: ComputedRef<A>
+  }
+  & SuspenseQueryTuple<A, E>
+
+export type QueryAtomFamily<I, A, E> = (input: I) => Atom.Atom<AsyncResult.AsyncResult<A, E>>
+
+interface QueryFamilyDescriptor<I, A, E> {
+  readonly id: string
+  readonly handler: (i: I) => Effect.Effect<A, E, any>
+  readonly options?: ClientForOptions
+  readonly queryKeyProjectionHash?: string
+}
+
+const queryFamilyCacheKey = (q: { readonly id: string; readonly options?: ClientForOptions; readonly queryKeyProjectionHash?: string }) =>
+  `${makeQueryKey(q).join("/")}:${q.queryKeyProjectionHash ?? ""}`
+
+// One atom family per request shape, keyed by the stable query key + projection hash (not the
+// handler object — `clientFor` returns a fresh proxy per call, so the object isn't shareable).
+// Module-level + key-indexed => the family is process-global, so the same request+input read
+// the same atom across components/pages => cross-page caching via the global registry.
+const queryFamilyByKey = new Map<string, any>()
+const getQueryFamily = <I, A, E>(
+  rt: AtomClientRuntime,
+  q: QueryFamilyDescriptor<I, A, E>
+): QueryAtomFamily<I, A, E> => {
+  const key = queryFamilyCacheKey(q)
+  let f = queryFamilyByKey.get(key)
+  if (!f) {
+    f = buildQueryFamily(rt, q)
+    queryFamilyByKey.set(key, f)
+  }
+  return f
+}
+
+// Atom-engine query options (formerly reconstructed from @tanstack/vue-query types).
+// The generic arity is kept so the exported interface signatures are unchanged for consumers.
 export interface CustomUseQueryOptions<
   TQueryFnData = unknown,
   TError = DefaultError,
   TData = TQueryFnData,
   TQueryData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey
-> extends
-  Omit<
-    QueryObserverOptions<TQueryFnData, TError, TData, TQueryData, TQueryKey>,
-    "queryKey" | "queryFn" | "initialData" | "enabled" | "placeholderData"
-  >
-{
-  enabled?: MaybeRefOrGetter<boolean | undefined> | (() => Enabled<TQueryFnData, TError, TQueryData, TQueryKey>)
+> {
+  readonly enabled?: MaybeRefOrGetter<boolean | undefined>
+  /** stale threshold in ms (or a Duration input) */
+  readonly staleTime?: number
+  /** garbage-collect after idle, ms (or "infinity") */
+  readonly gcTime?: number | "infinity"
+  readonly refetchOnWindowFocus?: boolean
+  readonly structuralSharing?: boolean
+  /** poll: re-fetch every N ms (tanstack refetchInterval) */
+  readonly refetchInterval?: number
+  readonly select?: (data: TQueryFnData) => TData
+  /** accepted for source compatibility; not used by the atom engine */
+  readonly retry?: boolean | number
+  readonly meta?: Record<string, unknown>
+  readonly _phantom?: [TQueryData, TQueryKey, TError]
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
@@ -53,11 +122,8 @@ export interface CustomUndefinedInitialQueryOptions<
   TQueryData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey
 > extends CustomUseQueryOptions<TQueryFnData, TError, TData, TQueryData, TQueryKey> {
-  initialData?: undefined | InitialDataFunction<NonUndefinedGuard<TQueryFnData>> | NonUndefinedGuard<TQueryFnData>
-  placeholderData?:
-    | undefined
-    | NonFunctionGuard<TQueryData>
-    | PlaceholderDataFunction<NonFunctionGuard<TQueryData>, TError, NonFunctionGuard<TQueryData>, TQueryKey>
+  readonly initialData?: TQueryFnData | (() => TQueryFnData) | undefined
+  readonly placeholderData?: NonFunctionGuard<TQueryData> | ((prev: TQueryData | undefined) => TQueryData) | undefined
 }
 export interface CustomDefinedInitialQueryOptions<
   TQueryFnData = unknown,
@@ -66,11 +132,8 @@ export interface CustomDefinedInitialQueryOptions<
   TQueryData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey
 > extends CustomUseQueryOptions<TQueryFnData, TError, TData, TQueryData, TQueryKey> {
-  initialData: NonUndefinedGuard<TQueryFnData> | (() => NonUndefinedGuard<TQueryFnData>)
-  placeholderData?:
-    | undefined
-    | NonFunctionGuard<TQueryData>
-    | PlaceholderDataFunction<NonFunctionGuard<TQueryData>, TError, NonFunctionGuard<TQueryData>, TQueryKey>
+  readonly initialData: TQueryFnData | (() => TQueryFnData)
+  readonly placeholderData?: NonFunctionGuard<TQueryData> | ((prev: TQueryData | undefined) => TQueryData) | undefined
 }
 
 export interface CustomDefinedPlaceholderQueryOptions<
@@ -80,71 +143,280 @@ export interface CustomDefinedPlaceholderQueryOptions<
   TQueryData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey
 > extends CustomUseQueryOptions<TQueryFnData, TError, TData, TQueryData, TQueryKey> {
-  initialData?: NonUndefinedGuard<TQueryFnData> | (() => NonUndefinedGuard<TQueryFnData>) | undefined
-  placeholderData:
-    | NonFunctionGuard<TQueryData>
-    | PlaceholderDataFunction<NonFunctionGuard<TQueryData>, TError, NonFunctionGuard<TQueryData>, TQueryKey>
+  readonly initialData?: TQueryFnData | (() => TQueryFnData) | undefined
+  readonly placeholderData: NonFunctionGuard<TQueryData> | ((prev: TQueryData | undefined) => TQueryData)
 }
 
-function swrToQuery<E, A>(r: {
-  error: CauseException<E> | undefined
-  data: A | undefined
-  isValidating: boolean
-}): AsyncResult.AsyncResult<A, E> {
-  if (r.error !== undefined) {
-    return AsyncResult.failureWithPrevious(
-      r.error.originalCause,
-      {
-        previous: r.data === undefined ? Option.none() : Option.some(AsyncResult.success(r.data)),
-        waiting: r.isValidating
-      }
-    )
-  }
-  if (r.data !== undefined) {
-    return AsyncResult.success<A, E>(r.data, { waiting: r.isValidating })
-  }
-
-  return AsyncResult.initial(r.isValidating)
+export interface AtomQueryNewOptions<TQueryFnData = unknown, TData = TQueryFnData> {
+  readonly enabled?: MaybeRefOrGetter<boolean | undefined>
+  readonly staleTime?: number
+  readonly idleTTL?: number | "infinity"
+  readonly gcTime?: number | "infinity"
+  readonly revalidateOnFocus?: boolean
+  readonly refetchOnWindowFocus?: boolean
+  readonly structuralSharing?: boolean
+  readonly refreshEvery?: number
+  readonly refetchInterval?: number
+  readonly select?: (data: TQueryFnData) => TData
 }
 
-function streamToAsyncIterableWithCauseException<A, E, R>(
-  self: Stream.Stream<A, E, R>,
-  context: Context.Context<R>,
-  id: string
-): AsyncIterable<A> {
+const normalizeQueryOptions = (options?: {
+  readonly staleTime?: number
+  readonly gcTime?: number | "infinity"
+  readonly idleTTL?: number | "infinity"
+  readonly refetchOnWindowFocus?: boolean
+  readonly revalidateOnFocus?: boolean
+  readonly structuralSharing?: boolean
+  readonly refetchInterval?: number
+  readonly refreshEvery?: number
+}): AtomQueryOptions => {
+  const out: {
+    staleTime?: number
+    gcTime?: number | "infinity"
+    revalidateOnFocus?: boolean
+    structuralSharing?: boolean
+    refetchInterval?: number
+  } = {}
+  if (options?.staleTime !== undefined) out.staleTime = options.staleTime
+  const gcTime = options?.idleTTL ?? options?.gcTime
+  if (gcTime !== undefined) out.gcTime = gcTime
+  const revalidateOnFocus = options?.revalidateOnFocus ?? options?.refetchOnWindowFocus
+  if (revalidateOnFocus !== undefined) out.revalidateOnFocus = revalidateOnFocus
+  if (options?.structuralSharing !== undefined) out.structuralSharing = options.structuralSharing
+  const refetchInterval = options?.refreshEvery ?? options?.refetchInterval
+  if (refetchInterval !== undefined) out.refetchInterval = refetchInterval
+  return out
+}
+
+export const useAtomQuery = <A, E>(
+  atom: () => Atom.Atom<AsyncResult.AsyncResult<A, E>>
+): QueryView<A, E> => {
+  const registry = injectRegistry()
+  const atomRef = computed(atom)
+  const atomResult = useAtomValue(() => atomRef.value)
+  const result = computed(() => atomResult.value)
+  const refresh = () => registry.refresh(atomRef.value)
+  const awaitResult = () => awaitAtomResult(registry, atomRef.value)
+  const refetch = () =>
+    Effect.gen(function*() {
+      refresh()
+      return yield* awaitResult()
+    })
+  const data = computed(() => Option.getOrUndefined(AsyncResult.value(result.value)))
+
   return {
-    [Symbol.asyncIterator]() {
-      const runPromise = Effect.runPromiseWith(context)
-      const runPromiseExit = Effect.runPromiseExitWith(context)
-      const scope = Scope.makeUnsafe()
-      let pull: any
-      let currentIter: Iterator<A> | undefined
-      return {
-        async next(): Promise<IteratorResult<A>> {
-          if (currentIter) {
-            const next = currentIter.next()
-            if (!next.done) return next
-            currentIter = undefined
-          }
-          pull ??= await runPromise(Channel.toPullScoped((self as any).channel, scope))
-          const exit = await runPromiseExit(pull)
-          if (Exit.isSuccess(exit)) {
-            currentIter = (exit.value as any)[Symbol.iterator]()
-            return currentIter!.next()
-          } else if (Pull.isDoneCause((exit as any).cause)) {
-            return { done: true, value: undefined }
-          }
-          throw new CauseException((exit as any).cause, id)
-        },
-        return(_) {
-          return runPromise(Effect.as(Scope.close(scope, Exit.void), { done: true, value: undefined }) as any)
-        }
-      }
-    }
+    result,
+    data,
+    awaitResult,
+    refetch,
+    refresh,
+    registry,
+    atom: atomRef
   }
 }
 
-export const makeQuery = <R>(getRuntime: () => Context.Context<R>) => {
+export const useAtomSuspense = <A, E>(
+  atom: () => Atom.Atom<AsyncResult.AsyncResult<A, E>>
+): Promise<SuspenseQueryView<A, E>> => {
+  const view = useAtomQuery(atom)
+  const data = computed<A>(() => {
+    const latest = view.data.value
+    if (latest === undefined) {
+      throw new Error("Internal Error: atom suspense resolved without a latest value")
+    }
+    return latest
+  })
+
+  const isMounted = ref(true)
+  onBeforeUnmount(() => {
+    isMounted.value = false
+  })
+
+  const eff = Effect.gen(function*() {
+    const exit = yield* view.awaitResult().pipe(Effect.exit)
+    if (!isMounted.value) {
+      return yield* Effect.interrupt
+    }
+    if (Exit.isFailure(exit)) {
+      return yield* Exit.failCause(exit.cause)
+    }
+
+    const fetch = (_options?: RefetchOptions) => view.refetch()
+    const handle = {
+      awaitResult: view.awaitResult,
+      refetch: view.refetch,
+      refresh: view.refresh,
+      registry: view.registry,
+      atom: view.atom
+    }
+    return Object.assign([
+      view.result,
+      data,
+      fetch,
+      handle
+    ] as const, {
+      ...view,
+      data
+    })
+  })
+
+  return Effect.runPromise(eff)
+}
+
+const optionValue = <I>(
+  arr: I | WatchSource<I> | undefined | WatchSource<Option.Option<I>>,
+  options?: { readonly mode?: "optional"; readonly enabled?: MaybeRefOrGetter<boolean | undefined> }
+): readonly [{ readonly value: I }, ComputedRef<boolean>] => {
+  if (options?.mode === "optional") {
+    const getOption: () => Option.Option<I> = typeof arr === "function"
+      ? arr as () => Option.Option<I>
+      : () => (arr as { value: Option.Option<I> }).value
+    return [
+      { get value() { return Option.getOrUndefined(getOption()) as I } },
+      computed(() => Option.isSome(getOption()))
+    ] as const
+  }
+  const req = !arr
+    ? ({ value: undefined as I })
+    : typeof arr === "function"
+    ? ({ get value() { return (arr as any)() } })
+    : (ref(arr) as any)
+  const enabled = options?.enabled
+  return [req, computed(() => enabled === undefined ? true : !!toValue(enabled))] as const
+}
+
+const observedAtom = <A, E>(
+  atom: Atom.Atom<AsyncResult.AsyncResult<A, E>>,
+  options?: {
+    readonly staleTime?: number
+    readonly gcTime?: number | "infinity"
+    readonly idleTTL?: number | "infinity"
+    readonly refetchOnWindowFocus?: boolean
+    readonly revalidateOnFocus?: boolean
+    readonly structuralSharing?: boolean
+    readonly refetchInterval?: number
+    readonly refreshEvery?: number
+  }
+): Atom.Atom<AsyncResult.AsyncResult<A, E>> => withQueryOptions(atom, normalizeQueryOptions(options))
+
+const queryAtomFor = <I, A, E, TData>(
+  rt: AtomClientRuntime,
+  q: QueryFamilyDescriptor<I, A, E>,
+  arg: I,
+  options?: Omit<AtomQueryNewOptions<A, TData>, "select"> | Omit<CustomUseQueryOptions<A, E, TData>, "select">
+): Atom.Atom<AsyncResult.AsyncResult<A, E>> => {
+  const family = getQueryFamily(rt, q)
+  return observedAtom(family(arg), options)
+}
+
+const makeQueryView = <I, A, E, TData>(
+  getAtomRt: () => AtomClientRuntime,
+  q: QueryFamilyDescriptor<I, A, E>,
+  arg: I | WatchSource<I> | undefined | WatchSource<Option.Option<I>>,
+  options?: (AtomQueryNewOptions<A, TData> | CustomUseQueryOptions<A, E, TData>) & {
+    readonly mode?: "optional"
+  }
+): QueryView<TData, E> => {
+  const atomRt = getAtomRt()
+  const registry = injectRegistry()
+  const [req, enabledRef] = optionValue<I>(arg, options)
+  const family = getQueryFamily(atomRt, q)
+  const atomRef = computed(() =>
+    enabledRef.value ? observedAtom(family(req.value), options) : disabledQueryAtom
+  )
+  const rawResult = useAtomValue(() => atomRef.value) as ComputedRef<AsyncResult.AsyncResult<A, E>>
+  const select = options?.select
+  const result = (select
+    ? computed(() => AsyncResult.map(rawResult.value, select))
+    : rawResult) as ComputedRef<AsyncResult.AsyncResult<TData, E>>
+  const refresh = () => registry.refresh(atomRef.value)
+  const awaitResult = () =>
+    select
+      ? awaitAtomResult(registry, atomRef.value).pipe(Effect.map(select))
+      : awaitAtomResult(registry, atomRef.value)
+  const refetch = () =>
+    Effect.gen(function*() {
+      refresh()
+      return yield* awaitResult()
+    })
+  const staleMs = staleTimeMsOf(normalizeQueryOptions(options))
+  onMounted(() => {
+    if (!enabledRef.value) return
+    if (isStaleResult(registry.get(atomRef.value), staleMs)) refresh()
+  })
+  const data = computed(() => Option.getOrUndefined(AsyncResult.value(result.value)))
+
+  return {
+    result,
+    data,
+    awaitResult,
+    refetch,
+    refresh,
+    registry,
+    atom: atomRef
+  }
+}
+
+export const makeQueryFamily = <R>(_getRuntime: () => Context.Context<R>, getAtomRt: () => AtomClientRuntime) => {
+  const useQueryFamily: {
+    <I, E, A, Request extends Req, Name extends string>(
+      q: RequestHandlerWithInput<I, A, E, R, Request, Name>
+    ): QueryAtomFamily<I, A, E>
+  } = <I, E, A, Request extends Req, Name extends string>(
+    q: RequestHandlerWithInput<I, A, E, R, Request, Name>
+  ) => getQueryFamily(getAtomRt(), q)
+
+  return useQueryFamily
+}
+
+export const makeQueryAtom = <R>(_getRuntime: () => Context.Context<R>, getAtomRt: () => AtomClientRuntime) => {
+  const useQueryAtom: {
+    <I, E, A, Request extends Req, Name extends string>(
+      q: RequestHandlerWithInput<I, A, E, R, Request, Name>
+    ): {
+      <TData = A>(
+        arg: I,
+        options?: Omit<AtomQueryNewOptions<A, TData>, "select">
+      ): Atom.Atom<AsyncResult.AsyncResult<A, E>>
+    }
+  } = <I, E, A, Request extends Req, Name extends string>(
+    q: RequestHandlerWithInput<I, A, E, R, Request, Name>
+  ) =>
+  <TData = A>(
+    arg: I,
+    options?: Omit<AtomQueryNewOptions<A, TData>, "select">
+  ) => queryAtomFor(getAtomRt(), q, arg, options)
+
+  return useQueryAtom
+}
+
+export const makeQueryNew = <R>(_getRuntime: () => Context.Context<R>, getAtomRt: () => AtomClientRuntime) => {
+  const useQueryNew: {
+    <I, E, A, Request extends Req, Name extends string>(
+      q: RequestHandlerWithInput<I, A, E, R, Request, Name>
+    ): {
+      <TData = A>(
+        arg: WatchSource<Option.Option<I>>,
+        options: Omit<AtomQueryNewOptions<A, TData>, "enabled"> & { mode: "optional" }
+      ): QueryView<TData, E>
+
+      <TData = A>(
+        arg: I | WatchSource<I> | undefined,
+        options?: AtomQueryNewOptions<A, TData>
+      ): QueryView<TData, E>
+    }
+  } = <I, E, A, Request extends Req, Name extends string>(
+    q: RequestHandlerWithInput<I, A, E, R, Request, Name>
+  ) =>
+  <TData = A>(
+    arg: I | WatchSource<I> | undefined | WatchSource<Option.Option<I>>,
+    options?: AtomQueryNewOptions<A, TData> & { readonly mode?: "optional" }
+  ) => makeQueryView<I, A, E, TData>(getAtomRt, q, arg, options)
+
+  return useQueryNew
+}
+
+export const makeQuery = <R>(_getRuntime: () => Context.Context<R>, getAtomRt: () => AtomClientRuntime) => {
   const useQuery_: {
     <I, A, E, Request extends Req, Name extends string>(
       q: RequestHandlerWithInput<I, A, E, R, Request, Name>
@@ -194,103 +466,24 @@ export const makeQuery = <R>(getRuntime: () => Context.Context<R>) => {
   ) =>
   <TData = A>(
     arg: I | WatchSource<I> | undefined | WatchSource<Option.Option<I>>,
-    // todo QueryKey type would be [string, ...string[]], but with I it would be [string, ...string[], I]
     options?: any
-    // TODO
   ) => {
-    // we wrap into CauseException because we want to keep the full cause of the failure.
-    const runPromise = makeRunPromise(getRuntime())
-    const arr = arg
+    const view = makeQueryView<I, A, E, TData>(getAtomRt, q, arg, options)
 
-    let req: { value: I } | undefined
-    let callerOptions: any = options
-
-    if (options?.mode === "optional") {
-      const getOption: () => Option.Option<I> = typeof arr === "function"
-        ? arr as () => Option.Option<I>
-        : () => (arr as { value: Option.Option<I> }).value
-      req = {
-        get value() {
-          // getOrUndefined returns undefined when None, but queryFn is only called when enabled (Some)
-          return Option.getOrUndefined(getOption()) as I
-        }
-      }
-      const { mode: _mode, enabled: _enabled, ...rest } = options ?? {}
-      callerOptions = { ...rest, enabled: computed(() => Option.isSome(getOption())) }
-    } else {
-      req = !arg
-        ? undefined
-        : typeof arr === "function"
-        ? ({
-          get value() {
-            return (arr as any)()
-          }
-        })
-        : ref(arg) as any
+    // 4th element is internal-only; the public `.suspense()` Promise boundary lives in makeClient.
+    const handle = {
+      awaitResult: view.awaitResult,
+      refetch: view.refetch,
+      refresh: view.refresh,
+      registry: view.registry,
+      atom: view.atom
     }
-
-    const queryKey = makeQueryKey(q)
-    const projectionHash = (q as { queryKeyProjectionHash?: string }).queryKeyProjectionHash
-
-    const defaultOptions = {
-      // we do not want to throw errors, because we turn the success and error responses into a Result type
-      // why don't we turn the error/success response into a Result type before returning to tanstack query? because we want to leverage tanstack query's retry and caching mechanism, which relies on throwing errors to trigger retries, and we don't want to interfere with that by catching the errors too early.
-      // but if we allow tanstack query to throw, it will trigger the error boundary in Vue - via a "watcher callback" error - which we currently report and log, which is not what we want.
-      // TODO: we might want to rethink the strategy of how to handle errors that happen after the initial load.
-      // For suspense, the initial load is captured by the suspense boundary.
-      // For subsequent loads (or non suspense use) we currently are required to use the QueryResult component to conditionally render error/loading/etc.
-      throwOnError: false
-    }
-
-    const r = useTanstackQuery<A, CauseException<E>, TData>({
-      ...defaultOptions,
-      ...callerOptions,
-      retry: (retryCount, error) => {
-        if (error instanceof CauseException) {
-          if (!isHttpClientError(error.cause) && !S.is(ServiceUnavailableError)(error.cause)) {
-            return false
-          }
-        }
-
-        return retryCount < 5
-      },
-      queryKey: projectionHash === undefined ? [...queryKey, req] : [...queryKey, req, projectionHash],
-      queryFn: ({ meta, signal }) =>
-        runPromise(
-          q
-            .handler(req?.value as I)
-            .pipe(
-              Effect.tapCauseIf(Cause.hasDies, (cause) => reportRuntimeError(cause)),
-              Effect.withSpan(`query ${q.id}`, {}, { captureStackTrace: false }),
-              meta?.["span"] ? Effect.withParentSpan(meta["span"] as Span) : (_) => _
-            ),
-          { signal }
-        )
-    })
-
-    const latestSuccess = shallowRef<TData>()
-    const result = computed((): AsyncResult.AsyncResult<TData, E> =>
-      swrToQuery({
-        error: r.error.value ?? undefined,
-        data: r.data.value === undefined ? latestSuccess.value : r.data.value, // we fall back to existing data, as tanstack query might loose it when the key changes
-        isValidating: r.isFetching.value
-      })
-    )
-    // not using `computed` here as we have a circular dependency
-    watch(result, (value) => latestSuccess.value = Option.getOrUndefined(AsyncResult.value(value)), { immediate: true })
 
     return [
-      result,
-      computed(() => latestSuccess.value),
-      // one thing to keep in mind is that span will be disconnected as Context does not pass from outside.
-      // TODO: consider how we should handle the Result here which is `QueryObserverResult<A, E>`
-      // and always ends up in the success channel, even when error..
-      (options?: RefetchOptions) =>
-        Effect.currentSpan.pipe(
-          Effect.orElseSucceed(() => null),
-          Effect.flatMap((span) => Effect.promise(() => r.refetch({ ...options, updateMeta: { span } })))
-        ),
-      r
+      view.result,
+      view.data,
+      (_options?: RefetchOptions) => view.refetch(),
+      handle
     ] as any
   }
 
@@ -359,66 +552,26 @@ type StreamQueryResult<A, E> = readonly [
   UseQueryReturnType<any, any>
 ]
 
-export const makeStreamQuery = <R>(getRuntime: () => Context.Context<R>) => {
+export const makeStreamQuery = <R>(
+  getRuntime: () => Context.Context<R>,
+  getAtomRt: () => AtomClientRuntime
+) => {
+  const query = makeQuery(getRuntime, getAtomRt)
+  // A stream query is an ordinary atom query over an effect that collects the whole stream
+  // into an array (`Stream.runCollect`). It reuses all the atom machinery (family cache, swr,
+  // invalidation, structural sharing). Note: unlike the old tanstack `streamedQuery`, the result
+  // appears once the stream completes, not incrementally (stream queries are not used today).
   const streamQuery_: {
     <I, E, A, Request extends Req, Name extends string>(
       q: RequestStreamHandlerWithInput<I, A, E, R, Request, Name>
     ): (arg: I | WatchSource<I>) => StreamQueryResult<A, E>
-  } = (q: any) => (arg?: any) => {
-    const context = getRuntime()
-    const arr = arg
-    const req: { value: any } | undefined = !arg
-      ? undefined
-      : typeof arr === "function"
-      ? ({
-        get value() {
-          return arr()
-        }
-      })
-      : ref(arg)
-    const queryKey = makeQueryKey(q)
-
-    const r = useTanstackQuery<any[], CauseException<any>, any[]>(
-      {
-        throwOnError: false,
-        retry: (retryCount: number, error: unknown) => {
-          if (error instanceof CauseException) {
-            if (!isHttpClientError(error.cause) && !S.is(ServiceUnavailableError)(error.cause)) {
-              return false
-            }
-          }
-          return retryCount < 5
-        },
-        queryKey: [...queryKey, req],
-        queryFn: streamedQuery({
-          streamFn: () => {
-            const stream = q.handler(req?.value)
-            return streamToAsyncIterableWithCauseException(stream, context, q.id)
-          }
-        })
-      }
-    )
-
-    const latestSuccess = shallowRef<any[]>()
-    const result = computed((): AsyncResult.AsyncResult<any[], any> =>
-      swrToQuery({
-        error: r.error.value ?? undefined,
-        data: r.data.value === undefined ? latestSuccess.value : r.data.value,
-        isValidating: r.isFetching.value
-      })
-    )
-    watch(result, (value) => latestSuccess.value = Option.getOrUndefined(AsyncResult.value(value)), { immediate: true })
-
-    return [
-      result,
-      computed(() => latestSuccess.value),
-      (options?: RefetchOptions) =>
-        Effect.currentSpan.pipe(
-          Effect.orElseSucceed(() => null),
-          Effect.flatMap((span) => Effect.promise(() => r.refetch({ ...options, updateMeta: { span } })))
-        ),
-      r
-    ] as any
+  } = (q: any) => {
+    const hook = query({
+      id: q.id,
+      options: q.options,
+      handler: (i: any) => Stream.runCollect(q.handler(i)).pipe(Effect.map((chunk) => [...chunk]))
+    } as any)
+    return (arg?: any) => hook(arg) as any
   }
 
   return streamQuery_
@@ -474,22 +627,24 @@ export function composeQueries<
 }
 
 export const useUpdateQuery = () => {
-  const queryClient = useQueryClient()
+  const registry = injectRegistry()
 
+  // NOTE: query atoms are derived (read-only) here, so unlike tanstack's `setQueryData` we can't
+  // optimistically patch the cache in place — this refetches the query (the `updater` is ignored).
+  // A first-class optimistic-update layer is planned for the atom-native redesign.
   const f: {
     <I, A>(
       query: RequestHandlerWithInput<I, A, any, any, any, any>,
       input: I,
       updater: (data: NoInfer<A>) => NoInfer<A>
     ): void
-  } = (query: any, input: any, updater: any) => {
-    const key = [...makeQueryKey(query), input]
-    const data = queryClient.getQueryData(key)
-    if (data) {
-      queryClient.setQueryData(key, updater)
-    } else {
-      console.warn(`Query data for key ${key} not found`, key)
+  } = (query: any, input: any, _updater: any) => {
+    const family = queryFamilyByKey.get(queryFamilyCacheKey(query))
+    if (!family) {
+      console.warn(`Query ${query.id} has not been used yet; nothing to update`)
+      return
     }
+    registry.refresh(family(input))
   }
   return f
 }

--- a/packages/vue/src/query.ts
+++ b/packages/vue/src/query.ts
@@ -3,6 +3,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-return */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
+import { injectRegistry, useAtomValue } from "@effect/atom-vue"
 import * as Array from "effect-app/Array"
 import { makeQueryKey, type Req } from "effect-app/client"
 import type { ClientForOptions, RequestHandlerWithInput, RequestStreamHandlerWithInput } from "effect-app/client/clientFor"
@@ -13,9 +14,8 @@ import * as Option from "effect-app/Option"
 import * as Exit from "effect/Exit"
 import * as Stream from "effect/Stream"
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult"
-import * as Atom from "effect/unstable/reactivity/Atom"
+import type * as Atom from "effect/unstable/reactivity/Atom"
 import { computed, type ComputedRef, type MaybeRefOrGetter, onBeforeUnmount, onMounted, ref, toValue, type WatchSource } from "vue"
-import { injectRegistry, useAtomValue } from "@effect/atom-vue"
 import { type AtomClientRuntime, type AtomQueryOptions, awaitAtomResult, buildQueryFamily, disabledQueryAtom, isStaleResult, staleTimeMsOf, withQueryOptions } from "./atomQuery.ts"
 
 // --- minimal local types (replacing the former @tanstack/vue-query type imports) ---
@@ -66,8 +66,9 @@ interface QueryFamilyDescriptor<I, A, E> {
   readonly queryKeyProjectionHash?: string
 }
 
-const queryFamilyCacheKey = (q: { readonly id: string; readonly options?: ClientForOptions; readonly queryKeyProjectionHash?: string }) =>
-  `${makeQueryKey(q).join("/")}:${q.queryKeyProjectionHash ?? ""}`
+const queryFamilyCacheKey = (
+  q: { readonly id: string; readonly options?: ClientForOptions; readonly queryKeyProjectionHash?: string }
+) => `${makeQueryKey(q).join("/")}:${q.queryKeyProjectionHash ?? ""}`
 
 // One atom family per request shape, keyed by the stable query key + projection hash (not the
 // handler object — `clientFor` returns a fresh proxy per call, so the object isn't shareable).
@@ -249,15 +250,18 @@ export const useAtomSuspense = <A, E>(
       registry: view.registry,
       atom: view.atom
     }
-    return Object.assign([
-      view.result,
-      data,
-      fetch,
-      handle
-    ] as const, {
-      ...view,
-      data
-    })
+    return Object.assign(
+      [
+        view.result,
+        data,
+        fetch,
+        handle
+      ] as const,
+      {
+        ...view,
+        data
+      }
+    )
   })
 
   return Effect.runPromise(eff)
@@ -272,14 +276,22 @@ const optionValue = <I>(
       ? arr as () => Option.Option<I>
       : () => (arr as { value: Option.Option<I> }).value
     return [
-      { get value() { return Option.getOrUndefined(getOption()) as I } },
+      {
+        get value() {
+          return Option.getOrUndefined(getOption()) as I
+        }
+      },
       computed(() => Option.isSome(getOption()))
     ] as const
   }
   const req = !arr
     ? ({ value: undefined as I })
     : typeof arr === "function"
-    ? ({ get value() { return (arr as any)() } })
+    ? ({
+      get value() {
+        return (arr as any)()
+      }
+    })
     : (ref(arr) as any)
   const enabled = options?.enabled
   return [req, computed(() => enabled === undefined ? true : !!toValue(enabled))] as const
@@ -321,9 +333,7 @@ const makeQueryView = <I, A, E, TData>(
   const registry = injectRegistry()
   const [req, enabledRef] = optionValue<I>(arg, options)
   const family = getQueryFamily(atomRt, q)
-  const atomRef = computed(() =>
-    enabledRef.value ? observedAtom(family(req.value), options) : disabledQueryAtom
-  )
+  const atomRef = computed(() => enabledRef.value ? observedAtom(family(req.value), options) : disabledQueryAtom)
   const rawResult = useAtomValue(() => atomRef.value) as ComputedRef<AsyncResult.AsyncResult<A, E>>
   const select = options?.select
   const result = (select

--- a/packages/vue/test/makeClient.test.ts
+++ b/packages/vue/test/makeClient.test.ts
@@ -5,6 +5,8 @@ import type { HandlerInput } from "effect-app/client/clientFor"
 import * as Effect from "effect-app/Effect"
 import * as S from "effect-app/Schema"
 import * as Exit from "effect/Exit"
+import * as Fiber from "effect/Fiber"
+import { TestClock } from "effect/testing"
 import * as Atom from "effect/unstable/reactivity/Atom"
 import type { CommandFromRequest } from "../src/makeClient.js"
 import { combineQueryInvalidators, invalidateQueries } from "../src/mutate.js"
@@ -193,7 +195,9 @@ it.effect("mutation invalidation awaits the injected query invalidator", () =>
       queryInvalidator
     )
 
-    const result = yield* mutate(Effect.succeed(123), { id: "abc" })
+    const fiber = yield* Effect.forkChild(mutate(Effect.succeed(123), { id: "abc" }))
+    yield* TestClock.adjust("1 millis")
+    const result = yield* Fiber.join(fiber)
 
     expect(result).toBe(123)
     expect(recorded).toEqual([

--- a/packages/vue/test/makeClient.test.ts
+++ b/packages/vue/test/makeClient.test.ts
@@ -2,9 +2,13 @@
 import { expect, expectTypeOf, it } from "@effect/vitest"
 import { configureInvalidation, makeQueryKey } from "effect-app/client"
 import type { HandlerInput } from "effect-app/client/clientFor"
+import * as Effect from "effect-app/Effect"
 import * as S from "effect-app/Schema"
 import * as Exit from "effect/Exit"
+import * as Atom from "effect/unstable/reactivity/Atom"
 import type { CommandFromRequest } from "../src/makeClient.js"
+import { combineQueryInvalidators, invalidateQueries } from "../src/mutate.js"
+import { useAtomQuery, useAtomSuspense } from "../src/query.js"
 import { Something, SomethingElse, SomethingElseReq, SomethingReq, useClient, useExperimental } from "./stubs.js"
 
 const somethingInvalidationResources = {
@@ -38,6 +42,10 @@ it("TaggedRequestFor .moduleName and request .id / .moduleName", () => {
   ])
 
   expectTypeOf(invalidates.invalidatesQueries).toBeFunction()
+  configureInvalidation<{ Something: typeof Something }>()((_queryKey) => [
+    // @ts-expect-error predicate filters are not supported by the atom query engine
+    { filters: { predicate: () => true } }
+  ])
   configureInvalidation<{ Something: typeof Something }>()((_queryKey, { Something }) => {
     // @ts-expect-error commands are intentionally excluded from configured resources
     void Something.DoSomething
@@ -171,6 +179,31 @@ it("clientFor handler shape — props variants", () => {
   client.DoMixed.handler({ name: "y" })
 })
 
+it.effect("mutation invalidation awaits the injected query invalidator", () =>
+  Effect.gen(function*() {
+    const recorded: Array<readonly [string, ReadonlyArray<unknown>]> = []
+    const keys = [["$Something"], ["$Something", "GetSomething2"]]
+    const queryInvalidator = combineQueryInvalidators(
+      { invalidateAndAwait: (keys) => Effect.sync(() => keys.forEach((key) => recorded.push(["atom", key]))) },
+      { invalidateAndAwait: (keys) => Effect.sync(() => keys.forEach((key) => recorded.push(["tanstack", key]))) }
+    )
+    const mutate = invalidateQueries(
+      { id: "Something.DoSomething" },
+      { queryInvalidation: () => keys },
+      queryInvalidator
+    )
+
+    const result = yield* mutate(Effect.succeed(123), { id: "abc" })
+
+    expect(result).toBe(123)
+    expect(recorded).toEqual([
+      ["atom", keys[0]],
+      ["atom", keys[1]],
+      ["tanstack", keys[0]],
+      ["tanstack", keys[1]]
+    ])
+  }))
+
 it("client[Key].Input — extracted input type per props variant", () => {
   const { clientFor } = useClient()
   const client = clientFor(
@@ -284,6 +317,66 @@ it.skip("query type tests", () => {
   const [, eee] = q({ id: "a" }, { initialData: 123, placeholderData: () => 123, select: (data) => data.toString() })
   const val4 = eee.value
   expectTypeOf(val4).toEqualTypeOf<string>()
+})
+
+it("additive atom query api type tests", () => {
+  const { clientFor } = useClient()
+  const client = clientFor(
+    Something,
+    undefined,
+    somethingInvalidationResources
+  )
+
+  if (false as boolean) {
+    const family = client.GetSomething2.family
+    const familyAtom = family({ id: "a" })
+    expectTypeOf<Atom.Success<typeof familyAtom>>().toEqualTypeOf<number>()
+
+    const mappedFamilyAtom = Atom.mapResult(familyAtom, (data) => data.toString())
+    expectTypeOf<Atom.Success<typeof mappedFamilyAtom>>().toEqualTypeOf<string>()
+    expectTypeOf(useAtomQuery(() => mappedFamilyAtom).data.value).toEqualTypeOf<string | undefined>()
+    useAtomSuspense(() => mappedFamilyAtom).then((view) => {
+      expectTypeOf(view[1].value).toEqualTypeOf<string>()
+      return view
+    })
+
+    const atom = client.GetSomething2.atom({ id: "a" })
+    expectTypeOf<Atom.Success<typeof atom>>().toEqualTypeOf<number>()
+    // @ts-expect-error raw atom exposure does not accept Vue select projections
+    client.GetSomething2.atom({ id: "a" }, { select: (data) => data.toString() })
+
+    const query = client.GetSomething2.queryNew({ id: "a" })
+    expectTypeOf(query.data.value).toEqualTypeOf<number | undefined>()
+
+    const selected = client.GetSomething2.queryNew({ id: "a" }, { select: (data) => data.toString() })
+    expectTypeOf(selected.data.value).toEqualTypeOf<string | undefined>()
+
+    client.GetSomething2.suspenseNew({ id: "a" }, { select: (data) => data.toString() }).then((view) => {
+      expectTypeOf(view[1].value).toEqualTypeOf<string>()
+      return view
+    })
+
+    const projected = client.GetSomething2.project(S.String)
+    const projectedFamilyAtom = projected.family({ id: "a" })
+    expectTypeOf<Atom.Success<typeof projectedFamilyAtom>>().toEqualTypeOf<string>()
+    const projectedAtom = projected.atom({ id: "a" })
+    expectTypeOf<Atom.Success<typeof projectedAtom>>().toEqualTypeOf<string>()
+    expectTypeOf(projected.queryNew({ id: "a" }).data.value).toEqualTypeOf<string | undefined>()
+    projected.suspenseNew({ id: "a" }).then((view) => {
+      expectTypeOf(view[1].value).toEqualTypeOf<string>()
+      return view
+    })
+
+    const helperFamilyAtom = client.helpers.getSomething2QueryFamily({ id: "a" })
+    expectTypeOf<Atom.Success<typeof helperFamilyAtom>>().toEqualTypeOf<number>()
+    expectTypeOf(client.helpers.getSomething2QueryNew({ id: "a" }).data.value).toEqualTypeOf<number | undefined>()
+    client.helpers.getSomething2SuspenseQueryNew({ id: "a" }).then((view) => {
+      expectTypeOf(view[1].value).toEqualTypeOf<number>()
+      return view
+    })
+  }
+
+  expect(true).toBe(true)
 })
 
 it.skip("works", () => {

--- a/packages/vue/test/makeClient.test.ts
+++ b/packages/vue/test/makeClient.test.ts
@@ -236,10 +236,23 @@ it("client[Key].Input — extracted input type per props variant", () => {
   expectTypeOf<typeof client.DoMixed.Input>().toEqualTypeOf<HandlerArg>()
 
   // Stream handlers — Input now extracts via RequestStreamHandlerWithInput fallback.
+  expectTypeOf(client.StreamQuery.Input).toEqualTypeOf<{ readonly id: string; readonly _tag?: "StreamQuery" }>()
   expectTypeOf(client.StreamWithoutFinal.Input).toEqualTypeOf<
     { readonly id: string; readonly _tag?: "StreamWithoutFinal" }
   >()
   expectTypeOf(client.StreamWithFinal.Input).toEqualTypeOf<{ readonly id: string; readonly _tag?: "StreamWithFinal" }>()
+
+  const assertStreamQueryTypes = () => {
+    const streamAtom = client.StreamQuery.atom({ id: "abc" })
+    expectTypeOf(streamAtom).toEqualTypeOf<Atom.Writable<Atom.PullResult<number, never>, void>>()
+    const streamView = client.StreamQuery.queryNew({ id: "abc" })
+    expectTypeOf(streamView.items.value).toEqualTypeOf<ReadonlyArray<number>>()
+    expectTypeOf(streamView.latest.value).toEqualTypeOf<number | undefined>()
+    expectTypeOf(streamView.done.value).toBeBoolean()
+    expectTypeOf(streamView.pull).toBeFunction()
+    expectTypeOf(streamView.pullAndAwait).toBeFunction()
+  }
+  void assertStreamQueryTypes
 })
 
 it("CommandFromRequest input shape — props variants", () => {

--- a/packages/vue/test/stubs.ts
+++ b/packages/vue/test/stubs.ts
@@ -200,6 +200,13 @@ class SomethingGetStructNullable extends SomethingQuery<SomethingGetStructNullab
   success: S.Struct({ a: S.NullOr(S.String) })
 }) {}
 
+class SomethingStreamQuery extends SomethingQuery<SomethingStreamQuery>()("StreamQuery", {
+  id: S.String
+}, {
+  stream: true,
+  success: S.FiniteFromString
+}) {}
+
 /** Stream event: intermediate progress update. */
 export class OperationProgress extends S.TaggedClass<OperationProgress>()("OperationProgress", {
   completed: S.NonNegativeInt,
@@ -239,6 +246,7 @@ export const Something = {
   DoMixed: SomethingDoMixed,
   DoSomething: SomethingDoSomething,
   GetStructNullable: SomethingGetStructNullable,
+  StreamQuery: SomethingStreamQuery,
   StreamWithoutFinal: SomethingStreamWithoutFinal,
   StreamWithFinal: SomethingStreamWithFinal
 }

--- a/packages/vue/test/stubs.ts
+++ b/packages/vue/test/stubs.ts
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { type MessageFormatElement } from "@formatjs/icu-messageformat-parser"
 import * as Intl from "@formatjs/intl"
-import { QueryClient, VueQueryPlugin } from "@tanstack/vue-query"
 import { ApiClientFactory, makeRpcClient } from "effect-app/client"
 import * as Effect from "effect-app/Effect"
 import * as Layer from "effect-app/Layer"
@@ -280,11 +279,9 @@ export const useClient = (
   const clientFor_ = ApiClientFactory.makeFor(Layer.empty)
   const rawClient = makeClient(() => ManagedRuntime.make(layers), clientFor_, Layer.empty)
 
-  // Provide a Vue injection context so that composition-API hooks (e.g. useQueryClient)
-  // called during client initialisation work outside a component setup() function.
+  // Provide a Vue injection context so composition-API hooks called during client
+  // initialisation work outside a component setup() function.
   const vueApp = createApp({})
-  const testQueryClientConfig = { defaultOptions: { queries: { retry: false }, mutations: { retry: false } } }
-  vueApp.use(VueQueryPlugin, { queryClient: new QueryClient(testQueryClientConfig) })
 
   const origClientFor = rawClient.clientFor
   const clientFor: typeof origClientFor = function(m, ...args) {


### PR DESCRIPTION
Adds the Atom-native query surface while keeping the legacy query APIs compatible and TanStack-backed by default.

- Keeps existing `.query()` and Promise-based `.suspense()` tuple APIs intact.
- Adds Atom-native `.queryNew()`, `.suspenseNew()`, `.atom()`, and `.family()` helpers for composition and gradual migration.
- Adds atom-native stream query helpers: stream-query clients now expose `.atom()`, `.family()`, and `.queryNew()` backed by `Atom.pull`, while legacy stream `.query()` remains collect-to-array compatibility.
- Adds `makeClient(..., { legacyQueryEngine })`; omitted/default is `"tanstack"`, while `"atom"` remains available for legacy `.query()` / `.suspense()`.
- Keeps `.atom()`, `.family()`, `.queryNew()`, `.suspenseNew()`, and stream `.queryNew()` Atom-native regardless of the legacy engine.
- Uses the Atom-compatible option/key surface as the shared contract; TanStack-only behavior is not exposed through the public API.
- Adds an internal TanStack adapter that maps TanStack state back to the existing tuple/query-handle shape.
- Types projected query handlers with `queryKeyProjectionHash` so Atom and TanStack use the same projection-aware key shape.
- Narrows configured invalidation filters to concrete query keys; predicate-style TanStack filters are not part of the supported surface.
- Injects one unified query invalidator into mutation wiring; TanStack mode composes Atom + TanStack invalidators for the same concrete key set.
- Passes the same invalidator to regular and stream mutations.
- Adds coverage for rejecting predicate filters, stream query pull atoms, and awaiting a composed query invalidator as one injected value.
- Adds `packages/vue/docs/atom-query-api-redesign.md` as the migration/design note.
- Adds a patch changeset for `effect-app` and `@effect-app/vue`.

Validation:
- `pnpm check` passed.
- `pnpm build` passed; Rolldown emitted existing `@vueuse/core` invalid pure-annotation warnings.
- `pnpm --filter @effect-app/vue test -- makeClient.test.ts` passed.
- `pnpm exec dprint check --config ../../dprint.jsonc .` passed in `packages/vue`.
- `pnpm lint-fix` was rerun; `cli`, `infra`, `vue`, and `vue-components` completed, but the root command still fails in `packages/effect-app` because oxlint invokes the unsupported `tsgolint` CLI and exits with `flag provided but not defined: -type-aware` before source validation completes.