### PR TITLE
feat(vue-components): native input types + typecheck stories

### DIFF
--- a/.changeset/omega-native-input-types.md
+++ b/.changeset/omega-native-input-types.md
@@ -1,0 +1,5 @@
+---
+"@effect-app/vue-components": patch
+---
+
+OmegaForm: expose native input types `tel`, `url`, `color`, `time`, `search` (already supported by `getInputType`), and render an editable text input with a dev `console.warn` for any input type no renderer branch handles (e.g. an unrecognized `"unknown"` schema type or a custom `type`) instead of rendering nothing.

--- a/.changeset/omegaform-typecheck-stories.md
+++ b/.changeset/omegaform-typecheck-stories.md
@@ -1,0 +1,5 @@
+---
+"@effect-app/vue-components": patch
+---
+
+Typecheck the OmegaForm Storybook stories (previously outside `tsconfig` scope) and migrate them off removed/renamed Schema APIs surfaced by it: `.withDefault` → `.withConstructorDefault`, error-filter `{ path, message }` → `{ path, issue }`, dropped deprecated `overrideDefaultValues`, and an `OmegaAutoGenMeta` type argument. Internal only — no change to the published API.

--- a/packages/vue-components/__tests__/OmegaForm/InputAttributes.test.ts
+++ b/packages/vue-components/__tests__/OmegaForm/InputAttributes.test.ts
@@ -1,6 +1,6 @@
 import { mount } from "@vue/test-utils"
 import * as S from "effect-app/Schema"
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 import { defineComponent } from "vue"
 import { useOmegaForm } from "../../src/components/OmegaForm"
 import OmegaIntlProvider from "../OmegaIntlProvider.vue"
@@ -69,5 +69,79 @@ describe("OmegaForm input attributes", () => {
     expect(input.attributes("validators")).toBeUndefined()
     expect(Object.values(input.attributes())).not.toContain("[object Object]")
     expect((input.element as HTMLInputElement).form).toBe(nativeForm)
+  })
+
+  it("renders a newly-supported native input type (tel) on the text-field branch", async () => {
+    const wrapper = mount({
+      components: { OmegaIntlProvider },
+      template: `
+        <OmegaIntlProvider>
+          <component :is="form.Form">
+            <component
+              :is="form.Input"
+              label="Phone"
+              name="phone"
+              type="tel"
+            />
+          </component>
+        </OmegaIntlProvider>
+      `,
+      setup() {
+        const form = useOmegaForm(
+          S.Struct({ phone: S.String }),
+          { defaultValues: { phone: "" } }
+        )
+
+        return { form }
+      }
+    }, {
+      global: {
+        components: { VTextField }
+      }
+    })
+
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find("input").attributes("type")).toBe("tel")
+  })
+
+  it("falls back to a text input and warns for a type no branch handles", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
+
+    const wrapper = mount({
+      components: { OmegaIntlProvider },
+      template: `
+        <OmegaIntlProvider>
+          <component :is="form.Form">
+            <component
+              :is="form.Input"
+              label="Mystery"
+              name="mystery"
+              type="totally-custom"
+            />
+          </component>
+        </OmegaIntlProvider>
+      `,
+      setup() {
+        const form = useOmegaForm(
+          S.Struct({ mystery: S.String }),
+          { defaultValues: { mystery: "" } }
+        )
+
+        return { form }
+      }
+    }, {
+      global: {
+        components: { VTextField }
+      }
+    })
+
+    await wrapper.vm.$nextTick()
+
+    // unhandled type → getInputType maps it to "text"
+    expect(wrapper.find("input").attributes("type")).toBe("text")
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("totally-custom"))
+
+    warn.mockRestore()
   })
 })

--- a/packages/vue-components/src/components/OmegaForm/OmegaInputVuetify.vue
+++ b/packages/vue-components/src/components/OmegaForm/OmegaInputVuetify.vue
@@ -34,7 +34,12 @@
       v-if="inputProps.type === 'email'
       || inputProps.type === 'string'
       || inputProps.type === 'password'
-      || inputProps.type === 'date'"
+      || inputProps.type === 'date'
+      || inputProps.type === 'tel'
+      || inputProps.type === 'url'
+      || inputProps.type === 'color'
+      || inputProps.type === 'time'
+      || inputProps.type === 'search'"
       :id="inputProps.id"
       :required="inputProps.required"
       :min-length="inputProps.minLength"
@@ -198,6 +203,33 @@
         />
       </template>
     </v-autocomplete>
+
+    <!-- Fallback for any type not handled by a dedicated branch above (e.g. an
+         unrecognized schema type resolved to "unknown", or a custom `type` with
+         no renderer). Renders an editable text input instead of nothing. -->
+    <v-text-field
+      v-if="isUnhandledType"
+      :id="inputProps.id"
+      :required="inputProps.required"
+      :type="getInputType(inputProps.type)"
+      :name="field.name"
+      :label="inputProps.label"
+      :error-messages="inputProps.errorMessages"
+      :error="inputProps.error"
+      v-bind="$attrs"
+      :model-value="state.value"
+      @update:model-value="(v: any) => field.handleChange(v)"
+    >
+      <template
+        v-if="$slots.label"
+        #label
+      >
+        <slot
+          name="label"
+          v-bind="{ required: inputProps.required, id: inputProps.id, label: inputProps.label }"
+        />
+      </template>
+    </v-text-field>
   </div>
 </template>
 
@@ -207,10 +239,12 @@
   generic="From extends Record<PropertyKey, any>, Name extends DeepKeys<From>"
 >
 import { type DeepKeys } from "@tanstack/vue-form"
+import { computed, watchEffect } from "vue"
 import type { VuetifyInputProps } from "./InputProps"
 import { getInputType } from "./inputs"
+import { typeOverrides } from "./types"
 
-defineProps<VuetifyInputProps<From, Name>>()
+const props = defineProps<VuetifyInputProps<From, Name>>()
 
 defineEmits<{
   (e: "focus", event: Event): void
@@ -219,6 +253,19 @@ defineEmits<{
 
 defineOptions({
   inheritAttrs: false
+})
+
+// True when no dedicated branch handles `inputProps.type` (it's outside the
+// built-in `typeOverrides`): the fallback text input renders and we warn.
+const isUnhandledType = computed(() => !(typeOverrides as readonly string[]).includes(props.inputProps.type))
+
+watchEffect(() => {
+  if (isUnhandledType.value) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[OmegaForm] Unhandled input type "${props.inputProps.type}", falling back to a text input.`
+    )
+  }
 })
 </script>
 

--- a/packages/vue-components/src/components/OmegaForm/types.ts
+++ b/packages/vue-components/src/components/OmegaForm/types.ts
@@ -100,21 +100,33 @@ export type OmegaArrayProps<
     items?: "please use `defaultItems` instead"
   }
 
-export type TypeOverride =
-  | "string"
-  | "text"
-  | "number"
-  | "select"
-  | "multiple"
-  | "boolean"
-  | "radio"
-  | "autocomplete"
-  | "autocompletemultiple"
-  | "switch"
-  | "range"
-  | "password"
-  | "email"
-  | "date"
+// Single source of truth for the built-in input types: the runtime array drives
+// both the `TypeOverride` union and the renderer's "is this type handled?" check,
+// so the two cannot drift apart.
+export const typeOverrides = [
+  "string",
+  "text",
+  "number",
+  "select",
+  "multiple",
+  "boolean",
+  "radio",
+  "autocomplete",
+  "autocompletemultiple",
+  "switch",
+  "range",
+  "password",
+  "email",
+  "date",
+  // native HTML input types that `getInputType` already maps 1:1
+  "tel",
+  "url",
+  "color",
+  "time",
+  "search"
+] as const
+
+export type TypeOverride = typeof typeOverrides[number]
 
 export interface OmegaError {
   label: string

--- a/packages/vue-components/stories/Commands/helpers.ts
+++ b/packages/vue-components/stories/Commands/helpers.ts
@@ -1,3 +1,8 @@
+// @ts-nocheck
+// TODO: this Commands demo helper has drifted against the current intl / Effect-Layer
+// APIs (makeIntl's Ref<"en"> vs I18n.toLayer's Ref<string>, and Layer/ManagedRuntime
+// error channels resolving to `unknown` instead of `never`). Quarantined so the
+// OmegaForm stories stay typechecked; fix in a dedicated pass.
 import { Commander, DefaultIntl } from "@effect-app/vue/commander"
 import { Confirm } from "@effect-app/vue/confirm"
 import { I18n } from "@effect-app/vue/intl"

--- a/packages/vue-components/stories/OmegaForm/AutoGeneration.vue
+++ b/packages/vue-components/stories/OmegaForm/AutoGeneration.vue
@@ -50,6 +50,7 @@
 </template>
 
 <script setup lang="ts">
+import { type DeepKeys } from "@tanstack/vue-form"
 import * as S from "effect-app/Schema"
 import { constUndefined } from "effect/Function"
 import * as Match from "effect/Match"
@@ -66,7 +67,8 @@ const schema = S.Struct({
 })
 type Meta = OmegaAutoGenMeta<
   typeof schema.Encoded,
-  typeof schema.Type
+  typeof schema.Type,
+  DeepKeys<typeof schema.Encoded>
 >
 const form = useOmegaForm(schema)
 </script>

--- a/packages/vue-components/stories/OmegaForm/Booleans.vue
+++ b/packages/vue-components/stories/OmegaForm/Booleans.vue
@@ -29,7 +29,7 @@ import { useOmegaForm } from "../../src"
 
 const form = useOmegaForm(
   S.Struct({
-    boolean: S.Boolean.withDefault,
+    boolean: S.Boolean.withConstructorDefault,
     switch: S.Boolean,
     true: S.Literal(true)
   }),

--- a/packages/vue-components/stories/OmegaForm/ComplexForm.vue
+++ b/packages/vue-components/stories/OmegaForm/ComplexForm.vue
@@ -124,8 +124,7 @@ const exampleForm = useOmegaForm(
   },
   {
     persistency: {
-      policies: ["local"],
-      overrideDefaultValues: true
+      policies: ["local"]
     }
   }
 )

--- a/packages/vue-components/stories/OmegaForm/CustomInput.vue
+++ b/packages/vue-components/stories/OmegaForm/CustomInput.vue
@@ -39,6 +39,8 @@ defineEmits<{
 }>()
 
 defineSlots<{
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- default slot forwards $attrs, unconstrained
+  default?: (props: any) => any
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Vue slot return type is unconstrained
   label?: (props: { required: boolean; id: string; label: string }) => any
 }>()

--- a/packages/vue-components/stories/OmegaForm/Date.vue
+++ b/packages/vue-components/stories/OmegaForm/Date.vue
@@ -8,7 +8,7 @@
         <input
           :model-value="state.value"
           type="date"
-          @change="(e: any) => {
+          @change="() => {
             field.handleChange('2024-06-01T00:00:00.000Z')
           }"
         >

--- a/packages/vue-components/stories/OmegaForm/Defaults.vue
+++ b/packages/vue-components/stories/OmegaForm/Defaults.vue
@@ -108,8 +108,8 @@ const struct = {
       p: S.NullOr(S.Struct({ z: S.String })),
       r: S.UndefinedOr(S.Struct({ z: S.String }))
     }))
-    .withDefault,
-  s: S.NullOr(S.Struct({ z: S.String })).withDefault,
+    .withConstructorDefault,
+  s: S.NullOr(S.Struct({ z: S.String })).withConstructorDefault,
   t: S.FiniteFromString.pipe(S.withConstructorDefault(Effect.succeed(1000))),
   u: S.NullOr(S.NonEmptyString),
   v: S.UndefinedOr(S.NonEmptyString)
@@ -170,7 +170,7 @@ const seven = useOmegaForm(S.Union([
   S.Struct({
     _tag: S.Literal("tag1").pipe(S.withConstructorDefault(Effect.succeed("tag1"))),
     a: S.NonEmptyString,
-    s: S.NullOr(S.Finite).withDefault
+    s: S.NullOr(S.Finite).withConstructorDefault
   }),
   S.Struct({
     _tag: S.Literal("tag2"),
@@ -185,7 +185,7 @@ const eight = useOmegaForm(ClassSchema
       if (form.a !== form.b) {
         return {
           path: ["a"],
-          message: "Email and confirmation must match!"
+          issue: "Email and confirmation must match!"
         }
       }
     }))
@@ -195,7 +195,7 @@ const nine = useOmegaForm(ClassSchema.pipe(S.check(S.makeFilter((form) => {
   if (form.a !== form.b) {
     return {
       path: ["a"],
-      message: "Email and confirmation must match!"
+      issue: "Email and confirmation must match!"
     }
   }
 }))))

--- a/packages/vue-components/stories/OmegaForm/Null.vue
+++ b/packages/vue-components/stories/OmegaForm/Null.vue
@@ -63,8 +63,7 @@ const exampleForm = useOmegaForm(
   },
   {
     persistency: {
-      policies: ["local"],
-      overrideDefaultValues: true
+      policies: ["local"]
     }
   }
 )

--- a/packages/vue-components/stories/OmegaForm/Nullable.vue
+++ b/packages/vue-components/stories/OmegaForm/Nullable.vue
@@ -36,7 +36,7 @@
               :label="field.name"
               :model-value="state.value"
               :error="state.meta.errors.length > 0"
-              :error-messages="state.meta.errors.map((e) => e.message).filter(Boolean)"
+              :error-messages="state.meta.errors.map((e) => e?.message).filter((m): m is string => !!m)"
               @update:model-value="field.handleChange"
             />
           </div>
@@ -57,14 +57,14 @@ import { useOmegaForm } from "../../src"
 
 const form = useOmegaForm(
   S.Struct({
-    a: S.NullOr(S.NonEmptyString).withDefault,
-    b: S.NullOr(S.String).withDefault,
+    a: S.NullOr(S.NonEmptyString).withConstructorDefault,
+    b: S.NullOr(S.String).withConstructorDefault,
     c: S
       .NullOr(S.Struct({
         d: S.NonEmptyString.pipe(S.check(S.isMinLength(20), S.isMaxLength(4000))),
         e: S.String
       }))
-      .withDefault
+      .withConstructorDefault
   }),
   {
     onSubmit: async ({ value }) => {

--- a/packages/vue-components/stories/OmegaForm/SimpleFormVuetifyDefault.vue
+++ b/packages/vue-components/stories/OmegaForm/SimpleFormVuetifyDefault.vue
@@ -22,8 +22,8 @@ import * as S from "effect-app/Schema"
 import { useOmegaForm } from "../../src"
 
 const schema = S.Struct({
-  aString: S.NullOr(S.NonEmptyString255).withDefault,
-  bString: S.NullOr(S.NonEmptyString255).withDefault
+  aString: S.NullOr(S.NonEmptyString255).withConstructorDefault,
+  bString: S.NullOr(S.NonEmptyString255).withConstructorDefault
 })
 const defaultValues = {
   aString: ""

--- a/packages/vue-components/stories/OmegaForm/WindowExitPrevention.vue
+++ b/packages/vue-components/stories/OmegaForm/WindowExitPrevention.vue
@@ -142,8 +142,7 @@
       message: "You have unsaved changes!"
     },
     persistency: {
-      policies: ["local"],
-      overrideDefaultValues: true
+      policies: ["local"]
     }
   }
 )</code></pre>
@@ -253,8 +252,7 @@ const persistentForm = useOmegaForm(
   {
     preventWindowExit: "prevent",
     persistency: {
-      policies: ["local"],
-      overrideDefaultValues: true
+      policies: ["local"]
     }
   }
 )

--- a/packages/vue-components/stories/OmegaForm/WithDefaultConstructor.vue
+++ b/packages/vue-components/stories/OmegaForm/WithDefaultConstructor.vue
@@ -21,10 +21,10 @@ const sum = ref(0)
 const AddSchema = S.Struct({
   first: S.PositiveNumber.pipe(S.withConstructorDefault(Effect.succeed(S.PositiveNumber(100)))),
   second: S.PositiveNumber.pipe(S.withConstructorDefault(Effect.succeed(S.PositiveNumber(100)))),
-  third: S.NullOr(S.String).withDefault,
+  third: S.NullOr(S.String).withConstructorDefault,
   fourth: S
     .Struct({
-      addForm: S.NullOr(S.String).withDefault,
+      addForm: S.NullOr(S.String).withConstructorDefault,
       b: S.PositiveNumber.pipe(S.withConstructorDefault(Effect.succeed(S.PositiveNumber(100)))),
       c: S.Struct({
         d: S.Finite.pipe(S.withConstructorDefault(Effect.succeed(10)))
@@ -40,8 +40,7 @@ const addForm = useOmegaForm(
   {
     persistency: {
       policies: ["querystring"],
-      keys: ["first"],
-      overrideDefaultValues: true
+      keys: ["first"]
     }
   }
 )

--- a/packages/vue-components/tsconfig.json
+++ b/packages/vue-components/tsconfig.json
@@ -21,6 +21,6 @@
       "vite/client"
     ]
   },
-  "include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.tsx", "src/**/*.vue", "src/index.js", "types/**/*.d.ts"],
-  "exclude": ["src/stories/**", "**/__tests__/**", "**/*.test.*"]
+  "include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.tsx", "src/**/*.vue", "src/index.js", "types/**/*.d.ts", "stories/**/*.ts", "stories/**/*.vue"],
+  "exclude": ["**/__tests__/**", "**/*.test.*"]
 }


### PR DESCRIPTION
## Summary

Two related changes to OmegaForm (one commit each):

### 1. Native input types + unhandled-type fallback (`92d947dc2`)
- `TypeOverride` is now derived from a single runtime `typeOverrides` array (no drift between the type union and the renderer's "is this handled?" check).
- Exposes the native input types `getInputType` already supports: **`tel`, `url`, `color`, `time`, `search`** — they render on the `v-text-field` branch with the correct native `type`.
- Adds a **catch-all fallback**: any type no branch handles (an unrecognized `"unknown"` schema type, or a custom `type`) now renders an editable text input and `console.warn`s, instead of rendering nothing.
- Tests: `tel` renders `type="tel"`; an unhandled type falls back to `text` + warns.

### 2. Typecheck the stories (`fd81d9b40`)
Stories lived outside vue-tsc's scope (`include` was `src/**` only; the `exclude` still pointed at the obsolete `src/stories/**`), so type errors went unnoticed. Adds `stories/**` to the typecheck and fixes the accumulated drift it surfaced:
- `.withDefault` → `.withConstructorDefault` (Schema API rename)
- error-filter shape `{ path, message }` → `{ path, issue }`
- dropped deprecated `overrideDefaultValues: true`
- `OmegaAutoGenMeta` 3rd type argument; a slot/undefined/unused-param fixup

`stories/Commands/helpers.ts` has deeper, cascading Effect/intl-Layer drift unrelated to OmegaForm; quarantined with `// @ts-nocheck` + TODO so the rest of the stories stay typechecked.

## Validation
- `pnpm --filter @effect-app/vue-components check` (0 errors, stories now included)
- `pnpm --filter @effect-app/vue-components build-storybook` (Node >=22.12)