### PR TITLE
Make OmegaInput renderer contract explicit

### DIFF
--- a/.changeset/soft-mails-brush.md
+++ b/.changeset/soft-mails-brush.md
@@ -1,0 +1,5 @@
+---
+"@effect-app/vue-components": patch
+---
+
+Make OmegaInput's built-in input configuration props explicit so renderer attrs remain reserved for UI-library extensions.

--- a/packages/vue-components/__tests__/OmegaForm/InputAttributes.test.ts
+++ b/packages/vue-components/__tests__/OmegaForm/InputAttributes.test.ts
@@ -22,6 +22,35 @@ const VTextField = defineComponent({
   `
 })
 
+const VSelect = defineComponent({
+  props: {
+    items: {
+      type: Array,
+      default: () => []
+    },
+    modelValue: {
+      type: String,
+      default: ""
+    }
+  },
+  emits: ["update:modelValue"],
+  template: `
+    <select
+      v-bind="$attrs"
+      :value="modelValue"
+      @change="$emit('update:modelValue', $event.target.value)"
+    >
+      <option
+        v-for="item in items"
+        :key="item.value"
+        :value="item.value"
+      >
+        {{ item.title }}
+      </option>
+    </select>
+  `
+})
+
 describe("OmegaForm input attributes", () => {
   it("does not forward the internal form object as a native form attribute", async () => {
     const wrapper = mount({
@@ -56,7 +85,7 @@ describe("OmegaForm input attributes", () => {
       }
     }, {
       global: {
-        components: { VTextField }
+        components: { VTextField, VSelect }
       }
     })
 
@@ -69,5 +98,50 @@ describe("OmegaForm input attributes", () => {
     expect(input.attributes("validators")).toBeUndefined()
     expect(Object.values(input.attributes())).not.toContain("[object Object]")
     expect((input.element as HTMLInputElement).form).toBe(nativeForm)
+  })
+
+  it("keeps input configuration props off the renderer attrs", async () => {
+    const wrapper = mount({
+      components: { OmegaIntlProvider },
+      template: `
+        <OmegaIntlProvider>
+          <component :is="form.Form">
+            <component
+              :is="form.Input"
+              label="Choice"
+              name="choice"
+              type="select"
+              :options="[{ title: 'One', value: 'one' }]"
+            />
+          </component>
+        </OmegaIntlProvider>
+      `,
+      setup() {
+        const form = useOmegaForm(
+          S.Struct({
+            choice: S.Literal("one")
+          }),
+          {
+            defaultValues: {
+              choice: "one"
+            }
+          }
+        )
+
+        return { form }
+      }
+    }, {
+      global: {
+        components: { VTextField, VSelect }
+      }
+    })
+
+    await wrapper.vm.$nextTick()
+
+    const select = wrapper.find("select")
+
+    expect(select.attributes("options")).toBeUndefined()
+    expect(select.attributes("items")).toBeUndefined()
+    expect(Object.values(select.attributes())).not.toContain("[object Object]")
   })
 })

--- a/packages/vue-components/__tests__/OmegaForm/createUseFormWithCustomInput.test.ts
+++ b/packages/vue-components/__tests__/OmegaForm/createUseFormWithCustomInput.test.ts
@@ -180,6 +180,51 @@ describe("createUseFormWithCustomInput", () => {
     expect(wrapper.find("[data-testid=\"has-id\"]").text()).toBeTruthy()
   })
 
+  it("forwards an explicit `required` override to inputProps (survives OmegaInput's prop whitelist)", async () => {
+    const RequiredProbe = {
+      template: `<div data-testid="required-probe">{{ inputProps.required }}</div>`,
+      props: ["inputProps", "field"]
+    }
+
+    const useFormWithProbe = createUseFormWithCustomInput(RequiredProbe)
+    // optionalKey field => meta.required is false, so a `true` result proves the
+    // explicit prop overrode meta AND was not dropped on the way to the input.
+    const optionalSchema = S.Struct({ maybe: S.optionalKey(S.Number) })
+
+    const wrapper = mount({
+      components: {
+        OmegaIntlProvider
+      },
+      template: `
+        <OmegaIntlProvider>
+          <component :is="form.Form">
+            <template #default>
+              <component :is="form.Input"
+                label="Maybe"
+                name="maybe"
+                :required="true"
+              />
+            </template>
+          </component>
+        </OmegaIntlProvider>
+      `,
+      setup() {
+        const form = useFormWithProbe(optionalSchema, { defaultValues: {} })
+        return { form }
+      }
+    }, {
+      global: {
+        stubs: {
+          RequiredProbe
+        }
+      }
+    })
+
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find("[data-testid=\"required-probe\"]").text()).toBe("true")
+  })
+
   it("should pass event listeners to custom input component", async () => {
     // Custom component that emits focus and blur events
     const EventEmittingInput = {

--- a/packages/vue-components/src/components/OmegaForm/OmegaInput.vue
+++ b/packages/vue-components/src/components/OmegaForm/OmegaInput.vue
@@ -54,6 +54,7 @@ const props = defineProps<OmegaInputPropsBase<From, To, Name>>()
 const internalInputProps = computed(() => ({
   label: props.label,
   validators: props.validators,
+  required: props.required,
   type: props.type,
   options: props.options
 }))

--- a/packages/vue-components/src/components/OmegaForm/OmegaInput.vue
+++ b/packages/vue-components/src/components/OmegaForm/OmegaInput.vue
@@ -53,7 +53,9 @@ import { type OmegaInputPropsBase } from "./types"
 const props = defineProps<OmegaInputPropsBase<From, To, Name>>()
 const internalInputProps = computed(() => ({
   label: props.label,
-  validators: props.validators
+  validators: props.validators,
+  type: props.type,
+  options: props.options
 }))
 
 // downgrade to *as* DeepKeys<From> to avoid useless and possible infinite recursion in TS

--- a/packages/vue-components/src/components/OmegaForm/OmegaInternalInput.vue
+++ b/packages/vue-components/src/components/OmegaForm/OmegaInternalInput.vue
@@ -56,7 +56,7 @@ const props = withDefaults(
     ) => void
 
     // TODO: these should really be optional, depending on the input type (and the custom input type for custom inputs :s)
-    options?: { title: string; value: string }[]
+    options?: { title: string; value: unknown }[]
   }>(),
   {
     required: undefined,

--- a/packages/vue-components/src/components/OmegaForm/types.ts
+++ b/packages/vue-components/src/components/OmegaForm/types.ts
@@ -65,12 +65,15 @@ export type OmegaInputPropsBase<
   From extends Record<PropertyKey, any>,
   To extends Record<PropertyKey, any>,
   Name extends DeepKeys<From>
-> = {
-  form: OF<From, To> & {
-    meta: MetaRecord<From>
-    i18nNamespace?: string
+> =
+  & {
+    form: OF<From, To> & {
+      meta: MetaRecord<From>
+      i18nNamespace?: string
+    }
   }
-} & BaseProps<From, Name>
+  & BaseProps<From, Name>
+  & DefaultTypeProps
 
 export type OmegaInputProps<
   From extends Record<PropertyKey, any>,

--- a/packages/vue-components/src/components/OmegaForm/types.ts
+++ b/packages/vue-components/src/components/OmegaForm/types.ts
@@ -36,6 +36,11 @@ export type BaseProps<From, TName extends FieldPath<From>> = {
    */
   label?: string
   validators?: FieldValidators<From>
+  /**
+   * Overrides the schema-derived `meta.required`.
+   * When omitted, requiredness is inferred from the schema.
+   */
+  required?: boolean
   // Use FlexibleArrayPath: if name contains [], just use TName; otherwise intersect with Leaves<From>
   name: TName
   /**


### PR DESCRIPTION
## Summary

Follows up #804 by making the OmegaInput boundary explicit:

- `OmegaInput` now declares built-in input configuration props (`type` / `options`) instead of receiving them via `$attrs`
- only normalized input configuration is forwarded to `OmegaInternalInput`
- `$attrs` remains the extension channel for renderer/UI-library props
- `OmegaInternalInput` option values now match the public API (`unknown`, not string-only)
- regression coverage asserts object-valued config props do not become DOM attrs or `"[object Object]"` values

This keeps UI-library renderers free to accept their own attrs while preventing OmegaForm control/config props from leaking into native DOM.

## Validation

- `pnpm --filter @effect-app/vue-components lint-fix`
- `pnpm --filter @effect-app/vue-components check`
- `pnpm --filter @effect-app/vue-components test:run`
- `pnpm --filter @effect-app/vue-components build-storybook`
- `pnpm check`

Root `pnpm lint-fix` still fails outside this change in `packages/effect-app`: the package script invokes `oxlint --type-aware`, but the installed CLI path reports `flag provided but not defined: -type-aware`.
