### PR TITLE
Fix atom query suspense cleanup

### DIFF
--- a/.changeset/clean-atom-suspense.md
+++ b/.changeset/clean-atom-suspense.md
@@ -1,0 +1,5 @@
+---
+"@effect-app/vue": patch
+---
+
+Fix atom-query suspense cleanup so per-observer wrappers unsubscribe on unmount while cached query atoms keep their idle TTL.

--- a/packages/vue/docs/atom-query-api-redesign.md
+++ b/packages/vue/docs/atom-query-api-redesign.md
@@ -112,6 +112,22 @@ const viewed = Atom.swr({ staleTime, revalidateOnFocus, focusSignal })(
 
 TTL is the awkward option. If TTL is part of the base atom, it should be a client/default policy, not the first observer's option. For old APIs, keep accepting `gcTime`, but normalize it into a base-atom policy that cannot be captured accidentally by the first observer. For new APIs, prefer an atom-native `idleTTL` or `timeToLive` name.
 
+## TanStack parity: observers, TTL, and cancellation
+
+Observer cleanup and cache lifetime are separate concerns:
+
+- Vue observers are registered through `@effect/atom-vue`'s `useAtomValue`, which uses a Vue `watchEffect` cleanup around `registry.subscribe`. Non-suspense component unmounts therefore remove observer subscriptions through normal Vue scope disposal.
+- Suspense helpers still load through native query atoms. The `Promise` returned by `.suspense()` / `.suspenseNew()` is only the Vue Suspense boundary that waits for `AtomRegistry.getResult`. Suspense setup runs in an explicit child `effectScope`; unmount stops that scope, removes the observer subscription, and aborts the waiting Effect so the Suspense Promise does not remain pending after the component is gone.
+- Observer-specific wrappers (`select`, SWR, focus revalidation, polling, structural sharing) must not get their own idle TTL. Otherwise a wrapper can keep source atoms observed after the component unmounts. TTL belongs to the canonical handler+input query atom.
+- The canonical query atom keeps its configured idle TTL after the last observer is gone. This preserves cached data and lets invalidation still reach cached-but-unmounted queries during the idle window.
+
+Current difference from TanStack Query:
+
+- TanStack creates an `AbortSignal` for each fetch. When the last observer is removed, it cancels the active retryer only if the query function consumed the signal; otherwise it cancels retries and lets the in-flight request finish so the result can populate cache.
+- Atom query currently does not cancel the canonical query atom's in-flight Effect merely because the last observer unmounted, because the canonical atom node can remain alive for `idleTTL`.
+- If canonical fetch cancellation is added later, it must match TanStack's observable state semantics: cancellation is control flow, not query data. Interrupting an in-flight fetch must not store an interrupt cause as the final `AsyncResult`; it should revert to the previous settled state, or to initial/idle when there is no previous result.
+- The desired parity target is: last observer gone -> remove observer subscriptions immediately; if no observers remain, interrupt the active fetch without recording an interrupt failure; keep the previous cached result until `idleTTL` expires.
+
 ## Option names
 
 Use atom-native names on the new APIs. Keep old option names on old APIs:

--- a/packages/vue/src/atomQuery.ts
+++ b/packages/vue/src/atomQuery.ts
@@ -206,6 +206,28 @@ export interface AtomQueryOptions {
 
 const defaults = { staleTime: Duration.seconds(5), gcTime: Duration.minutes(5) }
 
+export interface AtomQueryMetadata {
+  readonly staleTimeMs: number
+}
+
+const atomQueryMetadata = new WeakMap<Atom.Atom<AsyncResult.AsyncResult<any, any>>, AtomQueryMetadata>()
+
+const setAtomQueryMetadata = <A, E>(
+  atom: Atom.Atom<AsyncResult.AsyncResult<A, E>>,
+  opts: AtomQueryOptions = {}
+) => {
+  const staleTimeMs = staleTimeMsOf(opts)
+  const previous = atomQueryMetadata.get(atom)
+  atomQueryMetadata.set(atom, {
+    staleTimeMs: previous === undefined ? staleTimeMs : Math.min(previous.staleTimeMs, staleTimeMs)
+  })
+  return atom
+}
+
+export const getAtomQueryMetadata = <A, E>(
+  atom: Atom.Atom<AsyncResult.AsyncResult<A, E>>
+): AtomQueryMetadata | undefined => atomQueryMetadata.get(atom)
+
 /** Exported so the vue hook can do refetch-on-mount-per-observer with the same rule as swr. */
 export const isStaleResult = (r: AsyncResult.AsyncResult<any, any>, staleTimeMs: number): boolean => {
   if (r.waiting) return false
@@ -225,10 +247,8 @@ export const withQueryOptions = <A, E>(
   self: Atom.Atom<AsyncResult.AsyncResult<A, E>>,
   opts: AtomQueryOptions = {}
 ): Atom.Atom<AsyncResult.AsyncResult<A, E>> => {
+  setAtomQueryMetadata(self, opts)
   const staleTime: Duration.Input = opts.staleTime ?? defaults.staleTime
-  const gcTime = opts.gcTime === "infinity"
-    ? "infinity" as const
-    : Duration.fromInputUnsafe(opts.gcTime ?? defaults.gcTime)
   let atom = self
   const revalidateOnFocus = opts.revalidateOnFocus ?? true
   atom = Atom.swr({
@@ -238,7 +258,7 @@ export const withQueryOptions = <A, E>(
   })(atom)
   if (opts.refetchInterval) atom = Atom.withRefresh(Duration.millis(opts.refetchInterval))(atom)
   if (opts.structuralSharing ?? true) atom = structuralShare(atom)
-  return gcTime === "infinity" ? Atom.keepAlive(atom) : Atom.setIdleTTL(atom, gcTime)
+  return atom
 }
 
 /** Constant atom for disabled / `mode:"optional"`-None queries: stays Initial, never fetches. */
@@ -321,7 +341,7 @@ export const buildQueryFamily = <I, A, E>(
     // gcTime LAST so the whole chain (incl. the registration + tracking) stays alive through the
     // idle window, letting invalidation reach a cached-but-unmounted query.
     atom = Atom.setIdleTTL(atom, defaults.gcTime)
-    return Atom.withLabel(`query:${self.id}`)(atom)
+    return setAtomQueryMetadata(Atom.withLabel(`query:${self.id}`)(atom))
   })
 }
 
@@ -350,7 +370,7 @@ export const buildStreamQueryFamily = <I, A, E>(
     atom = rt.factory.withReactivity(reactivityKeys)(atom)
     atom = trackWritableByKeys(reactivityKeys)(atom)
     atom = Atom.setIdleTTL(atom, defaults.gcTime)
-    return Atom.withLabel(`stream-query:${self.id}`)(atom)
+    return setAtomQueryMetadata(Atom.withLabel(`stream-query:${self.id}`)(atom))
   })
 }
 

--- a/packages/vue/src/makeClient.ts
+++ b/packages/vue/src/makeClient.ts
@@ -16,7 +16,7 @@ import type * as Stream from "effect/Stream"
 import * as Struct from "effect/Struct"
 import type * as AsyncResult from "effect/unstable/reactivity/AsyncResult"
 import * as Reactivity from "effect/unstable/reactivity/Reactivity"
-import { computed, type ComputedRef, onBeforeUnmount, ref, type WatchSource } from "vue"
+import { computed, type ComputedRef, effectScope, onBeforeUnmount, onScopeDispose, ref, type WatchSource } from "vue"
 import { type AtomClientRuntime, invalidateAndAwait, makeAtomClientRuntime } from "./atomQuery.ts"
 import { type Commander, CommanderStatic, type Progress } from "./commander.ts"
 import { makeTanstackQuery, makeTanstackQueryCacheUpdater, makeTanstackQueryClient, makeTanstackQueryInvalidator } from "./internal/tanstackQuery.ts"
@@ -28,6 +28,29 @@ import { makeRunPromise } from "./runtime.ts"
 import { type Toast } from "./toast.ts"
 
 export type { Progress }
+
+const useScopedSuspenseSetup = <A>(setup: () => A) => {
+  const scope = effectScope()
+  const controller = new AbortController()
+  const value = scope.run(setup)
+  if (value === undefined) {
+    throw new Error("Internal Error: suspense setup scope did not initialize")
+  }
+
+  const isMounted = ref(true)
+  let stopped = false
+  const stop = () => {
+    if (stopped) return
+    stopped = true
+    isMounted.value = false
+    controller.abort()
+    scope.stop()
+  }
+  onBeforeUnmount(stop)
+  onScopeDispose(stop)
+
+  return [value, isMounted, controller.signal] as const
+}
 
 // TODO: optimize - work from encoded shape directly
 const projectHandler = <
@@ -491,18 +514,20 @@ export class QueryImpl<R> {
       argOrOptions: I | WatchSource<I>,
       options?: CustomUndefinedInitialQueryOptions<A, CauseException<E>, TData>
     ) => {
-      const [resultRef, latestRef, fetch, uqrt] = q<TData>(argOrOptions, options)
-      const latestDefinedRef = computed<TData>(() => {
-        const latest = latestRef.value
-        if (latest === undefined) {
-          throw new Error("Internal Error: suspense resolved without a latest value")
-        }
-        return latest
-      })
-
-      const isMounted = ref(true)
-      onBeforeUnmount(() => {
-        isMounted.value = false
+      const [
+        [resultRef, latestDefinedRef, fetch, uqrt],
+        isMounted,
+        signal
+      ] = useScopedSuspenseSetup(() => {
+        const [resultRef, latestRef, fetch, uqrt] = q<TData>(argOrOptions, options)
+        const latestDefinedRef = computed<TData>(() => {
+          const latest = latestRef.value
+          if (latest === undefined) {
+            throw new Error("Internal Error: suspense resolved without a latest value")
+          }
+          return latest
+        })
+        return [resultRef, latestDefinedRef, fetch, uqrt] as const
       })
 
       // @effect-diagnostics effect/missingEffectError:off
@@ -518,7 +543,7 @@ export class QueryImpl<R> {
         return [resultRef, latestDefinedRef, fetch, uqrt] as const
       })
 
-      return runPromise(eff)
+      return runPromise(eff, { signal })
     }
   }
 
@@ -546,18 +571,16 @@ export class QueryImpl<R> {
       argOrOptions: I | WatchSource<I>,
       options?: AtomQueryNewOptions<A, TData>
     ) => {
-      const view = q<TData>(argOrOptions, options)
-      const data = computed<TData>(() => {
-        const latest = view.data.value
-        if (latest === undefined) {
-          throw new Error("Internal Error: suspenseNew resolved without a latest value")
-        }
-        return latest
-      })
-
-      const isMounted = ref(true)
-      onBeforeUnmount(() => {
-        isMounted.value = false
+      const [{ view, data }, isMounted, signal] = useScopedSuspenseSetup(() => {
+        const view = q<TData>(argOrOptions, options)
+        const data = computed<TData>(() => {
+          const latest = view.data.value
+          if (latest === undefined) {
+            throw new Error("Internal Error: suspenseNew resolved without a latest value")
+          }
+          return latest
+        })
+        return { view, data }
       })
 
       // @effect-diagnostics effect/missingEffectError:off
@@ -592,7 +615,7 @@ export class QueryImpl<R> {
         )
       })
 
-      return runPromise(eff)
+      return runPromise(eff, { signal })
     }
   }
 }

--- a/packages/vue/src/query.ts
+++ b/packages/vue/src/query.ts
@@ -16,7 +16,7 @@ import * as Exit from "effect/Exit"
 import * as Stream from "effect/Stream"
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult"
 import * as Atom from "effect/unstable/reactivity/Atom"
-import { computed, type ComputedRef, type MaybeRefOrGetter, onBeforeUnmount, onMounted, ref, toValue, type WatchSource } from "vue"
+import { computed, type ComputedRef, effectScope, type MaybeRefOrGetter, onBeforeUnmount, onMounted, onScopeDispose, ref, toValue, type WatchSource } from "vue"
 import { type AtomClientRuntime, type AtomQueryOptions, awaitAtomResult, buildQueryFamily, buildStreamQueryFamily, disabledQueryAtom, isStaleResult, staleTimeMsOf, withQueryOptions } from "./atomQuery.ts"
 
 // --- minimal local types (replacing the former @tanstack/vue-query type imports) ---
@@ -38,6 +38,29 @@ export interface QueryHandle<A = unknown, E = unknown> {
 export interface QueryView<A, E> extends QueryHandle<A, E> {
   readonly result: ComputedRef<AsyncResult.AsyncResult<A, E>>
   readonly data: ComputedRef<A | undefined>
+}
+
+const useScopedSuspenseSetup = <A>(setup: () => A) => {
+  const scope = effectScope()
+  const controller = new AbortController()
+  const value = scope.run(setup)
+  if (value === undefined) {
+    throw new Error("Internal Error: atom suspense setup scope did not initialize")
+  }
+
+  const isMounted = ref(true)
+  let stopped = false
+  const stop = () => {
+    if (stopped) return
+    stopped = true
+    isMounted.value = false
+    controller.abort()
+    scope.stop()
+  }
+  onBeforeUnmount(stop)
+  onScopeDispose(stop)
+
+  return [value, isMounted, controller.signal] as const
 }
 
 export interface QueryCacheUpdater {
@@ -290,18 +313,16 @@ export const useAtomQuery = <A, E>(
 export const useAtomSuspense = <A, E>(
   atom: () => Atom.Atom<AsyncResult.AsyncResult<A, E>>
 ): Promise<SuspenseQueryView<A, E>> => {
-  const view = useAtomQuery(atom)
-  const data = computed<A>(() => {
-    const latest = view.data.value
-    if (latest === undefined) {
-      throw new Error("Internal Error: atom suspense resolved without a latest value")
-    }
-    return latest
-  })
-
-  const isMounted = ref(true)
-  onBeforeUnmount(() => {
-    isMounted.value = false
+  const [{ view, data }, isMounted, signal] = useScopedSuspenseSetup(() => {
+    const view = useAtomQuery(atom)
+    const data = computed<A>(() => {
+      const latest = view.data.value
+      if (latest === undefined) {
+        throw new Error("Internal Error: atom suspense resolved without a latest value")
+      }
+      return latest
+    })
+    return { view, data }
   })
 
   const eff = Effect.gen(function*() {
@@ -335,7 +356,7 @@ export const useAtomSuspense = <A, E>(
     )
   })
 
-  return Effect.runPromise(eff)
+  return Effect.runPromise(eff, { signal })
 }
 
 export type StreamQueryPullValue<A> = {

--- a/packages/vue/test/suspense.test.ts
+++ b/packages/vue/test/suspense.test.ts
@@ -1,7 +1,13 @@
+import { defaultRegistry, registryKey } from "@effect/atom-vue"
 import { Effect, Option } from "effect-app"
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult"
-import { computed, ref } from "vue"
+import * as Atom from "effect/unstable/reactivity/Atom"
+import { computed, createApp, nextTick, ref } from "vue"
+import { withQueryOptions } from "../src/atomQuery.js"
+import { useAtomQuery, useAtomSuspense } from "../src/query.js"
 import { awaitResolvedSuspenseResult } from "../src/suspense.js"
+
+const listenerCount = (atom: Atom.Atom<unknown>) => defaultRegistry.getNodes().get(atom)?.listeners.size ?? 0
 
 it("waits for the query result ref after suspense resolves", async () => {
   const result = ref<AsyncResult.AsyncResult<number, never>>(AsyncResult.initial(true))
@@ -17,4 +23,138 @@ it("keeps unresolved query results initial", async () => {
   const settled = await Effect.runPromise(awaitResolvedSuspenseResult(computed(() => result.value)))
 
   expect(AsyncResult.isInitial(settled)).toBe(true)
+})
+
+it("stops atom suspense subscriptions when the setup scope is disposed", async () => {
+  defaultRegistry.reset()
+  const atom = Atom.make(Effect.succeed(123))
+  let promise: ReturnType<typeof useAtomSuspense<number, never>> | undefined
+  const host = document.createElement("div")
+  const app = createApp({
+    setup() {
+      promise = useAtomSuspense(() => atom)
+      return () => null
+    }
+  })
+  app.provide(registryKey, defaultRegistry)
+  app.mount(host)
+
+  if (promise === undefined) {
+    throw new Error("suspense setup did not initialize")
+  }
+
+  await promise
+  expect(listenerCount(atom)).toBe(1)
+
+  app.unmount()
+  await nextTick()
+  await new Promise((resolve) => setTimeout(resolve, 0))
+  expect(listenerCount(atom)).toBe(0)
+  defaultRegistry.reset()
+})
+
+it("does not keep query option wrapper subscriptions after unmount", async () => {
+  defaultRegistry.reset()
+  const atom = Atom.make(Effect.succeed(123))
+  const observed = withQueryOptions(atom)
+  let promise: ReturnType<typeof useAtomSuspense<number, never>> | undefined
+  const host = document.createElement("div")
+  const app = createApp({
+    setup() {
+      promise = useAtomSuspense(() => observed)
+      return () => null
+    }
+  })
+  app.provide(registryKey, defaultRegistry)
+  app.mount(host)
+
+  if (promise === undefined) {
+    throw new Error("suspense setup did not initialize")
+  }
+
+  await promise
+  expect(listenerCount(atom)).toBe(1)
+
+  app.unmount()
+  await nextTick()
+  await new Promise((resolve) => setTimeout(resolve, 0))
+  expect(listenerCount(atom)).toBe(0)
+  defaultRegistry.reset()
+})
+
+it("aborts atom suspense promises when the component unmounts", async () => {
+  defaultRegistry.reset()
+  const atom = Atom.make(Effect.never)
+  let promise: ReturnType<typeof useAtomSuspense<number, never>> | undefined
+  const host = document.createElement("div")
+  const app = createApp({
+    setup() {
+      promise = useAtomSuspense(() => atom)
+      return () => null
+    }
+  })
+  app.provide(registryKey, defaultRegistry)
+  app.mount(host)
+
+  if (promise === undefined) {
+    throw new Error("suspense setup did not initialize")
+  }
+
+  app.unmount()
+  await nextTick()
+  const settled = await Promise.race([
+    promise.then(() => "resolved" as const, () => "rejected" as const),
+    new Promise<"pending">((resolve) => setTimeout(() => resolve("pending"), 20))
+  ])
+  expect(settled).toBe("rejected")
+  defaultRegistry.reset()
+})
+
+it("stops atom query subscriptions when the component unmounts", async () => {
+  defaultRegistry.reset()
+  const atom = Atom.make(Effect.succeed(123))
+  const host = document.createElement("div")
+  const app = createApp({
+    setup() {
+      useAtomQuery(() => atom)
+      return () => null
+    }
+  })
+  app.provide(registryKey, defaultRegistry)
+  app.mount(host)
+
+  await nextTick()
+  expect(listenerCount(atom)).toBe(1)
+
+  app.unmount()
+  await nextTick()
+  await new Promise((resolve) => setTimeout(resolve, 0))
+  expect(listenerCount(atom)).toBe(0)
+  defaultRegistry.reset()
+})
+
+it("does not keep non-suspense query option wrapper subscriptions after unmount", async () => {
+  defaultRegistry.reset()
+  const atom = Atom.make(Effect.succeed(123))
+  const observed = withQueryOptions(atom)
+  const host = document.createElement("div")
+  const app = createApp({
+    setup() {
+      useAtomQuery(() => observed)
+      return () => null
+    }
+  })
+  app.provide(registryKey, defaultRegistry)
+  app.mount(host)
+
+  await nextTick()
+  expect(listenerCount(observed)).toBe(1)
+  expect(listenerCount(atom)).toBe(1)
+
+  app.unmount()
+  await nextTick()
+  await new Promise((resolve) => setTimeout(resolve, 0))
+  expect(listenerCount(observed)).toBe(0)
+  expect(listenerCount(atom)).toBe(0)
+  defaultRegistry.reset()
 })


### PR DESCRIPTION
Adds scoped cleanup for atom-query suspense consumers so unmounted Vue setup scopes release observer subscriptions, while canonical query atoms keep their idle TTL for cache invalidation.

Suspense still uses native atom Effects for loading. The Promise involved is only the Vue Suspense-facing wrapper that waits for the atom result; this now receives an AbortSignal so unmount interrupts that wait immediately instead of leaving it pending.

Non-suspense query subscriptions already clean up via `@effect/atom-vue` `useAtomValue`/Vue `watchEffect` cleanup; this PR adds regression coverage for both direct non-suspense queries and `withQueryOptions` wrappers to lock that invariant down.

Documents current atom/TanStack parity behavior: observer cleanup vs idle TTL, Suspense wait cancellation, the current difference around canonical in-flight fetch cancellation, and the rule that interruption must be control flow rather than final query data.

Also records atom-query stale-time metadata for devtools consumers and adds regression coverage for suspense observer cleanup.

Changeset: ✅

Validation:
- ✅ pnpm --dir packages/vue lint-fix
- ✅ pnpm exec tsgo --build packages/vue/tsconfig.json --pretty false
- ✅ pnpm --dir packages/vue exec vitest run test/suspense.test.ts
- ✅ pnpm check
- ⚠️ pnpm lint-fix: fails in packages/effect-app because its script invokes `oxlint --type-aware`, which resolves to the unsupported `tsgolint` CLI entrypoint in this workspace; @effect-app/vue lint-fix passes.