### PR TITLE
Fix OmegaForm Enter submit with Vuetify inputs

### DIFF
--- a/.changeset/omegaform-enter-submit-repro.md
+++ b/.changeset/omegaform-enter-submit-repro.md
@@ -1,0 +1,5 @@
+---
+"@effect-app/vue-components": patch
+---
+
+Fix OmegaForm default inputs leaking the internal form object as a native `form="[object Object]"` attribute, restoring browser implicit Enter-key submission. Adds a Storybook repro for the default Vuetify input renderer.

--- a/packages/vue-components/__tests__/OmegaForm/InputAttributes.test.ts
+++ b/packages/vue-components/__tests__/OmegaForm/InputAttributes.test.ts
@@ -34,6 +34,7 @@ describe("OmegaForm input attributes", () => {
               label="Password"
               name="password"
               type="password"
+              :validators="{ onChange: () => undefined }"
             />
             <button type="submit">submit</button>
           </component>
@@ -65,6 +66,8 @@ describe("OmegaForm input attributes", () => {
     const nativeForm = wrapper.find("form").element
 
     expect(input.attributes("form")).toBeUndefined()
+    expect(input.attributes("validators")).toBeUndefined()
+    expect(Object.values(input.attributes())).not.toContain("[object Object]")
     expect((input.element as HTMLInputElement).form).toBe(nativeForm)
   })
 })

--- a/packages/vue-components/__tests__/OmegaForm/InputAttributes.test.ts
+++ b/packages/vue-components/__tests__/OmegaForm/InputAttributes.test.ts
@@ -1,0 +1,70 @@
+import { mount } from "@vue/test-utils"
+import * as S from "effect-app/Schema"
+import { describe, expect, it } from "vitest"
+import { defineComponent } from "vue"
+import { useOmegaForm } from "../../src/components/OmegaForm"
+import OmegaIntlProvider from "../OmegaIntlProvider.vue"
+
+const VTextField = defineComponent({
+  props: {
+    modelValue: {
+      type: String,
+      default: ""
+    }
+  },
+  emits: ["update:modelValue"],
+  template: `
+    <input
+      v-bind="$attrs"
+      :value="modelValue"
+      @input="$emit('update:modelValue', $event.target.value)"
+    />
+  `
+})
+
+describe("OmegaForm input attributes", () => {
+  it("does not forward the internal form object as a native form attribute", async () => {
+    const wrapper = mount({
+      components: { OmegaIntlProvider },
+      template: `
+        <OmegaIntlProvider>
+          <component :is="form.Form">
+            <component
+              :is="form.Input"
+              label="Password"
+              name="password"
+              type="password"
+            />
+            <button type="submit">submit</button>
+          </component>
+        </OmegaIntlProvider>
+      `,
+      setup() {
+        const form = useOmegaForm(
+          S.Struct({
+            password: S.NonEmptyString255
+          }),
+          {
+            defaultValues: {
+              password: ""
+            }
+          }
+        )
+
+        return { form }
+      }
+    }, {
+      global: {
+        components: { VTextField }
+      }
+    })
+
+    await wrapper.vm.$nextTick()
+
+    const input = wrapper.find("input")
+    const nativeForm = wrapper.find("form").element
+
+    expect(input.attributes("form")).toBeUndefined()
+    expect((input.element as HTMLInputElement).form).toBe(nativeForm)
+  })
+})

--- a/packages/vue-components/src/components/OmegaForm/OmegaInput.vue
+++ b/packages/vue-components/src/components/OmegaForm/OmegaInput.vue
@@ -13,7 +13,7 @@
     <template #default="{ field }">
       <OmegaInternalInput
         v-if="meta"
-        v-bind="{ ...$attrs, ...$props, inputClass: computedClass }"
+        v-bind="{ ...$attrs, ...propsWithoutForm, inputClass: computedClass }"
         :field="field as any"
         :state="field.state"
         :register="form.registerField"
@@ -51,6 +51,11 @@ import OmegaInternalInput from "./OmegaInternalInput.vue"
 import { type OmegaInputPropsBase } from "./types"
 
 const props = defineProps<OmegaInputPropsBase<From, To, Name>>()
+const propsWithoutForm = computed(() => {
+  const { form, ...rest } = props
+  void form
+  return rest
+})
 
 // downgrade to *as* DeepKeys<From> to avoid useless and possible infinite recursion in TS
 const propsName = computed(() => props.name as DeepKeys<From>)

--- a/packages/vue-components/src/components/OmegaForm/OmegaInput.vue
+++ b/packages/vue-components/src/components/OmegaForm/OmegaInput.vue
@@ -13,7 +13,7 @@
     <template #default="{ field }">
       <OmegaInternalInput
         v-if="meta"
-        v-bind="{ ...$attrs, ...propsWithoutForm, inputClass: computedClass }"
+        v-bind="{ ...$attrs, ...internalInputProps, inputClass: computedClass }"
         :field="field as any"
         :state="field.state"
         :register="form.registerField"
@@ -51,11 +51,10 @@ import OmegaInternalInput from "./OmegaInternalInput.vue"
 import { type OmegaInputPropsBase } from "./types"
 
 const props = defineProps<OmegaInputPropsBase<From, To, Name>>()
-const propsWithoutForm = computed(() => {
-  const { form, ...rest } = props
-  void form
-  return rest
-})
+const internalInputProps = computed(() => ({
+  label: props.label,
+  validators: props.validators
+}))
 
 // downgrade to *as* DeepKeys<From> to avoid useless and possible infinite recursion in TS
 const propsName = computed(() => props.name as DeepKeys<From>)

--- a/packages/vue-components/stories/OmegaForm.stories.ts
+++ b/packages/vue-components/stories/OmegaForm.stories.ts
@@ -16,6 +16,7 @@ import DecodeTransformFallbackComponent from "./OmegaForm/DecodeTransformFallbac
 import DefaultsComponent from "./OmegaForm/Defaults.vue"
 import DialogBlockingExamplesComponent from "./OmegaForm/DialogBlockingExamples.vue"
 import EmailFormComponent from "./OmegaForm/EmailForm.vue"
+import EnterSubmitReproComponent from "./OmegaForm/EnterSubmitRepro.vue"
 import FormInputComponent from "./OmegaForm/form.Input.vue"
 import FormTaggedUnionComponent from "./OmegaForm/FormTaggedUnion.vue"
 import IntegerValidationGermanComponent from "./OmegaForm/IntegerValidationGerman.vue"
@@ -129,6 +130,13 @@ export const SimpleForm: Story = {
   render: () => ({
     components: { SimpleFormComponent },
     template: "<SimpleFormComponent />"
+  })
+}
+
+export const EnterSubmitRepro: Story = {
+  render: () => ({
+    components: { EnterSubmitReproComponent },
+    template: "<EnterSubmitReproComponent />"
   })
 }
 

--- a/packages/vue-components/stories/OmegaForm/EnterSubmitRepro.vue
+++ b/packages/vue-components/stories/OmegaForm/EnterSubmitRepro.vue
@@ -1,0 +1,78 @@
+<template>
+  <div class="enter-submit-repro">
+    <section>
+      <h2>Native Vuetify form</h2>
+      <form @submit.prevent="nativeSubmitCount++">
+        <v-text-field
+          v-model="nativePassword"
+          label="Native password"
+          type="password"
+        />
+        <v-btn
+          type="submit"
+          :disabled="!nativePassword.trim()"
+        >
+          submit
+        </v-btn>
+      </form>
+      <p>Submit count: {{ nativeSubmitCount }}</p>
+    </section>
+
+    <section>
+      <h2>OmegaForm Vuetify input</h2>
+      <form.Form :subscribe="['values']">
+        <template #default="{ subscribedValues: { values } }">
+          <form.Input
+            label="Omega password"
+            name="password"
+            type="password"
+          />
+          <v-btn
+            type="submit"
+            :disabled="!values.password?.trim()"
+          >
+            submit
+          </v-btn>
+        </template>
+      </form.Form>
+      <p>Submit count: {{ omegaSubmitCount }}</p>
+    </section>
+  </div>
+</template>
+
+<script setup lang="ts">
+import * as S from "effect-app/Schema"
+import { ref } from "vue"
+import { useOmegaForm } from "../../src/components/OmegaForm"
+
+const nativePassword = ref("")
+const nativeSubmitCount = ref(0)
+const omegaSubmitCount = ref(0)
+
+const form = useOmegaForm(
+  S.Struct({
+    password: S.NonEmptyString255
+  }),
+  {
+    defaultValues: {
+      password: ""
+    },
+    onSubmit: async () => {
+      omegaSubmitCount.value++
+    }
+  }
+)
+</script>
+
+<style scoped>
+.enter-submit-repro {
+  display: grid;
+  gap: 24px;
+  max-width: 480px;
+}
+
+section {
+  display: grid;
+  gap: 12px;
+}
+</style>


### PR DESCRIPTION
## Summary

Fixes OmegaForm default inputs leaking parent/internal props into the default input renderer. The original symptom was the internal TanStack/Omega `form` object reaching the native input as `form="[object Object]"`.

That HTML `form` attribute overrides the input's form owner, so browsers do not run implicit Enter-key submission for the surrounding `<form.Form>`. Button clicks still worked because the submit button belonged to the wrapper form.

This PR:
- forwards only the parent props `OmegaInternalInput` actually needs instead of spreading all `OmegaInput` props
- prevents the internal `form` prop, redundant parent `name`, and object-valued props such as `validators` from flowing toward DOM-rendering inputs
- adds a unit regression that asserts default-rendered inputs do not receive native `form` / `validators` attrs, have no `"[object Object]"` attrs, and still belong to their parent form
- keeps the Storybook repro comparing native Vuetify form submission with OmegaForm

## Validation

- `pnpm --filter @effect-app/vue-components lint-fix`
- `pnpm --filter @effect-app/vue-components check`
- `pnpm --filter @effect-app/vue-components test:run`
- `pnpm --filter @effect-app/vue-components build-storybook`
- `pnpm check`
- Browser probe against `Components/OmegaForm / EnterSubmitRepro`: Omega input no longer has `form="[object Object]"`; pressing Enter increments the OmegaForm submit counter

Root `pnpm lint-fix` still fails outside this change in `packages/effect-app`: the package script invokes `oxlint --type-aware`, but the installed CLI path reports `flag provided but not defined: -type-aware`.
