### PR TITLE
fix(vue): share Equal leaves in TanStack queries

### DIFF
--- a/.changeset/tanstack-effect-equal-structural-sharing.md
+++ b/.changeset/tanstack-effect-equal-structural-sharing.md
@@ -1,0 +1,5 @@
+---
+"@effect-app/vue": patch
+---
+
+Default legacy TanStack queries to Effect-Equal-aware structural sharing.

--- a/packages/vue/src/atomQuery.ts
+++ b/packages/vue/src/atomQuery.ts
@@ -123,7 +123,7 @@ const isPlainObject = (o: unknown): o is Record<string, unknown> => {
  * (Vue skips re-rendering it). Leaves — including decoded Schema CLASS INSTANCES — are compared with
  * Effect `Equal.equals` (structural), which reuses equal instances that tanstack's `===` could not.
  */
-const replaceEqualDeep = (prev: any, next: any): any => {
+export const replaceEqualDeep = (prev: any, next: any): any => {
   if (prev === next) return prev
   const bothArrays = Array.isArray(prev) && Array.isArray(next)
   if (bothArrays || (isPlainObject(prev) && isPlainObject(next))) {

--- a/packages/vue/src/internal/tanstackQuery.ts
+++ b/packages/vue/src/internal/tanstackQuery.ts
@@ -12,6 +12,7 @@ import { isHttpClientError } from "effect/unstable/http/HttpClientError"
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult"
 import * as Atom from "effect/unstable/reactivity/Atom"
 import { computed, type MaybeRefOrGetter, shallowRef, toValue, watch, type WatchSource } from "vue"
+import { replaceEqualDeep } from "../atomQuery.ts"
 import { reportRuntimeError } from "../lib.ts"
 import type { QueryInvalidator } from "../mutate.ts"
 import type { CustomDefinedInitialQueryOptions, CustomDefinedPlaceholderQueryOptions, CustomUndefinedInitialQueryOptions, CustomUseQueryOptions, MakeQuery2, QueryCacheUpdater, QueryHandle, QueryObserverResult, RefetchOptions } from "../query.ts"
@@ -140,11 +141,12 @@ export const makeTanstackQuery = <R>(
     const runPromise = makeRunPromise(getRuntime())
     const queryKey = makeQueryKey(q)
     const enabled = resolveEnabled(arg, options)
+    const structuralSharing = options?.structuralSharing === false ? false : replaceEqualDeep
     const tanstackOptions = {
       ...(options?.staleTime !== undefined ? { staleTime: options.staleTime } : {}),
       ...(typeof options?.gcTime === "number" ? { gcTime: options.gcTime } : {}),
       ...(options?.refetchOnWindowFocus !== undefined ? { refetchOnWindowFocus: options.refetchOnWindowFocus } : {}),
-      ...(options?.structuralSharing !== undefined ? { structuralSharing: options.structuralSharing } : {}),
+      structuralSharing,
       ...(options?.refetchInterval !== undefined ? { refetchInterval: options.refetchInterval } : {}),
       ...(options?.select !== undefined ? { select: options.select } : {})
     }

--- a/packages/vue/test/suspense-regression.test.ts
+++ b/packages/vue/test/suspense-regression.test.ts
@@ -77,3 +77,39 @@ it("makeClient .suspense(): observer re-pointed mid-flight -> resolves (seeded) 
 
   ctx.dispose()
 })
+
+it("makeTanstackQuery structurally shares Effect-Equal leaves by default", async () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: Infinity, staleTime: 0 } }
+  })
+  const getRuntime = () => Context.empty()
+  let calls = 0
+  const handler = fakeHandler(
+    "Test/StructuralSharing",
+    () =>
+      Effect.sync(() => {
+        calls += 1
+        return {
+          stable: {
+            date: new Date("2026-01-01T00:00:00.000Z"),
+            option: Option.some({ id: "same" })
+          },
+          revision: calls
+        }
+      })
+  )
+  const query = makeTanstackQuery(getRuntime, queryClient)(handler)
+  const ctx = makeContext(queryClient)
+
+  const [, , , handle] = ctx.run(() => query(undefined, {}))
+  const first = await Effect.runPromise(handle.awaitResult())
+  const second = await Effect.runPromise(handle.refetch())
+
+  expect(second.revision).toBe(2)
+  expect(second).not.toBe(first)
+  expect(second.stable).toBe(first.stable)
+  expect(second.stable.date).toBe(first.stable.date)
+  expect(second.stable.option).toBe(first.stable.option)
+
+  ctx.dispose()
+})


### PR DESCRIPTION
## Summary
- reuse the atom engine Effect-Equal-aware structural sharing merge for legacy TanStack queries
- keep `structuralSharing: false` as the opt-out
- add a regression covering Date and Option leaves across refetches

## Validation
- `pnpm --filter @effect-app/vue test:run suspense-regression.test.ts`
- `pnpm --filter @effect-app/vue check`
- `pnpm check`
- `pnpm lint-fix` attempted; blocked in existing `packages/effect-app` script because `oxlint --type-aware --fix ./src` invokes the unsupported tsgolint entrypoint and exits 2 before this patch is involved
