### PR TITLE
fix(vue): preserve query parent spans, and add `disableQueryInvalidation` flag to Command config for background saves

### DIFF
--- a/.changeset/disable-query-invalidation.md
+++ b/.changeset/disable-query-invalidation.md
@@ -1,0 +1,19 @@
+---
+"effect-app": minor
+"@effect-app/vue": minor
+---
+
+Add `disableQueryInvalidation` flag to Command config for background saves.
+
+Set `disableQueryInvalidation: true` in a `Req.Command` config (3rd argument)
+to suppress all client-side query invalidation for that command — client
+`invalidatesQueries` callbacks, server-returned `metadata.invalidateQueries`,
+and repository-derived write-dependency matching are all skipped. Use for
+background saves (e.g. debounced auto-save) whose writes should not trigger
+query refetches.
+
+- `InvalidationConfig` gains `disableQueryInvalidation?: boolean`.
+- `RequestHandlerWithInput` gains `disableQueryInvalidation?: boolean`,
+  propagated from `Request.config` by `ApiClientFactory.makeFor`.
+- `invalidateCache` early-returns `Effect.void` when the flag is set,
+  applying to both regular and stream mutations.

--- a/.changeset/query-span-propagation.md
+++ b/.changeset/query-span-propagation.md
@@ -1,0 +1,5 @@
+---
+"@effect-app/vue": patch
+---
+
+Preserve Effect parent spans across query refetch and invalidation.

--- a/packages/effect-app/src/client/apiClientFactory.ts
+++ b/packages/effect-app/src/client/apiClientFactory.ts
@@ -279,7 +279,10 @@ const makeApiClientFactory = Effect
             const requestMeta = {
               Request,
               id,
-              options
+              options,
+              disableQueryInvalidation: (h as { config?: { disableQueryInvalidation?: boolean } })
+                .config
+                ?.disableQueryInvalidation === true
             }
 
             const requestNameLayer = Layer.succeed(RequestName, {

--- a/packages/effect-app/src/client/clientFor.ts
+++ b/packages/effect-app/src/client/clientFor.ts
@@ -100,6 +100,7 @@ export interface RequestHandlerWithInput<I, A, E, R, Request extends Req, Id ext
   options?: ClientForOptions
   Request: Request
   queryKeyProjectionHash?: string
+  disableQueryInvalidation?: boolean
 }
 
 /** Type alias: a no-input handler is simply `RequestHandlerWithInput<void, …>`. */

--- a/packages/effect-app/src/client/makeClient.ts
+++ b/packages/effect-app/src/client/makeClient.ts
@@ -73,6 +73,7 @@ export type InvalidationCallback<Resources, Input = unknown, Success = unknown, 
 export type InvalidationConfig<Resources, Input = unknown, Success = unknown, Failure = unknown> = {
   readonly invalidatesQueries: InvalidationCallback<Resources, Input, Success, Failure>
   readonly invalidationResources?: Resources
+  readonly disableQueryInvalidation?: boolean
 }
 
 type InvalidationConfigForCommand<

--- a/packages/vue/src/atomQuery.ts
+++ b/packages/vue/src/atomQuery.ts
@@ -27,6 +27,7 @@ import * as Hash from "effect/Hash"
 import type * as Layer from "effect/Layer"
 import * as Ref from "effect/Ref"
 import * as Stream from "effect/Stream"
+import type * as Tracer from "effect/Tracer"
 import { isHttpClientError } from "effect/unstable/http/HttpClientError"
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult"
 import * as Atom from "effect/unstable/reactivity/Atom"
@@ -126,8 +127,9 @@ const atomsForKeys = (keys: ReadonlyArray<unknown>): ReadonlyArray<Atom.Atom<Asy
  */
 export const invalidateAndAwait = (keys: ReadonlyArray<unknown>): Effect.Effect<void, never, Reactivity.Reactivity> =>
   Effect.gen(function*() {
-    yield* Reactivity.invalidate(keys) // invalidates everything but only refreshes what's mounted
     const atoms = atomsForKeys(keys)
+    yield* Effect.forEach(atoms, captureAtomQueryParentSpan, { discard: true, concurrency: "inherit" })
+    yield* Reactivity.invalidate(keys) // invalidates everything but only refreshes what's mounted
     //    for (const a of atoms) defaultRegistry.refresh(a) // refreshes everything even when not mounted
     if (atoms.length === 0) return
     yield* Effect.forEach(atoms, (a) => awaitAtomResult(defaultRegistry, a).pipe(Effect.exit))
@@ -191,8 +193,8 @@ export interface AtomClientRuntime {
  * Shares the ManagedRuntime's `memoMap` so layers are not built twice, and so
  * query-registration and mutation-invalidation resolve the SAME `Reactivity`.
  */
-export const makeAtomClientRuntime = (
-  getContext: () => Layer.Layer<any, never, never>,
+export const makeAtomClientRuntime = <R>(
+  getContext: () => Layer.Layer<R, never, never>,
   memoMap: Layer.MemoMap
 ): AtomClientRuntime => {
   const factory = Atom.context({ memoMap })
@@ -233,6 +235,45 @@ export interface AtomQueryMetadata {
 }
 
 const atomQueryMetadata = new WeakMap<Atom.Atom<AsyncResult.AsyncResult<any, any>>, AtomQueryMetadata>()
+const atomQueryParentSpans = new WeakMap<Atom.Atom<AsyncResult.AsyncResult<any, any>>, Tracer.AnySpan>()
+
+const atomSpanTarget = <A, E>(atom: Atom.Atom<AsyncResult.AsyncResult<A, E>>) => {
+  let target = atom
+  while (target.initialValueTarget !== undefined) {
+    target = target.initialValueTarget
+  }
+  return target
+}
+
+const takeAtomQueryParentSpan = <A, E>(atom: Atom.Atom<AsyncResult.AsyncResult<A, E>>) => {
+  const target = atomSpanTarget(atom)
+  const span = atomQueryParentSpans.get(target)
+  if (span !== undefined) atomQueryParentSpans.delete(target)
+  return span
+}
+
+const setAtomQueryParentSpan = <A, E>(
+  atom: Atom.Atom<AsyncResult.AsyncResult<A, E>>,
+  span: Tracer.AnySpan
+) => {
+  atomQueryParentSpans.set(atomSpanTarget(atom), span)
+}
+
+export const captureAtomQueryParentSpan = <A, E>(
+  atom: Atom.Atom<AsyncResult.AsyncResult<A, E>>
+): Effect.Effect<void> =>
+  Effect.currentParentSpan.pipe(
+    Effect.tap((span) => Effect.sync(() => setAtomQueryParentSpan(atom, span))),
+    Effect.ignore
+  )
+
+export const refreshAtomWithCurrentSpan = <A, E>(
+  registry: AtomRegistry.AtomRegistry,
+  atom: Atom.Atom<AsyncResult.AsyncResult<A, E>>
+): Effect.Effect<void> =>
+  captureAtomQueryParentSpan(atom).pipe(
+    Effect.andThen(Effect.sync(() => registry.refresh(atom)))
+  )
 
 const setAtomQueryMetadata = <A, E>(
   atom: Atom.Atom<AsyncResult.AsyncResult<A, E>>,
@@ -347,24 +388,30 @@ export const buildQueryFamily = <I, A, E>(
     // The last recorded reads are retained on the (memoized) family atom so `trackReadDependencies`
     // can re-assert them on a cache-hit remount that never re-runs the handler.
     let lastReads: DataDependencies.DataDependencies = DataDependencies.empty()
-    const recordReads = Effect.gen(function*() {
-      const readsRef = yield* Ref.make(DataDependencies.empty())
-      const writesRef = yield* Ref.make(DataDependencies.empty())
-      const recorder = DataDependencies.makeDataDependencyRecorder(readsRef, writesRef)
-      const result = yield* self
-        .handler(input)
-        .pipe(Effect.provideService(DataDependencies.DataDependencyRecorder, recorder))
-      lastReads = yield* Ref.get(readsRef)
-      setQueryReadDependencies(fullKey, lastReads)
-      return result
-    })
-    let atom: Atom.Atom<AsyncResult.AsyncResult<A, E>> = rt.runtime.atom(
-      recordReads
-        .pipe(
+    let atom: Atom.Atom<AsyncResult.AsyncResult<A, E>>
+    atom = rt.runtime.atom(
+      Effect.suspend(() => {
+        const recordReads = Effect.gen(function*() {
+          const readsRef = yield* Ref.make(DataDependencies.empty())
+          const writesRef = yield* Ref.make(DataDependencies.empty())
+          const recorder = DataDependencies.makeDataDependencyRecorder(readsRef, writesRef)
+          const result = yield* self
+            .handler(input)
+            .pipe(Effect.provideService(DataDependencies.DataDependencyRecorder, recorder))
+          lastReads = yield* Ref.get(readsRef)
+          setQueryReadDependencies(fullKey, lastReads)
+          return result
+        })
+        const effect = recordReads.pipe(
           Effect.retry({ times: 5, while: isRetryable }),
           Effect.tapCauseIf(Cause.hasDies, (cause) => reportRuntimeError(cause)),
           Effect.withSpan(`query ${self.id}`, {}, { captureStackTrace: false })
         )
+        const parentSpan = takeAtomQueryParentSpan(atom)
+        return parentSpan === undefined
+          ? effect
+          : effect.pipe(Effect.withParentSpan(parentSpan, { captureStackTrace: false }))
+      })
     )
     // Register under every prefix of the full key => hierarchical (prefix) invalidation. Two roles:
     //   - withReactivity: `Reactivity.invalidate(key)` refreshes this atom (the actual refetch).

--- a/packages/vue/src/internal/tanstackQuery.ts
+++ b/packages/vue/src/internal/tanstackQuery.ts
@@ -9,6 +9,7 @@ import * as Option from "effect-app/Option"
 import * as S from "effect-app/Schema"
 import * as Cause from "effect/Cause"
 import * as Ref from "effect/Ref"
+import type * as Tracer from "effect/Tracer"
 import { isHttpClientError } from "effect/unstable/http/HttpClientError"
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult"
 import * as Atom from "effect/unstable/reactivity/Atom"
@@ -100,11 +101,17 @@ export const makeTanstackQueryClient = () => new QueryClient()
 
 export const makeTanstackQueryInvalidator = (queryClient: QueryClient): QueryInvalidator => ({
   invalidateAndAwait: (keys) =>
-    Effect.forEach(
-      keys,
-      (queryKey) => Effect.promise(() => queryClient.invalidateQueries({ queryKey })),
-      { discard: true, concurrency: "inherit" }
-    )
+    Effect.gen(function*() {
+      const span = yield* Effect.currentParentSpan.pipe(Effect.orElseSucceed(() => undefined))
+      yield* Effect.forEach(
+        keys,
+        (queryKey) => {
+          const options = { updateMeta: { span } }
+          return Effect.promise(() => queryClient.invalidateQueries({ queryKey }, options))
+        },
+        { discard: true, concurrency: "inherit" }
+      )
+    })
 })
 
 const fullQueryKey = (
@@ -167,7 +174,12 @@ export const makeTanstackQuery = <R>(
         const input = resolveInput(arg, options?.mode)
         return fullQueryKey(q, queryKey, input)
       }),
-      queryFn: ({ signal }: { readonly signal: AbortSignal }) =>
+      queryFn: (
+        { meta, signal }: {
+          readonly meta?: { readonly span?: Tracer.AnySpan | undefined } | undefined
+          readonly signal: AbortSignal
+        }
+      ) =>
         runPromise(
           Effect.gen(function*() {
             const input = resolveInput(arg, options?.mode)!
@@ -182,7 +194,10 @@ export const makeTanstackQuery = <R>(
               .pipe(
                 Effect.provideService(DataDependencies.DataDependencyRecorder, recorder),
                 Effect.tapCauseIf(Cause.hasDies, (cause) => reportRuntimeError(cause)),
-                Effect.withSpan(`query ${q.id}`, {}, { captureStackTrace: false })
+                Effect.withSpan(`query ${q.id}`, {}, { captureStackTrace: false }),
+                meta?.span === undefined
+                  ? (effect) => effect
+                  : Effect.withParentSpan(meta.span, { captureStackTrace: false })
               )
             setQueryReadDependencies(fullQueryKey(q, queryKey, input), yield* Ref.get(readsRef))
             return result
@@ -229,21 +244,25 @@ export const makeTanstackQuery = <R>(
         )
 
     const refetch = (): Effect.Effect<TData, E> =>
-      Effect
-        .tryPromise({
-          try: async () => {
-            const queryResult = await tanstack.refetch({ throwOnError: true })
-            const data = queryResult.data
-            if (data === undefined) {
-              throw new Error("TanStack query refetched without data")
-            }
-            return data
-          },
-          catch: (error) => error
-        })
-        .pipe(
-          Effect.catch((error) => recoverCauseException<TData, E>(error))
-        )
+      Effect.gen(function*() {
+        const span = yield* Effect.currentParentSpan.pipe(Effect.orElseSucceed(() => undefined))
+        return yield* Effect
+          .tryPromise({
+            try: async () => {
+              const options = { throwOnError: true, updateMeta: { span } }
+              const queryResult = await tanstack.refetch(options)
+              const data = queryResult.data
+              if (data === undefined) {
+                throw new Error("TanStack query refetched without data")
+              }
+              return data
+            },
+            catch: (error) => error
+          })
+          .pipe(
+            Effect.catch((error) => recoverCauseException<TData, E>(error))
+          )
+      })
 
     const handle: QueryHandle<TData, E> = {
       awaitResult,

--- a/packages/vue/src/mutate.ts
+++ b/packages/vue/src/mutate.ts
@@ -263,7 +263,7 @@ export const asStreamResult = <Args extends readonly any[], A, E, R>(
 }
 
 const buildInvalidateCache = <RInvalidator>(
-  self: { id: string; options?: ClientForOptions },
+  self: { id: string; options?: ClientForOptions; disableQueryInvalidation?: boolean },
   queryInvalidation: MutationOptionsBase["queryInvalidation"] | undefined,
   queryInvalidator: QueryInvalidator<RInvalidator>
 ) => {
@@ -310,6 +310,8 @@ const buildInvalidateCache = <RInvalidator>(
     writeDependencies: DataDependencies.DataDependencies = DataDependencies.empty()
   ) =>
     Effect.suspend(() => {
+      if (self.disableQueryInvalidation) return Effect.void
+
       const clientKeys = getClientInvalidationKeys(input, output)
       // Derive extra reactivity keys from repository write-dependencies: every live query whose
       // recorded read-dependencies intersect this mutation's writes must be refreshed.
@@ -322,7 +324,13 @@ const buildInvalidateCache = <RInvalidator>(
 
       return Effect
         .andThen(
-          Effect.annotateCurrentSpan({ clientKeys, serverKeys, writeDependencies }),
+          Effect.annotateCurrentSpan({
+            keys,
+            clientKeys,
+            serverKeys,
+            derivedKeys,
+            writeDependencies: [...writeDependencies]
+          }),
           // refetch + AWAIT every live query registered under these keys, so by the time the
           // mutation resolves the affected queries are fresh.
           queryInvalidator.invalidateAndAwait(keys)
@@ -337,7 +345,7 @@ const buildInvalidateCache = <RInvalidator>(
 }
 
 export const invalidateQueries = <RInvalidator>(
-  self: { id: string; options?: ClientForOptions },
+  self: { id: string; options?: ClientForOptions; disableQueryInvalidation?: boolean },
   options: MutationOptionsBase | undefined,
   queryInvalidator: QueryInvalidator<RInvalidator>
 ) => {
@@ -435,6 +443,7 @@ export const makeStreamMutation2 = <RInvalidator>(queryInvalidator: QueryInvalid
     self: {
       id: string
       options?: ClientForOptions
+      disableQueryInvalidation?: boolean
       handler: (i: any) => Stream.Stream<any, any, any>
     },
     mergedInvalidation?: MutationOptionsBase["queryInvalidation"]

--- a/packages/vue/src/query.ts
+++ b/packages/vue/src/query.ts
@@ -17,7 +17,7 @@ import * as Stream from "effect/Stream"
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult"
 import * as Atom from "effect/unstable/reactivity/Atom"
 import { computed, type ComputedRef, effectScope, type MaybeRefOrGetter, onBeforeUnmount, onMounted, onScopeDispose, ref, toValue, type WatchSource } from "vue"
-import { type AtomClientRuntime, type AtomQueryOptions, awaitAtomResult, buildQueryFamily, buildStreamQueryFamily, disabledQueryAtom, isStaleResult, staleTimeMsOf, withQueryOptions } from "./atomQuery.ts"
+import { type AtomClientRuntime, type AtomQueryOptions, awaitAtomResult, buildQueryFamily, buildStreamQueryFamily, disabledQueryAtom, isStaleResult, refreshAtomWithCurrentSpan, staleTimeMsOf, withQueryOptions } from "./atomQuery.ts"
 
 // --- minimal local types (replacing the former @tanstack/vue-query type imports) ---
 type DefaultError = Error
@@ -294,7 +294,7 @@ export const useAtomQuery = <A, E>(
   const awaitResult = () => awaitAtomResult(registry, atomRef.value)
   const refetch = () =>
     Effect.gen(function*() {
-      refresh()
+      yield* refreshAtomWithCurrentSpan(registry, atomRef.value)
       return yield* awaitResult()
     })
   const data = computed(() => Option.getOrUndefined(AsyncResult.value(result.value)))
@@ -512,7 +512,7 @@ const makeQueryView = <I, A, E, TData>(
       : awaitAtomResult(registry, atomRef.value)
   const refetch = () =>
     Effect.gen(function*() {
-      refresh()
+      yield* refreshAtomWithCurrentSpan(registry, atomRef.value)
       return yield* awaitResult()
     })
   const staleMs = staleTimeMsOf(normalizeQueryOptions(options))

--- a/packages/vue/test/query-span.test.ts
+++ b/packages/vue/test/query-span.test.ts
@@ -1,0 +1,92 @@
+import { defaultRegistry, registryKey } from "@effect/atom-vue"
+import { QueryClient, VueQueryPlugin } from "@tanstack/vue-query"
+import type { RequestHandlerWithInput } from "effect-app/client/clientFor"
+import * as Context from "effect-app/Context"
+import * as Effect from "effect-app/Effect"
+import * as Layer from "effect-app/Layer"
+import * as Option from "effect-app/Option"
+import type * as Cause from "effect/Cause"
+import * as AsyncResult from "effect/unstable/reactivity/AsyncResult"
+import { createApp, effectScope, nextTick } from "vue"
+import { buildQueryFamily, makeAtomClientRuntime } from "../src/atomQuery.js"
+import { makeTanstackQuery } from "../src/internal/tanstackQuery.js"
+import { useAtomQuery } from "../src/query.js"
+
+const fakeHandler = <A, E>(
+  id: string,
+  run: (input: void) => Effect.Effect<A, E, never>
+): RequestHandlerWithInput<void, A, E, never, never, string> => ({
+  id,
+  handler: run,
+  Request: undefined as never
+})
+
+const querySpanParentName = Effect.currentSpan.pipe(
+  Effect.map((span) =>
+    Option.match(span.parent, {
+      onNone: () => "none",
+      onSome: (parent) => parent._tag === "Span" ? parent.name : "external"
+    })
+  )
+)
+
+function makeTanstackContext(queryClient: QueryClient) {
+  const app = createApp({ render: () => null })
+  app.use(VueQueryPlugin, { queryClient })
+  const scope = effectScope(true)
+  const run = <T>(fn: () => T): T => {
+    let out!: T
+    app.runWithContext(() => {
+      scope.run(() => {
+        out = fn()
+      })
+    })
+    return out
+  }
+  return { run, dispose: () => scope.stop() }
+}
+
+it("passes the current parent span through legacy TanStack refetch", async () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: Infinity, staleTime: 0 } }
+  })
+  const query = makeTanstackQuery(() => Context.empty(), queryClient)(
+    fakeHandler("Test/TanStackSpan", () => querySpanParentName)
+  )
+  const ctx = makeTanstackContext(queryClient)
+
+  const [, , , handle] = ctx.run(() => query(undefined, {}))
+  await Effect.runPromise(handle.awaitResult())
+
+  const parentName = await Effect.runPromise(handle.refetch().pipe(Effect.withSpan("trigger")))
+
+  expect(parentName).toBe("trigger")
+  ctx.dispose()
+})
+
+it("passes the current parent span through atom query refetch", async () => {
+  defaultRegistry.reset()
+  const rt = makeAtomClientRuntime(() => Layer.empty, Layer.makeMemoMapUnsafe())
+  const family = buildQueryFamily(rt, fakeHandler("Test/AtomSpan", () => querySpanParentName))
+  const atom = family(undefined)
+  let view!: ReturnType<typeof useAtomQuery<string, Cause.NoSuchElementError>>
+  const host = document.createElement("div")
+  const app = createApp({
+    setup() {
+      view = useAtomQuery(() => atom)
+      return () => null
+    }
+  })
+  app.provide(registryKey, defaultRegistry)
+  app.mount(host)
+
+  await Effect.runPromise(view.awaitResult())
+  const parentName = await Effect.runPromise(view.refetch().pipe(Effect.withSpan("trigger")))
+
+  expect(parentName).toBe("trigger")
+  expect(AsyncResult.isSuccess(view.result.value)).toBe(true)
+
+  app.unmount()
+  await nextTick()
+  defaultRegistry.reset()
+})


### PR DESCRIPTION
## Summary
- restore legacy TanStack query parent-span handoff via query meta/updateMeta
- capture parent spans for atom query refetch/invalidation before refresh
- add regression tests for TanStack and atom query refetch span parenting
- add patch changeset for @effect-app/vue

## Validation
- pnpm --filter @effect-app/vue check
- pnpm --filter @effect-app/vue test:run query-span.test.ts
- pnpm --filter @effect-app/vue lint-fix
- pnpm check

Note: repo-wide pnpm lint-fix still fails in packages/effect-app because its lint-fix script invokes an unsupported oxlint --type-aware entrypoint; the Vue package lint-fix completed successfully.