### PR TITLE
Derive query invalidation from repository dependencies (atom engine)

### DIFF
--- a/.changeset/repo-derived-query-invalidation.md
+++ b/.changeset/repo-derived-query-invalidation.md
@@ -1,0 +1,7 @@
+---
+"effect-app": minor
+"@effect-app/infra": minor
+"@effect-app/vue": minor
+---
+
+Derive query invalidation from repository read/write dependencies and propagate dependency metadata through RPC clients.

--- a/.changeset/stream-drain-data-dependencies.md
+++ b/.changeset/stream-drain-data-dependencies.md
@@ -1,0 +1,11 @@
+---
+"effect-app": patch
+"@effect-app/infra": patch
+---
+
+Stream RPC: drain read/write data-dependencies per emitted value chunk instead of sending the
+cumulative set on every metadata chunk. Each metadata chunk now carries only the delta recorded
+since the last chunk, the bucket is cleared for the next segment, and the terminal "done"/"error"
+chunks drain the remainder. The emit condition also broadens to include non-empty reads, so stream
+queries forward their read-dependencies mid-stream too. The client already accumulates deltas into
+its per-call recorder, so no FE change is required.

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@effect-app/e2e",
+  "version": "4.0.0-beta.282",
+  "license": "MIT",
+  "type": "module",
+  "private": true,
+  "dependencies": {
+    "@effect-app/infra": "workspace:*",
+    "@effect-app/vue": "workspace:*",
+    "effect-app": "workspace:*"
+  },
+  "devDependencies": {
+    "@effect/atom-vue": "^4.0.0-beta.88",
+    "@effect/platform-node": "4.0.0-beta.88",
+    "@effect/vitest": "4.0.0-beta.88",
+    "@tanstack/vue-query": "5.96.2",
+    "@types/node": "25.9.1",
+    "@vitejs/plugin-vue": "^6.0.7",
+    "effect": "^4.0.0-beta.88",
+    "typescript": "~6.0.3",
+    "vitest": "^4.1.7",
+    "vue": "^3.5.35"
+  },
+  "scripts": {
+    "check": "tsgo --noEmit",
+    "test": "vitest",
+    "test:run": "vitest run --passWithNoTests",
+    "lint": "oxlint --quiet --type-aware ./test && pnpm exec dprint check --config ../../dprint.jsonc .",
+    "lint-fix": "oxlint --quiet --type-aware --fix ./test && pnpm exec dprint fmt --config ../../dprint.jsonc .",
+    "testsuite": "pnpm lint && pnpm run test:run",
+    "clean": "rm -rf dist"
+  },
+  "sideEffects": false
+}

--- a/packages/e2e/test/repoInvalidation.e2e.test.ts
+++ b/packages/e2e/test/repoInvalidation.e2e.test.ts
@@ -1,0 +1,140 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/**
+ * Full-stack invalidation e2e: REAL `makeRepo` repositories (backed by the infra memory store) wired
+ * into the REAL @effect-app/vue query engines. Confirms that a command writing through `repo.save`
+ * invalidates and refetches a query that read through `repo.all` — for both the atom engine and the
+ * legacy tanstack engine. No manual `DataDependencies.read/write`: the deps are produced by the real
+ * repository operations and flow through the engine's recorder.
+ *
+ * A second, unrelated repository provides the negative control: writing it must NOT refetch the
+ * query (confirming derivation is precise and there is no implicit namespace invalidation).
+ */
+import { MemoryStoreLive } from "@effect-app/infra/Store/Memory"
+import { awaitAtomResult, buildQueryFamily, invalidateAndAwait, makeAtomClientRuntime } from "@effect-app/vue/atomQuery"
+import { invalidateQueries } from "@effect-app/vue/mutate"
+import { defaultRegistry } from "@effect/atom-vue"
+import { expect, it } from "@effect/vitest"
+import { QueryClient, VueQueryPlugin } from "@tanstack/vue-query"
+import * as Context from "effect-app/Context"
+import * as Effect from "effect-app/Effect"
+import * as Layer from "effect-app/Layer"
+import { makeRepo, RepositoryRegistryLive } from "effect-app/Model"
+import * as S from "effect-app/Schema"
+import { setupRequestContextFromCurrent } from "effect-app/setupRequest"
+import * as ManagedRuntime from "effect/ManagedRuntime"
+import * as Reactivity from "effect/unstable/reactivity/Reactivity"
+import { createApp, effectScope, ref } from "vue"
+// The legacy tanstack engine lives behind vue's blocked `./internal/*` export; reach it via source.
+import { makeTanstackQuery, makeTanstackQueryInvalidator } from "../../vue/src/internal/tanstackQuery.ts"
+
+class RepoItem extends S.Class<RepoItem>("RepoItem")({ id: S.String, label: S.String }) {}
+class OtherItem extends S.Class<OtherItem>("OtherItem")({ id: S.String, label: S.String }) {}
+
+class RepoItems extends Context.Service<RepoItems>()("RepoItems", { make: makeRepo("RepoItem", RepoItem, {}) }) {
+  static Default = Layer.effect(this, this.make).pipe(
+    Layer.provide(Layer.merge(MemoryStoreLive, RepositoryRegistryLive))
+  )
+}
+class OtherItems extends Context.Service<OtherItems>()("OtherItems", { make: makeRepo("OtherItem", OtherItem, {}) }) {
+  static Default = Layer.effect(this, this.make).pipe(
+    Layer.provide(Layer.merge(MemoryStoreLive, RepositoryRegistryLive))
+  )
+}
+
+// A fresh real-repository runtime per test (isolated store). The query/command effects are expressed
+// purely as real repo operations; `runs` counts query-handler executions to detect (spurious) refetches.
+const setupRepos = () => {
+  const mrt = ManagedRuntime.make(Layer.mergeAll(RepoItems.Default, OtherItems.Default, Reactivity.layer))
+  const repo = mrt.runSync(RepoItems)
+  const other = mrt.runSync(OtherItems)
+  const baseContext = mrt.runSync(Effect.context<any>())
+  let runs = 0
+  const count = Effect
+    .sync(() => runs++)
+    .pipe(
+      Effect.andThen(repo.all),
+      Effect.map((items) => items.length),
+      Effect.orDie,
+      setupRequestContextFromCurrent()
+    )
+  const save = (id: string) =>
+    repo.save(new RepoItem({ id, label: id })).pipe(Effect.orDie, setupRequestContextFromCurrent())
+  const saveOther = (id: string) =>
+    other.save(new OtherItem({ id, label: id })).pipe(Effect.orDie, setupRequestContextFromCurrent())
+  return { baseContext, memoMap: mrt.memoMap, count, save, saveOther, runs: () => runs }
+}
+
+it("atom engine: repo.save invalidates+refetches the query; an unrelated repo write does not", async () => {
+  const { baseContext, count, memoMap, runs, save, saveOther } = setupRepos()
+  const reactivity = Context.get(baseContext, Reactivity.Reactivity)
+  const rt = makeAtomClientRuntime(
+    () => Layer.succeedContext(baseContext),
+    memoMap
+  )
+  const invalidator = {
+    invalidateAndAwait: (keys: ReadonlyArray<ReadonlyArray<unknown>>) =>
+      invalidateAndAwait(keys).pipe(Effect.provideService(Reactivity.Reactivity, reactivity))
+  }
+  const atom = buildQueryFamily(rt as any, { id: "AtomRepo.List", handler: () => count } as any)(undefined)
+  const unmount = defaultRegistry.mount(atom)
+  const saveCmd = (id: string, eff: Effect.Effect<unknown, never, any>) =>
+    Effect.runPromise(
+      invalidateQueries({ id }, undefined, invalidator)(eff, { id }).pipe(Effect.provide(baseContext)) as any
+    )
+
+  try {
+    expect(await Effect.runPromise(awaitAtomResult(defaultRegistry, atom) as any)).toBe(0)
+
+    // Real write to the repo the query read => refetch; the query now sees the new item.
+    await saveCmd("AtomRepo.Save", save("1"))
+    expect(await Effect.runPromise(awaitAtomResult(defaultRegistry, atom) as any)).toBe(1)
+
+    // Negative control: writing an UNRELATED repo must not re-run the query handler.
+    const before = runs()
+    await saveCmd("AtomOther.Save", saveOther("x"))
+    expect(runs()).toBe(before)
+  } finally {
+    unmount()
+  }
+})
+
+it("tanstack engine: repo.save invalidates+refetches the query; an unrelated repo write does not", async () => {
+  const { baseContext, count, runs, save, saveOther } = setupRepos()
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: Infinity, staleTime: 0 } }
+  })
+  const useQuery = makeTanstackQuery(() => baseContext, queryClient)
+  const invalidator = makeTanstackQueryInvalidator(queryClient)
+
+  const app = createApp({ render: () => null })
+  app.use(VueQueryPlugin, { queryClient })
+  const scope = effectScope(true)
+  let handle: any
+  let data: any
+  app.runWithContext(() =>
+    scope.run(() => {
+      const tuple = useQuery({ id: "TanstackRepo.List", handler: () => count } as any)(
+        ref(undefined) as any,
+        {} as any
+      ) as any
+      data = tuple[1]
+      handle = tuple[3]
+    })
+  )
+  const saveCmd = (id: string, eff: Effect.Effect<unknown, never, any>) =>
+    Effect.runPromise(invalidateQueries({ id }, undefined, invalidator)(eff, { id }).pipe(Effect.provide(baseContext)))
+
+  try {
+    expect(await Effect.runPromise(handle.refetch())).toBe(0)
+
+    await saveCmd("TanstackRepo.Save", save("1"))
+    expect(data.value).toBe(1)
+
+    // Negative control: writing an UNRELATED repo must not re-run the query handler.
+    const before = runs()
+    await saveCmd("TanstackOther.Save", saveOther("x"))
+    expect(runs()).toBe(before)
+  } finally {
+    scope.stop()
+  }
+})

--- a/packages/e2e/tsconfig.json
+++ b/packages/e2e/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": [
+      "esnext",
+      "DOM"
+    ],
+    "moduleResolution": "Node16",
+    "esModuleInterop": true,
+    "noEmit": true,
+    // Leaf test package: it imports workspace packages by source, so disable project-mode (which
+    // would demand every transitively-imported source file be listed) and emit nothing.
+    "composite": false,
+    "incremental": false,
+    "declarationMap": false,
+    "rootDir": "../..",
+    "types": [
+      "node",
+      "vitest/globals"
+    ]
+  },
+  "include": [
+    "./test/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/packages/e2e/vitest.config.ts
+++ b/packages/e2e/vitest.config.ts
@@ -1,0 +1,13 @@
+/// <reference types="vitest" />
+import { defineConfig } from "vitest/config"
+import makeConfig from "../../vite.config.base"
+
+export default defineConfig({
+  ...makeConfig(__dirname),
+  test: {
+    environment: "node",
+    include: ["**/test/**/*.test.{ts,tsx}"],
+    exclude: ["node_modules/**", "dist/**"],
+    globals: true
+  }
+})

--- a/packages/effect-app/src/DataDependencies.ts
+++ b/packages/effect-app/src/DataDependencies.ts
@@ -22,6 +22,7 @@ export interface DataDependencyRecorderService {
   readonly read: (dependency: DataDependency) => Effect.Effect<void>
   readonly write: (dependency: DataDependency) => Effect.Effect<void>
   readonly get: Effect.Effect<DataDependencySet>
+  readonly drain: Effect.Effect<DataDependencySet>
   readonly drainWrites: Effect.Effect<DataDependencies>
 }
 
@@ -38,6 +39,7 @@ export const DataDependencyRecorder = Context.Reference<DataDependencyRecorderSe
       read: (_dependency) => Effect.void,
       write: (_dependency) => Effect.void,
       get: Effect.succeed({ reads: [], writes: [] }),
+      drain: Effect.succeed({ reads: [], writes: [] }),
       drainWrites: Effect.succeed([])
     })
   }
@@ -53,6 +55,10 @@ export const makeDataDependencyRecorder = (
   get: Effect.all({
     reads: Ref.get(readsRef),
     writes: Ref.get(writesRef)
+  }),
+  drain: Effect.all({
+    reads: Ref.getAndSet(readsRef, []),
+    writes: Ref.getAndSet(writesRef, [])
   }),
   drainWrites: Ref.getAndSet(writesRef, [])
 })

--- a/packages/effect-app/src/DataDependencies.ts
+++ b/packages/effect-app/src/DataDependencies.ts
@@ -1,0 +1,72 @@
+import * as Ref from "effect/Ref"
+import * as Context from "./Context.ts"
+import * as Effect from "./Effect.ts"
+import * as S from "./Schema.ts"
+
+export const DataDependency = S.Struct({
+  type: S.Literals(["repo", "signal"]),
+  name: S.String
+})
+export type DataDependency = S.Schema.Type<typeof DataDependency>
+
+export const DataDependencies = S.Array(DataDependency)
+export type DataDependencies = S.Schema.Type<typeof DataDependencies>
+
+export const DataDependencySet = S.Struct({
+  reads: DataDependencies,
+  writes: DataDependencies
+})
+export type DataDependencySet = S.Schema.Type<typeof DataDependencySet>
+
+export interface DataDependencyRecorderService {
+  readonly read: (dependency: DataDependency) => Effect.Effect<void>
+  readonly write: (dependency: DataDependency) => Effect.Effect<void>
+  readonly get: Effect.Effect<DataDependencySet>
+  readonly drainWrites: Effect.Effect<DataDependencies>
+}
+
+const containsDependency = (dependencies: ReadonlyArray<DataDependency>, dependency: DataDependency) =>
+  dependencies.some((_) => _.type === dependency.type && _.name === dependency.name)
+
+const appendDependency = (dependency: DataDependency) => (dependencies: DataDependencies): DataDependencies =>
+  containsDependency(dependencies, dependency) ? dependencies : [...dependencies, dependency]
+
+export const DataDependencyRecorder = Context.Reference<DataDependencyRecorderService>(
+  "effect-app/DataDependencyRecorder",
+  {
+    defaultValue: () => ({
+      read: (_dependency) => Effect.void,
+      write: (_dependency) => Effect.void,
+      get: Effect.succeed({ reads: [], writes: [] }),
+      drainWrites: Effect.succeed([])
+    })
+  }
+)
+export type DataDependencyRecorder = typeof DataDependencyRecorder
+
+export const makeDataDependencyRecorder = (
+  readsRef: Ref.Ref<DataDependencies>,
+  writesRef: Ref.Ref<DataDependencies>
+): DataDependencyRecorderService => ({
+  read: (dependency) => Ref.update(readsRef, appendDependency(dependency)),
+  write: (dependency) => Ref.update(writesRef, appendDependency(dependency)),
+  get: Effect.all({
+    reads: Ref.get(readsRef),
+    writes: Ref.get(writesRef)
+  }),
+  drainWrites: Ref.getAndSet(writesRef, [])
+})
+
+export const repo = (name: string): DataDependency => ({ type: "repo", name })
+export const signal = (name: string): DataDependency => ({ type: "signal", name })
+
+export const QueryReadDependenciesMetaKey = "effect-app.query.readDependencies"
+
+export const read = (dependency: DataDependency) => DataDependencyRecorder.use((_) => _.read(dependency))
+
+export const write = (dependency: DataDependency) => DataDependencyRecorder.use((_) => _.write(dependency))
+
+export const intersects = (
+  a: ReadonlyArray<DataDependency>,
+  b: ReadonlyArray<DataDependency>
+) => a.some((dependency) => containsDependency(b, dependency))

--- a/packages/effect-app/src/Model/Repository/internal/internal.ts
+++ b/packages/effect-app/src/Model/Repository/internal/internal.ts
@@ -16,6 +16,7 @@ import { toNonEmptyArray } from "../../../Array.ts"
 import * as Chunk from "../../../Chunk.ts"
 import { NotFoundError } from "../../../client/errors.ts"
 import * as Context from "../../../Context.ts"
+import * as DataDependencies from "../../../DataDependencies.ts"
 import * as Effect from "../../../Effect.ts"
 import { flatMapOption } from "../../../Effect.ts"
 import * as Option from "../../../Option.ts"
@@ -100,6 +101,9 @@ export function makeRepoInternal<
           )
 
           const store = yield* mkStore(args.makeInitial, args.config)
+          const repoDependency = DataDependencies.repo(name)
+          const recordRead = DataDependencies.read(repoDependency)
+          const recordWrite = DataDependencies.write(repoDependency)
           const cms = Effect.map(getContextMap.pipe(Effect.orDie), (_) => ({
             get: (id: string) => _.get(`${name}.${id}`),
             set: (id: string, etag: string | undefined) => _.set(`${name}.${id}`, etag)
@@ -162,6 +166,7 @@ export function makeRepoInternal<
               (_) => decodeMany(_).pipe(Effect.orDie)
             )
             .pipe(
+              Effect.tap(() => recordRead),
               Effect.map((_) => _ as T[]),
               Effect.withSpan("Repository.all", {
                 kind: "client",
@@ -231,6 +236,7 @@ export function makeRepoInternal<
             kind: "client",
             attributes: { "app.entity": name }
           })(function*(id: T[IdKey]) {
+            yield* recordRead
             yield* Effect.annotateCurrentSpan({ "app.entity.id": id })
             return yield* flatMapOption(findE(id), (_) => Effect.orDie(decode(_)))
           })
@@ -258,6 +264,7 @@ export function makeRepoInternal<
 
           const saveAndPublish = Effect.fn("Repository.saveAndPublish", { attributes: { "app.entity": name } })(
             function*(items: Iterable<T>, events: Iterable<Evt> = []) {
+              yield* recordWrite
               const it = Chunk.fromIterable(items)
               const evts = [...events]
               yield* Effect.annotateCurrentSpan({
@@ -277,6 +284,7 @@ export function makeRepoInternal<
 
           const removeAndPublish = Effect.fn("Repository.removeAndPublish", { attributes: { "app.entity": name } })(
             function*(a: Iterable<T>, events: Iterable<Evt> = []) {
+              yield* recordWrite
               const { set } = yield* cms
               const it = [...a]
               const evts = [...events]
@@ -305,6 +313,7 @@ export function makeRepoInternal<
 
           const removeById = Effect.fn("Repository.removeById", { attributes: { "app.entity": name } })(
             function*(idOrIds: T[IdKey] | ReadonlyArray<T[IdKey]>) {
+              yield* recordWrite
               const ids = globalThis.Array.isArray(idOrIds)
                 ? idOrIds as readonly T[IdKey][]
                 : [idOrIds as T[IdKey]]
@@ -460,6 +469,7 @@ export function makeRepoInternal<
                   "db.response.returned_rows": Array.isArray(r) ? r.length : 1
                 })
               ),
+              Effect.tap(() => recordRead),
               Effect.withSpan("Repository.query", {
                 kind: "client",
                 attributes: { "app.entity": name }
@@ -552,6 +562,7 @@ export function makeRepoInternal<
               const dec = S.decodeEffectConcurrently(S.Array(schema))
               return store.queryRaw(q).pipe(
                 Effect.flatMap(dec),
+                Effect.tap(() => recordRead),
                 Effect.withSpan("Repository.queryRaw", {
                   kind: "client",
                   attributes: { "app.entity": name }
@@ -573,11 +584,13 @@ export function makeRepoInternal<
               return {
                 all: allE.pipe(
                   Effect.flatMap(decMany),
+                  Effect.tap(() => recordRead),
                   Effect.map((_) => _ as any[]),
                   Effect.withSpan("Repository.mapped.all", spanAttrs, { captureStackTrace: false })
                 ),
                 find: (id: T[IdKey]) =>
                   flatMapOption(findE(id), dec).pipe(
+                    Effect.tap(() => recordRead),
                     Effect.withSpan("Repository.mapped.find", {
                       ...spanAttrs,
                       attributes: { ...spanAttrs.attributes, "app.entity.id": id }
@@ -601,6 +614,7 @@ export function makeRepoInternal<
                 // },
                 save: (...xes: any[]) =>
                   Effect.flatMap(encMany(xes), (_) => saveAllE(_)).pipe(
+                    Effect.tap(() => recordWrite),
                     Effect.withSpan("Repository.mapped.save", spanAttrs, { captureStackTrace: false })
                   )
               }

--- a/packages/effect-app/src/client.ts
+++ b/packages/effect-app/src/client.ts
@@ -5,3 +5,4 @@ export * from "./client/errors.ts"
 export * from "./client/InvalidationKeys.ts"
 export * from "./client/makeClient.ts"
 // codegen:end
+export * as DataDependencies from "./DataDependencies.ts"

--- a/packages/effect-app/src/client/apiClientFactory.ts
+++ b/packages/effect-app/src/client/apiClientFactory.ts
@@ -10,6 +10,7 @@ import * as Struct from "effect/Struct"
 import { Rpc, RpcClient, RpcGroup, RpcSerialization } from "effect/unstable/rpc"
 import * as Config from "../Config.ts"
 import * as Context from "../Context.ts"
+import * as DataDependencies from "../DataDependencies.ts"
 import * as Effect from "../Effect.ts"
 import { HttpClient, HttpClientRequest } from "../http.ts"
 import { Invalidation } from "../rpc.ts"
@@ -142,7 +143,12 @@ export const makeRpcGroupFromRequestsAndModuleName = <M extends RequestsAny, con
               stream: true as const
             })
             : Invalidation.makeCommandRpc(r._tag, { payload: r, success: r.success, error: r.error })
-          : Rpc.make(r._tag, { payload: r, success: r.success, error: r.error, stream: isStream })) as any
+          : Rpc.make(r._tag, {
+            payload: r,
+            success: isStream ? r.success : Invalidation.QueryResponseWithMetaData(r.success),
+            error: r.error,
+            stream: isStream
+          })) as any
       })
     )
     .prefix(`${moduleName}.`)
@@ -211,6 +217,20 @@ const makeApiClientFactory = Effect
       // `InvalidationKeysFromServer` and yield the raw payload / re-fail with the raw
       // error. Middleware-thrown failures arrive raw on the Cause already (no wrap to
       // strip) — the `else` branch passes them through.
+      const forwardDependencies = (
+        dependencies: DataDependencies.DataDependencySet | undefined,
+        options?: { readonly reads?: boolean }
+      ) =>
+        dependencies === undefined
+          ? Effect.void
+          : Effect.gen(function*() {
+            const dependencyRecorder = yield* DataDependencies.DataDependencyRecorder
+            if (options?.reads) {
+              yield* Effect.forEach(dependencies.reads, dependencyRecorder.read, { discard: true })
+            }
+            yield* Effect.forEach(dependencies.writes, dependencyRecorder.write, { discard: true })
+          })
+
       const unwrapCommand = (eff: Effect.Effect<any, any, any>): Effect.Effect<any, any, any> =>
         eff.pipe(
           Effect.flatMap((result: any) =>
@@ -218,6 +238,7 @@ const makeApiClientFactory = Effect
               const keys: ReadonlyArray<Invalidation.InvalidationKey> = result?.metadata?.invalidateQueries ?? []
               const invalidationKeys = yield* InvalidationKeysFromServer
               yield* Effect.forEach(keys, (key) => invalidationKeys.add(key), { discard: true })
+              yield* forwardDependencies(result?.metadata?.dataDependencies)
               return result.payload
             })
           ),
@@ -227,9 +248,20 @@ const makeApiClientFactory = Effect
                 const keys: ReadonlyArray<Invalidation.InvalidationKey> = result.metadata?.invalidateQueries ?? []
                 const invalidationKeys = yield* InvalidationKeysFromServer
                 yield* Effect.forEach(keys, (key) => invalidationKeys.add(key), { discard: true })
+                yield* forwardDependencies(result.metadata?.dataDependencies)
                 return yield* Effect.fail(result.error)
               })
               : Effect.fail(result)
+          )
+        )
+
+      const unwrapQuery = (eff: Effect.Effect<any, any, any>): Effect.Effect<any, any, any> =>
+        eff.pipe(
+          Effect.flatMap((result: any) =>
+            Effect.gen(function*() {
+              yield* forwardDependencies(result?.metadata?.dataDependencies, { reads: true })
+              return result.payload
+            })
           )
         )
 
@@ -275,7 +307,7 @@ const makeApiClientFactory = Effect
                       Effect.provide(layers, { local: true }),
                       Effect.provide(svcs)
                     )
-                  return isCommand ? unwrapCommand(rpcEffect) : rpcEffect
+                  return isCommand ? unwrapCommand(rpcEffect) : isStream ? rpcEffect : unwrapQuery(rpcEffect)
                 })
               )
 
@@ -292,13 +324,24 @@ const makeApiClientFactory = Effect
                           // Collect server invalidation keys from the "done" chunk, then discard it.
                           Stream.tap((item: any) =>
                             item._tag === "done" || item._tag === "metadata"
-                              ? InvalidationKeysFromServer.use((svc) =>
-                                Effect.forEach(
-                                  (item.metadata as Invalidation.CommandMetaData).invalidateQueries,
-                                  svc.add,
+                              ? Effect.gen(function*() {
+                                const metadata = item.metadata as Invalidation.CommandMetaData
+                                const invalidationKeys = yield* InvalidationKeysFromServer
+                                yield* Effect.forEach(metadata.invalidateQueries, invalidationKeys.add, {
+                                  discard: true
+                                })
+                                const dependencyRecorder = yield* DataDependencies.DataDependencyRecorder
+                                yield* Effect.forEach(
+                                  metadata.dataDependencies.reads,
+                                  dependencyRecorder.read,
                                   { discard: true }
                                 )
-                              )
+                                yield* Effect.forEach(
+                                  metadata.dataDependencies.writes,
+                                  dependencyRecorder.write,
+                                  { discard: true }
+                                )
+                              })
                               : Effect.void
                           ),
                           Stream.filter((item: any) => item._tag === "value"),
@@ -309,15 +352,20 @@ const makeApiClientFactory = Effect
                           Stream.catch((err: any) =>
                             err?._tag === "error" && err?.metadata
                               ? Stream.fromEffect(
-                                InvalidationKeysFromServer.use((svc) =>
-                                  Effect
-                                    .forEach(
-                                      (err.metadata as Invalidation.CommandMetaData).invalidateQueries,
-                                      svc.add,
-                                      { discard: true }
-                                    )
-                                    .pipe(Effect.flatMap(() => Effect.fail(err.error)))
-                                )
+                                Effect.gen(function*() {
+                                  const metadata = err.metadata as Invalidation.CommandMetaData
+                                  const invalidationKeys = yield* InvalidationKeysFromServer
+                                  yield* Effect.forEach(metadata.invalidateQueries, invalidationKeys.add, {
+                                    discard: true
+                                  })
+                                  const dependencyRecorder = yield* DataDependencies.DataDependencyRecorder
+                                  yield* Effect.forEach(
+                                    metadata.dataDependencies.writes,
+                                    dependencyRecorder.write,
+                                    { discard: true }
+                                  )
+                                  return yield* Effect.fail(err.error)
+                                })
                               )
                               : Stream.fail(err)
                           ),

--- a/packages/effect-app/src/rpc/Invalidation.ts
+++ b/packages/effect-app/src/rpc/Invalidation.ts
@@ -2,6 +2,7 @@ import * as Ref from "effect/Ref"
 import { Rpc } from "effect/unstable/rpc"
 import { type ClientForOptions, makeQueryKey } from "../client/clientFor.ts"
 import * as Context from "../Context.ts"
+import * as DataDependencies from "../DataDependencies.ts"
 import * as Effect from "../Effect.ts"
 import * as S from "../Schema.ts"
 
@@ -23,7 +24,7 @@ const normalizeKey = (input: InvalidationKeyInput): InvalidationKey => {
 const isBatch = (
   input: InvalidationKeyInput | ReadonlyArray<InvalidationKeyInput>
 ): input is ReadonlyArray<InvalidationKeyInput> =>
-  Array.isArray(input) && input.length > 0 && typeof input[0] !== "string"
+  Array.isArray(input) && input[0] !== undefined && typeof input[0] !== "string"
 
 const normalizeInputs = (
   input: InvalidationKeyInput | ReadonlyArray<InvalidationKeyInput>
@@ -46,8 +47,21 @@ export const InvalidationKeys = S.Array(InvalidationKey)
 export type InvalidationKeys = S.Schema.Type<typeof InvalidationKeys>
 
 /** Metadata included in every command response for server-driven cache invalidation. */
-export const CommandMetaData = S.Struct({ invalidateQueries: InvalidationKeys })
+export const CommandMetaData = S.Struct({
+  invalidateQueries: InvalidationKeys,
+  dataDependencies: DataDependencies.DataDependencySet
+})
 export type CommandMetaData = S.Schema.Type<typeof CommandMetaData>
+
+export const emptyDataDependencies: DataDependencies.DataDependencySet = { reads: [], writes: [] }
+
+export const makeMetaData = (
+  invalidateQueries: InvalidationKeys,
+  dataDependencies: DataDependencies.DataDependencySet = emptyDataDependencies
+): CommandMetaData => ({ invalidateQueries, dataDependencies })
+
+export const QueryResponseWithMetaData = <S extends S.Top>(success: S) =>
+  S.Struct({ payload: success, metadata: S.Struct({ dataDependencies: DataDependencies.DataDependencySet }) })
 
 /**
  * Wraps a command's success schema so that the wire format carries both the `payload`

--- a/packages/infra/src/routing.ts
+++ b/packages/infra/src/routing.ts
@@ -2,9 +2,11 @@
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
 /* eslint-disable @typescript-eslint/no-empty-object-type */
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import * as Array from "effect-app/Array"
 import type { NonEmptyReadonlyArray } from "effect-app/Array"
 import { getMeta } from "effect-app/client"
 import * as Config from "effect-app/Config"
+import * as DataDependencies from "effect-app/DataDependencies"
 import * as Effect from "effect-app/Effect"
 import { type HttpHeaders } from "effect-app/http"
 import * as Layer from "effect-app/Layer"
@@ -454,10 +456,19 @@ export const makeRouter = <Live extends Layer.Layer<any, any, any> = Layer.Layer
                   // clients can invalidate queries even when the stream fails.
                   const keysRef = Ref.makeUnsafe<ReadonlyArray<Invalidation.InvalidationKey>>([])
                   const invalidationSet = Invalidation.makeInvalidationSet(keysRef)
+                  const readsRef = Ref.makeUnsafe<DataDependencies.DataDependencies>([])
+                  const writesRef = Ref.makeUnsafe<DataDependencies.DataDependencies>([])
+                  const dependencyRecorder = DataDependencies.makeDataDependencyRecorder(readsRef, writesRef)
+                  const metadata = (keys: ReadonlyArray<Invalidation.InvalidationKey>) =>
+                    Effect.map(
+                      dependencyRecorder.get,
+                      (dataDependencies) => Invalidation.makeMetaData(keys, dataDependencies)
+                    )
                   return Stream.concat(
                     (result as Stream.Stream<any, any, any>).pipe(
                       Stream.map((item: any) => ({ _tag: "value" as const, value: item })),
                       Stream.provideService(Invalidation.InvalidationSet, invalidationSet),
+                      Stream.provideService(DataDependencies.DataDependencyRecorder, dependencyRecorder),
                       // V3: after each value chunk, drain accumulated keys and emit a "metadata"
                       // chunk if any keys were collected since the last drain. This lets clients
                       // invalidate queries mid-stream without waiting for the "done" chunk.
@@ -465,13 +476,18 @@ export const makeRouter = <Live extends Layer.Layer<any, any, any> = Layer.Layer
                         Stream
                           .fromEffect(
                             Ref.getAndSet(keysRef, []).pipe(
-                              Effect.map((keys) =>
-                                keys.length > 0
-                                  ? [
-                                    valueChunk,
-                                    { _tag: "metadata" as const, metadata: { invalidateQueries: keys } }
-                                  ]
-                                  : [valueChunk]
+                              Effect.flatMap((keys) =>
+                                metadata(keys).pipe(
+                                  Effect.map((meta) =>
+                                    Array.isReadonlyArrayNonEmpty(keys)
+                                      || Array.isReadonlyArrayNonEmpty(meta.dataDependencies.writes)
+                                      ? [
+                                        valueChunk,
+                                        { _tag: "metadata" as const, metadata: meta }
+                                      ]
+                                      : [valueChunk]
+                                  )
+                                )
                               )
                             )
                           )
@@ -482,11 +498,15 @@ export const makeRouter = <Live extends Layer.Layer<any, any, any> = Layer.Layer
                         Stream.fromEffect(
                           Ref.get(keysRef).pipe(
                             Effect.flatMap((keys) =>
-                              Effect.fail({
-                                _tag: "error" as const,
-                                error: err,
-                                metadata: { invalidateQueries: keys }
-                              })
+                              metadata(keys).pipe(
+                                Effect.flatMap((meta) =>
+                                  Effect.fail({
+                                    _tag: "error" as const,
+                                    error: err,
+                                    metadata: meta
+                                  })
+                                )
+                              )
                             )
                           )
                         )
@@ -494,7 +514,11 @@ export const makeRouter = <Live extends Layer.Layer<any, any, any> = Layer.Layer
                     ),
                     Stream.fromEffect(
                       Ref.get(keysRef).pipe(
-                        Effect.map((keys) => ({ _tag: "done" as const, metadata: { invalidateQueries: keys } }))
+                        Effect.flatMap((keys) =>
+                          metadata(keys).pipe(
+                            Effect.map((meta) => ({ _tag: "done" as const, metadata: meta }))
+                          )
+                        )
                       )
                     )
                   )
@@ -511,6 +535,13 @@ export const makeRouter = <Live extends Layer.Layer<any, any, any> = Layer.Layer
                   })
                   .pipe(Effect.andThen(result as Effect.Effect<unknown, unknown, unknown>))
 
+                const readsRef = Ref.makeUnsafe<DataDependencies.DataDependencies>([])
+                const writesRef = Ref.makeUnsafe<DataDependencies.DataDependencies>([])
+                const dependencyRecorder = DataDependencies.makeDataDependencyRecorder(readsRef, writesRef)
+                effect = effect.pipe(
+                  Effect.provideService(DataDependencies.DataDependencyRecorder, dependencyRecorder)
+                )
+
                 // Commands: provide a request-scoped `InvalidationSet` and wrap both
                 // success (`CommandResponseWithMetaData`) and handler-thrown failure
                 // (`CommandFailureWithMetaData`) so the client receives accumulated
@@ -525,18 +556,39 @@ export const makeRouter = <Live extends Layer.Layer<any, any, any> = Layer.Layer
                     Effect.provideService(Invalidation.InvalidationSet, invalidationSet),
                     Effect.flatMap((value) =>
                       Ref.get(keysRef).pipe(
-                        Effect.map((keys) => ({ payload: value, metadata: { invalidateQueries: keys } }) as any)
+                        Effect.flatMap((keys) =>
+                          dependencyRecorder.get.pipe(
+                            Effect.map((dataDependencies) =>
+                              ({
+                                payload: value,
+                                metadata: Invalidation.makeMetaData(keys, dataDependencies)
+                              }) as any
+                            )
+                          )
+                        )
                       )
                     ),
                     Effect.catch((err: any) =>
                       Ref.get(keysRef).pipe(
                         Effect.flatMap((keys) =>
-                          Effect.fail({
-                            _tag: "CommandFailureWithMetaData" as const,
-                            error: err,
-                            metadata: { invalidateQueries: keys }
-                          })
+                          dependencyRecorder.get.pipe(
+                            Effect.flatMap((dataDependencies) =>
+                              Effect.fail({
+                                _tag: "CommandFailureWithMetaData" as const,
+                                error: err,
+                                metadata: Invalidation.makeMetaData(keys, dataDependencies)
+                              })
+                            )
+                          )
                         )
+                      )
+                    )
+                  )
+                } else {
+                  effect = effect.pipe(
+                    Effect.flatMap((value) =>
+                      dependencyRecorder.get.pipe(
+                        Effect.map((dataDependencies) => ({ payload: value, metadata: { dataDependencies } }) as any)
                       )
                     )
                   )
@@ -584,7 +636,7 @@ export const makeRouter = <Live extends Layer.Layer<any, any, any> = Layer.Layer
                     })
                   : Rpc.make(resource._tag, {
                     payload: resource,
-                    success: resource.success,
+                    success: isStream ? resource.success : Invalidation.QueryResponseWithMetaData(resource.success),
                     error: resource.error,
                     stream: isStream
                   }))

--- a/packages/infra/src/routing.ts
+++ b/packages/infra/src/routing.ts
@@ -461,7 +461,7 @@ export const makeRouter = <Live extends Layer.Layer<any, any, any> = Layer.Layer
                   const dependencyRecorder = DataDependencies.makeDataDependencyRecorder(readsRef, writesRef)
                   const metadata = (keys: ReadonlyArray<Invalidation.InvalidationKey>) =>
                     Effect.map(
-                      dependencyRecorder.get,
+                      dependencyRecorder.drain,
                       (dataDependencies) => Invalidation.makeMetaData(keys, dataDependencies)
                     )
                   return Stream.concat(
@@ -480,6 +480,7 @@ export const makeRouter = <Live extends Layer.Layer<any, any, any> = Layer.Layer
                                 metadata(keys).pipe(
                                   Effect.map((meta) =>
                                     Array.isReadonlyArrayNonEmpty(keys)
+                                      || Array.isReadonlyArrayNonEmpty(meta.dataDependencies.reads)
                                       || Array.isReadonlyArrayNonEmpty(meta.dataDependencies.writes)
                                       ? [
                                         valueChunk,

--- a/packages/infra/test/repository-ext.test.ts
+++ b/packages/infra/test/repository-ext.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from "@effect/vitest"
+import * as DataDependencies from "effect-app/DataDependencies"
 import * as Effect from "effect-app/Effect"
 import * as Layer from "effect-app/Layer"
 import { makeRepo } from "effect-app/Model/Repository"
 import { RepositoryRegistryLive } from "effect-app/Model/Repository/Registry"
 import * as S from "effect-app/Schema"
 import { setupRequestContextFromCurrent } from "effect-app/setupRequest"
+import * as Ref from "effect/Ref"
 import { MemoryStoreLive } from "../src/Store/Memory.js"
 
 class BatchItem extends S.Class<BatchItem>("BatchItem")({
@@ -54,6 +56,31 @@ describe("repository ext save/remove batching", () => {
         const all = yield* repo.all
         expect(all).toHaveLength(1)
         expect(all[0]?.id).toBe("4")
+      })
+      .pipe(
+        setupRequestContextFromCurrent(),
+        Effect.provide(TestStoreLive)
+      ))
+
+  it.effect("records repository read and write dependencies", () =>
+    Effect
+      .gen(function*() {
+        const readsRef = yield* Ref.make<DataDependencies.DataDependencies>([])
+        const writesRef = yield* Ref.make<DataDependencies.DataDependencies>([])
+        const recorder = DataDependencies.makeDataDependencyRecorder(readsRef, writesRef)
+
+        yield* Effect
+          .gen(function*() {
+            const repo = yield* makeRepo("DependencyItem", BatchItem, {})
+            yield* repo.save(new BatchItem({ id: "1", label: "one" }))
+            yield* repo.all
+            yield* repo.find("1")
+            yield* repo.removeById("1")
+          })
+          .pipe(Effect.provideService(DataDependencies.DataDependencyRecorder, recorder))
+
+        expect(yield* Ref.get(readsRef)).toEqual([DataDependencies.repo("DependencyItem")])
+        expect(yield* Ref.get(writesRef)).toEqual([DataDependencies.repo("DependencyItem")])
       })
       .pipe(
         setupRequestContextFromCurrent(),

--- a/packages/infra/test/rpc-e2e-invalidation.test.ts
+++ b/packages/infra/test/rpc-e2e-invalidation.test.ts
@@ -103,6 +103,12 @@ class StreamWithKey extends Req.Command<StreamWithKey>()("StreamWithKey", {}, {
   success: S.Number
 }) {}
 
+class StreamWithRepoWrite extends Req.Command<StreamWithRepoWrite>()("StreamWithRepoWrite", {}, {
+  stream: true,
+  allowAnonymous: true,
+  success: S.Number
+}) {}
+
 class RepoItem extends S.Class<RepoItem>("RepoItem")({
   id: S.String,
   label: S.String
@@ -158,6 +164,7 @@ const InvRsc = {
   DoWithBothKeys,
   DoAndFail,
   StreamWithKey,
+  StreamWithRepoWrite,
   GetRepoCount,
   SaveRepoItem,
   SaveOtherItem
@@ -190,6 +197,12 @@ const router = Router(InvRsc)({
       StreamWithKey: () =>
         Stream.fromIterable([1, 2, 3]).pipe(
           Stream.tap(() => Invalidation.InvalidationSet.use((_) => _.add(StreamKey)))
+        ),
+      StreamWithRepoWrite: () =>
+        Stream.fromIterable([1, 2, 3]).pipe(
+          Stream.tap((n) =>
+            repo.save(new RepoItem({ id: String(n), label: "x" })).pipe(Effect.orDie, setupRequestContextFromCurrent())
+          )
         ),
       GetRepoCount: () => repo.all.pipe(Effect.map((_) => _.length), Effect.orDie, setupRequestContextFromCurrent()),
       SaveRepoItem: ({ id, label }) =>
@@ -330,6 +343,25 @@ it.live(
     // Handler taps `InvalidationSet.use` once per emitted value; routing's V3 mid-stream
     // metadata drain forwards each batch as it arrives.
     expect(keys).toStrictEqual([StreamKey, StreamKey, StreamKey])
+  }, Effect.provide(TestLayer)),
+  { timeout: 10_000 }
+)
+
+it.live(
+  "stream: per-chunk repo writes are drained and forwarded to the client recorder",
+  Effect.fnUntraced(function*() {
+    const client = yield* ApiClientFactory.makeFor(Layer.empty)(InvRsc)
+    const readsRef = yield* Ref.make<DataDependencies.DataDependencies>([])
+    const writesRef = yield* Ref.make<DataDependencies.DataDependencies>([])
+    const svc = DataDependencies.makeDataDependencyRecorder(readsRef, writesRef)
+    const values = yield* Stream.runCollect(client.StreamWithRepoWrite.handler()).pipe(
+      Effect.provideService(DataDependencies.DataDependencyRecorder, svc)
+    )
+    const writes = yield* Ref.get(writesRef)
+    expect(values).toStrictEqual([1, 2, 3])
+    // Each emitted value writes to RepoItem; routing drains the writes per chunk and the client
+    // accumulates them — the recorder dedupes, so a single RepoItem entry is recorded.
+    expect(writes).toStrictEqual([DataDependencies.repo("RepoItem")])
   }, Effect.provide(TestLayer)),
   { timeout: 10_000 }
 )

--- a/packages/infra/test/rpc-e2e-invalidation.test.ts
+++ b/packages/infra/test/rpc-e2e-invalidation.test.ts
@@ -14,12 +14,15 @@
  */
 import { NodeHttpServer } from "@effect/platform-node"
 import { expect, it } from "@effect/vitest"
-import { ApiClientFactory, InvalidationKeysFromServer, makeInvalidationKeysService, makeRpcClient } from "effect-app/client"
+import { ApiClientFactory, DataDependencies, InvalidationKeysFromServer, InvalidStateError, makeInvalidationKeysService, makeRpcClient, OptimisticConcurrencyException } from "effect-app/client"
+import * as Context from "effect-app/Context"
 import { HttpRouter, HttpServer } from "effect-app/http"
 import { DefaultGenericMiddlewares } from "effect-app/middleware"
+import { makeRepo, RepositoryRegistryLive } from "effect-app/Model"
 import { Invalidation, MiddlewareMaker } from "effect-app/rpc"
 import * as S from "effect-app/Schema"
 import { TaggedErrorClass } from "effect-app/Schema"
+import { setupRequestContextFromCurrent } from "effect-app/setupRequest"
 import * as Effect from "effect/Effect"
 import * as Exit from "effect/Exit"
 import * as Layer from "effect/Layer"
@@ -31,6 +34,7 @@ import { RpcSerialization } from "effect/unstable/rpc"
 import { createServer } from "http"
 import { makeRouter } from "../src/routing.js"
 import { DefaultGenericMiddlewaresLive } from "../src/routing/middleware.js"
+import { MemoryStoreLive } from "../src/Store/Memory.js"
 import { AllowAnonymous, AllowAnonymousLive, RequestContextMap, RequireRoles, RequireRolesLive, SomeElseMiddleware, SomeElseMiddlewareLive, SomeService, Test, TestLive } from "./fixtures.js"
 
 // ---------------------------------------------------------------------------
@@ -99,14 +103,75 @@ class StreamWithKey extends Req.Command<StreamWithKey>()("StreamWithKey", {}, {
   success: S.Number
 }) {}
 
-const InvRsc = { DoNothing, DoWithDynamicKey, DoWithBothKeys, DoAndFail, StreamWithKey }
+class RepoItem extends S.Class<RepoItem>("RepoItem")({
+  id: S.String,
+  label: S.String
+}) {}
+
+class GetRepoCount extends Req.Query<GetRepoCount>()("GetRepoCount", {}, {
+  allowAnonymous: true,
+  success: S.Number
+}) {}
+
+class SaveRepoItem extends Req.Command<SaveRepoItem>()("SaveRepoItem", {
+  id: S.String,
+  label: S.String
+}, {
+  allowAnonymous: true,
+  error: S.Union([InvalidStateError, OptimisticConcurrencyException]),
+  success: S.Void
+}) {}
+
+class RepoItems extends Context.Service<RepoItems>()("RepoItems", {
+  make: makeRepo("RepoItem", RepoItem, {})
+}) {
+  static Default = Layer.effect(this, this.make).pipe(
+    Layer.provide(Layer.merge(MemoryStoreLive, RepositoryRegistryLive))
+  )
+}
+
+// A second, unrelated repo — its writes must NOT invalidate a query that only read `RepoItem`.
+class OtherItem extends S.Class<OtherItem>("OtherItem")({
+  id: S.String,
+  label: S.String
+}) {}
+
+class SaveOtherItem extends Req.Command<SaveOtherItem>()("SaveOtherItem", {
+  id: S.String,
+  label: S.String
+}, {
+  allowAnonymous: true,
+  success: S.Void
+}) {}
+
+class OtherItems extends Context.Service<OtherItems>()("OtherItems", {
+  make: makeRepo("OtherItem", OtherItem, {})
+}) {
+  static Default = Layer.effect(this, this.make).pipe(
+    Layer.provide(Layer.merge(MemoryStoreLive, RepositoryRegistryLive))
+  )
+}
+
+const InvRsc = {
+  DoNothing,
+  DoWithDynamicKey,
+  DoWithBothKeys,
+  DoAndFail,
+  StreamWithKey,
+  GetRepoCount,
+  SaveRepoItem,
+  SaveOtherItem
+}
 
 // ---------------------------------------------------------------------------
 // Controllers / router
 // ---------------------------------------------------------------------------
 
 const router = Router(InvRsc)({
+  dependencies: [RepoItems.Default, OtherItems.Default],
   *effect(match) {
+    const repo = yield* RepoItems
+    const otherRepo = yield* OtherItems
     return match({
       DoNothing: () => Effect.void,
       DoWithDynamicKey: Effect.fnUntraced(function*() {
@@ -125,7 +190,12 @@ const router = Router(InvRsc)({
       StreamWithKey: () =>
         Stream.fromIterable([1, 2, 3]).pipe(
           Stream.tap(() => Invalidation.InvalidationSet.use((_) => _.add(StreamKey)))
-        )
+        ),
+      GetRepoCount: () => repo.all.pipe(Effect.map((_) => _.length), Effect.orDie, setupRequestContextFromCurrent()),
+      SaveRepoItem: ({ id, label }) =>
+        repo.save(new RepoItem({ id, label })).pipe(Effect.orDie, setupRequestContextFromCurrent()),
+      SaveOtherItem: ({ id, label }) =>
+        otherRepo.save(new OtherItem({ id, label })).pipe(Effect.orDie, setupRequestContextFromCurrent())
     })
   }
 })
@@ -169,6 +239,15 @@ const withCapture = <A, E, R>(eff: Effect.Effect<A, E, R>) =>
     const svc = makeInvalidationKeysService(ref)
     const result = yield* eff.pipe(Effect.provideService(InvalidationKeysFromServer, svc), Effect.exit)
     return { result, keys: yield* Ref.get(ref) }
+  })
+
+const withDependencyCapture = <A, E, R>(eff: Effect.Effect<A, E, R>) =>
+  Effect.gen(function*() {
+    const readsRef = yield* Ref.make<DataDependencies.DataDependencies>([])
+    const writesRef = yield* Ref.make<DataDependencies.DataDependencies>([])
+    const svc = DataDependencies.makeDataDependencyRecorder(readsRef, writesRef)
+    const result = yield* eff.pipe(Effect.provideService(DataDependencies.DataDependencyRecorder, svc), Effect.exit)
+    return { result, dependencies: yield* svc.get }
   })
 
 // ---------------------------------------------------------------------------
@@ -251,6 +330,59 @@ it.live(
     // Handler taps `InvalidationSet.use` once per emitted value; routing's V3 mid-stream
     // metadata drain forwards each batch as it arrives.
     expect(keys).toStrictEqual([StreamKey, StreamKey, StreamKey])
+  }, Effect.provide(TestLayer)),
+  { timeout: 10_000 }
+)
+
+it.live(
+  "repository dependencies flow through query and command metadata",
+  Effect.fnUntraced(function*() {
+    const client = yield* ApiClientFactory.makeFor(Layer.empty)(InvRsc)
+
+    const query = yield* withDependencyCapture(client.GetRepoCount.handler())
+    expect(Exit.isSuccess(query.result) && query.result.value).toBe(0)
+    expect(query.dependencies.reads).toStrictEqual([DataDependencies.repo("RepoItem")])
+    expect(query.dependencies.writes).toStrictEqual([])
+
+    const command = yield* withDependencyCapture(client.SaveRepoItem.handler({ id: "1", label: "one" }))
+    expect(Exit.isSuccess(command.result)).toBe(true)
+    expect(command.dependencies.reads).toStrictEqual([])
+    expect(command.dependencies.writes).toStrictEqual([DataDependencies.repo("RepoItem")])
+  }, Effect.provide(TestLayer)),
+  { timeout: 10_000 }
+)
+
+it.live(
+  "query invalidation: a command's writes invalidate exactly the queries whose reads intersect",
+  Effect.fnUntraced(function*() {
+    const client = yield* ApiClientFactory.makeFor(Layer.empty)(InvRsc)
+
+    // Client-side query registry: queryKey -> read dependencies forwarded by the server. Mirrors
+    // @effect-app/vue's `dependencyMetadata`; the derivation predicate (`intersects`) is the exact
+    // one the vue mutate engine uses to pick invalidation targets from a command's writes.
+    const queryReads = new Map<string, DataDependencies.DataDependencies>()
+    const invalidatedBy = (writes: DataDependencies.DataDependencies) =>
+      [...queryReads]
+        .filter(([, reads]) => DataDependencies.intersects(reads, writes))
+        .map(([key]) => key)
+
+    // Run the query through the real client; register its forwarded reads under its key.
+    const query = yield* withDependencyCapture(client.GetRepoCount.handler())
+    expect(Exit.isSuccess(query.result)).toBe(true)
+    queryReads.set("GetRepoCount", query.dependencies.reads)
+    // Before any command, nothing is invalidated.
+    expect(invalidatedBy([])).toStrictEqual([])
+
+    // A command writing the SAME repo the query read => the query is selected for invalidation.
+    const save = yield* withDependencyCapture(client.SaveRepoItem.handler({ id: "1", label: "one" }))
+    expect(Exit.isSuccess(save.result)).toBe(true)
+    expect(invalidatedBy(save.dependencies.writes)).toStrictEqual(["GetRepoCount"])
+
+    // A command writing an UNRELATED repo => the query is NOT invalidated (negative control).
+    const saveOther = yield* withDependencyCapture(client.SaveOtherItem.handler({ id: "2", label: "two" }))
+    expect(Exit.isSuccess(saveOther.result)).toBe(true)
+    expect(saveOther.dependencies.writes).toStrictEqual([DataDependencies.repo("OtherItem")])
+    expect(invalidatedBy(saveOther.dependencies.writes)).toStrictEqual([])
   }, Effect.provide(TestLayer)),
   { timeout: 10_000 }
 )

--- a/packages/vue-components/tsconfig.json
+++ b/packages/vue-components/tsconfig.json
@@ -21,6 +21,15 @@
       "vite/client"
     ]
   },
-  "include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.tsx", "src/**/*.vue", "src/index.js", "types/**/*.d.ts", "stories/**/*.ts", "stories/**/*.vue"],
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.d.ts",
+    "src/**/*.tsx",
+    "src/**/*.vue",
+    "src/index.js",
+    "types/**/*.d.ts",
+    "stories/**/*.ts",
+    "stories/**/*.vue"
+  ],
   "exclude": ["**/__tests__/**", "**/*.test.*"]
 }

--- a/packages/vue/src/atomQuery.ts
+++ b/packages/vue/src/atomQuery.ts
@@ -14,7 +14,7 @@
  * abstraction (mirrors AtomRpc's recipe; see docs/atom-query-plan.md).
  */
 import { defaultRegistry } from "@effect/atom-vue"
-import { makeQueryKey } from "effect-app/client"
+import { DataDependencies, makeQueryKey } from "effect-app/client"
 import type { ClientForOptions } from "effect-app/client/clientFor"
 import { ServiceUnavailableError } from "effect-app/client/errors"
 import * as Effect from "effect-app/Effect"
@@ -25,12 +25,14 @@ import * as Duration from "effect/Duration"
 import * as Equal from "effect/Equal"
 import * as Hash from "effect/Hash"
 import type * as Layer from "effect/Layer"
+import * as Ref from "effect/Ref"
 import * as Stream from "effect/Stream"
 import { isHttpClientError } from "effect/unstable/http/HttpClientError"
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult"
 import * as Atom from "effect/unstable/reactivity/Atom"
 import * as AtomRegistry from "effect/unstable/reactivity/AtomRegistry"
 import * as Reactivity from "effect/unstable/reactivity/Reactivity"
+import { clearQueryReadDependencies, setQueryReadDependencies } from "./dependencyMetadata.ts"
 import { reportRuntimeError } from "./lib.ts"
 
 /** All non-empty prefixes of a key, longest last. `[a,b,c]` -> `[[a],[a,b],[a,b,c]]`. */
@@ -82,6 +84,15 @@ const trackWritableByKeys =
       (refresh) => refresh(tracked)
     )
   }
+
+/** Drop a query's recorded read-dependencies when its atom is GC'd (mirrors `trackByKeys`). */
+const trackReadDependencies =
+  (key: ReadonlyArray<unknown>) =>
+  <A, E>(atom: Atom.Atom<AsyncResult.AsyncResult<A, E>>): Atom.Atom<AsyncResult.AsyncResult<A, E>> =>
+    Atom.transform(atom, (get) => {
+      get.addFinalizer(() => clearQueryReadDependencies(key))
+      return get(atom)
+    }, { initialValueTarget: atom })
 
 const atomsForKeys = (keys: ReadonlyArray<unknown>): ReadonlyArray<Atom.Atom<AsyncResult.AsyncResult<any, any>>> => {
   const atoms = new Set<Atom.Atom<AsyncResult.AsyncResult<any, any>>>()
@@ -319,9 +330,21 @@ export const buildQueryFamily = <I, A, E>(
   const baseKey = makeQueryKey(self) // hierarchical, input-independent
 
   return Atom.family((input: I) => {
-    let atom: Atom.Atom<AsyncResult.AsyncResult<A, E>> = rt.runtime.atom(
-      self
+    const fullKey = [...baseKey, input]
+    // Record the repository/server read-dependencies seen while fetching, keyed by `fullKey`, so a
+    // later mutation whose writes intersect them can derive this query as an invalidation target.
+    const recordReads = Effect.gen(function*() {
+      const readsRef = yield* Ref.make<DataDependencies.DataDependencies>([])
+      const writesRef = yield* Ref.make<DataDependencies.DataDependencies>([])
+      const recorder = DataDependencies.makeDataDependencyRecorder(readsRef, writesRef)
+      const result = yield* self
         .handler(input)
+        .pipe(Effect.provideService(DataDependencies.DataDependencyRecorder, recorder))
+      setQueryReadDependencies(fullKey, yield* Ref.get(readsRef))
+      return result
+    })
+    let atom: Atom.Atom<AsyncResult.AsyncResult<A, E>> = rt.runtime.atom(
+      recordReads
         .pipe(
           Effect.retry({ times: 5, while: isRetryable }),
           Effect.tapCauseIf(Cause.hasDies, (cause) => reportRuntimeError(cause)),
@@ -331,13 +354,13 @@ export const buildQueryFamily = <I, A, E>(
     // Register under every prefix of the full key => hierarchical (prefix) invalidation. Two roles:
     //   - withReactivity: `Reactivity.invalidate(key)` refreshes this atom (the actual refetch).
     //   - trackByKeys:    records the atom in `keyAtoms` so the mutation can AWAIT its settle.
-    const fullKey = [...baseKey, input]
     const projectedFullKey = self.queryKeyProjectionHash === undefined
       ? fullKey
       : [...baseKey, self.queryKeyProjectionHash, input]
     const reactivityKeys = uniqueKeys([...prefixesOf(fullKey), ...prefixesOf(projectedFullKey)])
     atom = rt.factory.withReactivity(reactivityKeys)(atom)
     atom = trackByKeys(reactivityKeys)(atom)
+    atom = trackReadDependencies(fullKey)(atom)
     // gcTime LAST so the whole chain (incl. the registration + tracking) stays alive through the
     // idle window, letting invalidation reach a cached-but-unmounted query.
     atom = Atom.setIdleTTL(atom, defaults.gcTime)

--- a/packages/vue/src/dependencyMetadata.ts
+++ b/packages/vue/src/dependencyMetadata.ts
@@ -1,0 +1,38 @@
+import { DataDependencies } from "effect-app/client"
+import * as Hash from "effect/Hash"
+
+// Maps a live query's reactivity key (its full `[...queryKey, input]` key) to the
+// data dependencies it read while fetching. Populated when the query handler resolves and
+// cleared when the query atom is GC'd, so the set mirrors the live query atoms (mounted or
+// cached-within-ttl) — the atom equivalent of the former tanstack query cache.
+type Entry = { readonly key: ReadonlyArray<unknown>; readonly reads: DataDependencies.DataDependencies }
+const readDependencies = new Map<number, Entry>()
+
+export const setQueryReadDependencies = (
+  key: ReadonlyArray<unknown>,
+  reads: DataDependencies.DataDependencies
+) => {
+  const h = Hash.hash(key)
+  if (reads.length === 0) readDependencies.delete(h)
+  else readDependencies.set(h, { key, reads })
+}
+
+export const clearQueryReadDependencies = (key: ReadonlyArray<unknown>) => {
+  readDependencies.delete(Hash.hash(key))
+}
+
+/**
+ * Reactivity keys of every live query whose recorded read-dependencies intersect this
+ * mutation's `writeDependencies`. Returned keys are passed to `invalidateAndAwait`, refreshing
+ * exactly those queries.
+ */
+export const getDerivedInvalidationKeys = (
+  writeDependencies: ReadonlyArray<DataDependencies.DataDependency>
+): ReadonlyArray<ReadonlyArray<unknown>> => {
+  if (writeDependencies.length === 0) return []
+  const keys: Array<ReadonlyArray<unknown>> = []
+  for (const { key, reads } of readDependencies.values()) {
+    if (DataDependencies.intersects(reads, writeDependencies)) keys.push(key)
+  }
+  return keys
+}

--- a/packages/vue/src/internal/tanstackQuery.ts
+++ b/packages/vue/src/internal/tanstackQuery.ts
@@ -1,6 +1,6 @@
 import { injectRegistry } from "@effect/atom-vue"
 import { QueryClient, useQuery as useTanstackQuery } from "@tanstack/vue-query"
-import { makeQueryKey, type Req } from "effect-app/client"
+import { DataDependencies, makeQueryKey, type Req } from "effect-app/client"
 import type { RequestHandlerWithInput } from "effect-app/client/clientFor"
 import { CauseException, ServiceUnavailableError } from "effect-app/client/errors"
 import type * as Context from "effect-app/Context"
@@ -8,11 +8,13 @@ import * as Effect from "effect-app/Effect"
 import * as Option from "effect-app/Option"
 import * as S from "effect-app/Schema"
 import * as Cause from "effect/Cause"
+import * as Ref from "effect/Ref"
 import { isHttpClientError } from "effect/unstable/http/HttpClientError"
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult"
 import * as Atom from "effect/unstable/reactivity/Atom"
 import { computed, type MaybeRefOrGetter, shallowRef, toValue, watch, type WatchSource } from "vue"
 import { replaceEqualDeep } from "../atomQuery.ts"
+import { clearQueryReadDependencies, setQueryReadDependencies } from "../dependencyMetadata.ts"
 import { reportRuntimeError } from "../lib.ts"
 import type { QueryInvalidator } from "../mutate.ts"
 import type { CustomDefinedInitialQueryOptions, CustomDefinedPlaceholderQueryOptions, CustomUndefinedInitialQueryOptions, CustomUseQueryOptions, MakeQuery2, QueryCacheUpdater, QueryHandle, QueryObserverResult, RefetchOptions } from "../query.ts"
@@ -131,6 +133,12 @@ export const makeTanstackQuery = <R>(
   getRuntime: () => Context.Context<R>,
   queryClient: QueryClient
 ): MakeQuery2<R> => {
+  // Drop a query's recorded read-dependencies when tanstack evicts it from the cache, so the
+  // registry mirrors the live queries (mirrors the atom engine's `trackReadDependencies` finalizer).
+  queryClient.getQueryCache().subscribe((event) => {
+    if (event.type === "removed") clearQueryReadDependencies(event.query.queryKey)
+  })
+
   const useQuery: MakeQuery2<R> = <I, A, E, Request extends Req, Name extends string>(
     q: RequestHandlerWithInput<I, A, E, R, Request, Name>
   ) =>
@@ -161,12 +169,24 @@ export const makeTanstackQuery = <R>(
       }),
       queryFn: ({ signal }: { readonly signal: AbortSignal }) =>
         runPromise(
-          q
-            .handler(resolveInput(arg, options?.mode)!)
-            .pipe(
-              Effect.tapCauseIf(Cause.hasDies, (cause) => reportRuntimeError(cause)),
-              Effect.withSpan(`query ${q.id}`, {}, { captureStackTrace: false })
-            ),
+          Effect.gen(function*() {
+            const input = resolveInput(arg, options?.mode)!
+            // Record the repository/server read-dependencies seen while fetching, keyed by the
+            // tanstack queryKey, so a later mutation whose writes intersect them derives this query
+            // as an invalidation target (the tanstack invalidator invalidates by this same key).
+            const readsRef = yield* Ref.make<DataDependencies.DataDependencies>([])
+            const writesRef = yield* Ref.make<DataDependencies.DataDependencies>([])
+            const recorder = DataDependencies.makeDataDependencyRecorder(readsRef, writesRef)
+            const result = yield* q
+              .handler(input)
+              .pipe(
+                Effect.provideService(DataDependencies.DataDependencyRecorder, recorder),
+                Effect.tapCauseIf(Cause.hasDies, (cause) => reportRuntimeError(cause)),
+                Effect.withSpan(`query ${q.id}`, {}, { captureStackTrace: false })
+              )
+            setQueryReadDependencies(fullQueryKey(q, queryKey, input), yield* Ref.get(readsRef))
+            return result
+          }),
           { signal }
         )
     }, queryClient)

--- a/packages/vue/src/mutate.ts
+++ b/packages/vue/src/mutate.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { type InvalidationKey, InvalidationKeysFromServer, makeInvalidationKeysService, makeQueryKey, type Req } from "effect-app/client"
+import { DataDependencies, type InvalidationKey, InvalidationKeysFromServer, makeInvalidationKeysService, makeQueryKey, type Req } from "effect-app/client"
 import type { ClientForOptions, RequestHandlerWithInput } from "effect-app/client/clientFor"
 import type { InvalidateQueryInstruction } from "effect-app/client/makeClient"
 import * as Effect from "effect-app/Effect"
@@ -14,6 +14,7 @@ import * as AsyncResult from "effect/unstable/reactivity/AsyncResult"
 import type * as Reactivity from "effect/unstable/reactivity/Reactivity"
 import { computed, type ComputedRef, shallowRef } from "vue"
 import { invalidateAndAwait } from "./atomQuery.ts"
+import { getDerivedInvalidationKeys } from "./dependencyMetadata.ts"
 
 export type GetQueryKey = (h: { id: string; options?: ClientForOptions }) => string[]
 
@@ -296,25 +297,32 @@ const buildInvalidateCache = <RInvalidator>(
       return keys
     }
 
-    return queryKey ? [queryKey] : []
+    // No implicit namespace invalidation: without an explicit `queryInvalidation` config, client
+    // keys are empty and invalidation is driven solely by server keys + repository write-dependency
+    // derivation. (`getQueryKey` is still offered to the config callback as a convenience base.)
+    return []
   }
 
   const invalidateCache = (
     input: unknown,
     output: Exit.Exit<unknown, unknown>,
-    serverKeys: ReadonlyArray<InvalidationKey>
+    serverKeys: ReadonlyArray<InvalidationKey>,
+    writeDependencies: ReadonlyArray<DataDependencies.DataDependency> = []
   ) =>
     Effect.suspend(() => {
       const clientKeys = getClientInvalidationKeys(input, output)
+      // Derive extra reactivity keys from repository write-dependencies: every live query whose
+      // recorded read-dependencies intersect this mutation's writes must be refreshed.
+      const derivedKeys = getDerivedInvalidationKeys(writeDependencies)
       // Invalidate exact reactivity keys (= the prefixes query atoms register under). Each key
       // array is hashed structurally, matching the query-side registration.
-      const keys: ReadonlyArray<ReadonlyArray<unknown>> = [...clientKeys, ...serverKeys]
+      const keys: ReadonlyArray<ReadonlyArray<unknown>> = [...clientKeys, ...serverKeys, ...derivedKeys]
 
       if (!isReadonlyArrayNonEmpty(keys)) return Effect.void
 
       return Effect
         .andThen(
-          Effect.annotateCurrentSpan({ clientKeys, serverKeys }),
+          Effect.annotateCurrentSpan({ clientKeys, serverKeys, writeDependencies }),
           // refetch + AWAIT every live query registered under these keys, so by the time the
           // mutation resolves the affected queries are fresh.
           queryInvalidator.invalidateAndAwait(keys)
@@ -340,12 +348,17 @@ export const invalidateQueries = <RInvalidator>(
   const handle = <A, E, R>(eff: Effect.Effect<A, E, R>, input?: unknown) =>
     Effect.gen(function*() {
       const keysRef = yield* Ref.make<ReadonlyArray<InvalidationKey>>([])
+      const readsRef = yield* Ref.make<DataDependencies.DataDependencies>([])
+      const writesRef = yield* Ref.make<DataDependencies.DataDependencies>([])
+      const dependencyRecorder = DataDependencies.makeDataDependencyRecorder(readsRef, writesRef)
       const result = yield* eff.pipe(
         Effect.provideService(InvalidationKeysFromServer, makeInvalidationKeysService(keysRef)),
+        Effect.provideService(DataDependencies.DataDependencyRecorder, dependencyRecorder),
         Effect.onExit((exit) =>
           Effect.gen(function*() {
             const serverKeys = yield* Ref.get(keysRef)
-            yield* invalidateCache(input, exit, serverKeys)
+            const writeDependencies = yield* Ref.get(writesRef)
+            yield* invalidateCache(input, exit, serverKeys, writeDependencies)
           })
         )
       )
@@ -354,7 +367,8 @@ export const invalidateQueries = <RInvalidator>(
           Effect.onExit((exit) =>
             Effect.gen(function*() {
               const serverKeys = yield* Ref.get(keysRef)
-              yield* invalidateCache(input, exit, serverKeys)
+              const writeDependencies = yield* Ref.get(writesRef)
+              yield* invalidateCache(input, exit, serverKeys, writeDependencies)
             })
           )
         )
@@ -436,15 +450,20 @@ export const makeStreamMutation2 = <RInvalidator>(queryInvalidator: QueryInvalid
           // returns void to keep the server-side invalidation service effect-free.
           (key) => invCache(input, Exit.succeed(undefined), [key]) as Effect.Effect<void>
         )
+        const readsRef = yield* Ref.make<DataDependencies.DataDependencies>([])
+        const writesRef = yield* Ref.make<DataDependencies.DataDependencies>([])
+        const dependencyRecorder = DataDependencies.makeDataDependencyRecorder(readsRef, writesRef)
         const lastRef = yield* Ref.make<any>(undefined)
         return source.pipe(
           Stream.provideService(InvalidationKeysFromServer, invKeys),
+          Stream.provideService(DataDependencies.DataDependencyRecorder, dependencyRecorder),
           Stream.tap((v) => Ref.set(lastRef, v)),
           Stream.ensuring(
             Effect.gen(function*() {
               const lastValue = yield* Ref.get(lastRef)
               const serverKeys = yield* Ref.get(keysRef)
-              yield* invCache(input, Exit.succeed(lastValue), serverKeys)
+              const writeDependencies = yield* Ref.get(writesRef)
+              yield* invCache(input, Exit.succeed(lastValue), serverKeys, writeDependencies)
             })
           )
         )

--- a/packages/vue/test/dependencyInvalidation.test.ts
+++ b/packages/vue/test/dependencyInvalidation.test.ts
@@ -2,7 +2,7 @@
 import { defaultRegistry } from "@effect/atom-vue"
 import { expect, it } from "@effect/vitest"
 import { QueryClient, VueQueryPlugin } from "@tanstack/vue-query"
-import { DataDependencies, InvalidationKeysFromServer, makeQueryKey } from "effect-app/client"
+import { DataDependencies, type InvalidationKey, InvalidationKeysFromServer, makeQueryKey } from "effect-app/client"
 import * as Context from "effect-app/Context"
 import * as Effect from "effect-app/Effect"
 import * as Fiber from "effect/Fiber"
@@ -14,7 +14,7 @@ import { createApp, effectScope, ref } from "vue"
 import { awaitAtomResult, buildQueryFamily, invalidateAndAwait, makeAtomClientRuntime } from "../src/atomQuery.js"
 import { clearQueryReadDependencies, getDerivedInvalidationKeys, setQueryReadDependencies } from "../src/dependencyMetadata.js"
 import { makeTanstackQuery, makeTanstackQueryInvalidator } from "../src/internal/tanstackQuery.js"
-import { invalidateQueries } from "../src/mutate.js"
+import { invalidateQueries, type MutationOptionsBase } from "../src/mutate.js"
 
 const repo = DataDependencies.repo("FrontendRepo")
 const otherRepo = DataDependencies.repo("OtherRepo")
@@ -220,9 +220,13 @@ it("atom engine: disposing the query atom clears its recorded reads", async () =
 
 interface EngineHarness {
   readonly queryFullKey: ReadonlyArray<unknown>
+  readonly serverInvalidationKey: InvalidationKey
   readonly fetchInitial: () => Promise<unknown>
   readonly runs: () => number
-  readonly runCommand: (options: any, command: Effect.Effect<unknown, never, any>) => Promise<unknown>
+  readonly runCommand: (
+    options: MutationOptionsBase | undefined,
+    command: Effect.Effect<unknown, never>
+  ) => Promise<unknown>
   readonly dispose: () => void
 }
 
@@ -238,6 +242,7 @@ const makeTanstackHarness = (queryRepo: DataDependencies.DataDependency): Engine
   const [, , , handle] = ctx.run(() => useQuery(self as any)(ref(undefined) as any, {} as any)) as any
   return {
     queryFullKey: [...makeQueryKey(self), undefined],
+    serverInvalidationKey: makeQueryKey(self),
     fetchInitial: () => Effect.runPromise(handle.refetch()),
     runs: () => runs,
     runCommand: (options, command) =>
@@ -264,6 +269,7 @@ const makeAtomHarness = (queryRepo: DataDependencies.DataDependency): EngineHarn
   const unmount = defaultRegistry.mount(atom)
   return {
     queryFullKey: [...makeQueryKey(self), undefined],
+    serverInvalidationKey: makeQueryKey(self),
     fetchInitial: () => Effect.runPromise(awaitAtomResult(defaultRegistry, atom) as any),
     runs: () => runs,
     runCommand: (options, command) =>
@@ -285,12 +291,20 @@ const runInvalidationMatrix = (engine: string, makeHarness: (repo: DataDependenc
     const h = makeHarness(queryRepo)
     const noop = Effect.succeed(undefined)
 
-    const expectRefetch = async (label: string, options: any, command: Effect.Effect<unknown, never, any>) => {
+    const expectRefetch = async (
+      label: string,
+      options: MutationOptionsBase | undefined,
+      command: Effect.Effect<unknown, never>
+    ) => {
       const before = h.runs()
       await h.runCommand(options, command)
       expect(h.runs(), `${label} should refetch`).toBeGreaterThan(before)
     }
-    const expectNoRefetch = async (label: string, options: any, command: Effect.Effect<unknown, never, any>) => {
+    const expectNoRefetch = async (
+      label: string,
+      options: MutationOptionsBase | undefined,
+      command: Effect.Effect<unknown, never>
+    ) => {
       const before = h.runs()
       await h.runCommand(options, command)
       expect(h.runs(), `${label} must not refetch`).toBe(before)
@@ -301,13 +315,21 @@ const runInvalidationMatrix = (engine: string, makeHarness: (repo: DataDependenc
       expect(h.runs()).toBeGreaterThanOrEqual(1)
 
       // 1. write-dependency derivation: command writes the repo the query read.
-      await expectRefetch("intersecting write dep", undefined, DataDependencies.write(queryRepo).pipe(Effect.as(undefined)))
+      await expectRefetch(
+        "intersecting write dep",
+        undefined,
+        DataDependencies.write(queryRepo).pipe(Effect.as(undefined))
+      )
 
       // 2. write-dependency derivation: command writes an UNRELATED repo (same namespace).
-      await expectNoRefetch("unrelated write dep", undefined, DataDependencies.write(otherRepo).pipe(Effect.as(undefined)))
+      await expectNoRefetch(
+        "unrelated write dep",
+        undefined,
+        DataDependencies.write(otherRepo).pipe(Effect.as(undefined))
+      )
 
       // 3. explicit `queryInvalidation` config targeting the query.
-      await expectRefetch("explicit config", { queryInvalidation: () => [h.queryFullKey] }, noop)
+      await expectRefetch("explicit config", { queryInvalidation: () => [h.queryFullKey as any] }, noop)
 
       // 4. explicit config targeting an UNRELATED key.
       await expectNoRefetch("unrelated explicit config", { queryInvalidation: () => [["$NotAQuery"]] }, noop)
@@ -316,7 +338,7 @@ const runInvalidationMatrix = (engine: string, makeHarness: (repo: DataDependenc
       await expectRefetch(
         "server key",
         undefined,
-        Effect.flatMap(InvalidationKeysFromServer, (svc) => svc.add(h.queryFullKey)).pipe(Effect.as(undefined))
+        Effect.flatMap(InvalidationKeysFromServer, (svc) => svc.add(h.serverInvalidationKey)).pipe(Effect.as(undefined))
       )
 
       // 6. nothing — no config, no deps, no server keys, same namespace (no implicit invalidation).

--- a/packages/vue/test/dependencyInvalidation.test.ts
+++ b/packages/vue/test/dependencyInvalidation.test.ts
@@ -1,0 +1,330 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { defaultRegistry } from "@effect/atom-vue"
+import { expect, it } from "@effect/vitest"
+import { QueryClient, VueQueryPlugin } from "@tanstack/vue-query"
+import { DataDependencies, InvalidationKeysFromServer, makeQueryKey } from "effect-app/client"
+import * as Context from "effect-app/Context"
+import * as Effect from "effect-app/Effect"
+import * as Fiber from "effect/Fiber"
+import * as Layer from "effect/Layer"
+import * as ManagedRuntime from "effect/ManagedRuntime"
+import { TestClock } from "effect/testing"
+import * as Reactivity from "effect/unstable/reactivity/Reactivity"
+import { createApp, effectScope, ref } from "vue"
+import { awaitAtomResult, buildQueryFamily, invalidateAndAwait, makeAtomClientRuntime } from "../src/atomQuery.js"
+import { clearQueryReadDependencies, getDerivedInvalidationKeys, setQueryReadDependencies } from "../src/dependencyMetadata.js"
+import { makeTanstackQuery, makeTanstackQueryInvalidator } from "../src/internal/tanstackQuery.js"
+import { invalidateQueries } from "../src/mutate.js"
+
+const repo = DataDependencies.repo("FrontendRepo")
+const otherRepo = DataDependencies.repo("OtherRepo")
+
+// --- shared registry + derivation logic --------------------------------------------------------
+
+it("getDerivedInvalidationKeys returns keys of queries whose reads intersect the writes", () => {
+  const inventoryKey = ["$Inventory", "List", undefined]
+  const ordersKey = ["$Orders", "List", undefined]
+  setQueryReadDependencies(inventoryKey, [repo])
+  setQueryReadDependencies(ordersKey, [otherRepo])
+
+  try {
+    expect(getDerivedInvalidationKeys([repo])).toEqual([inventoryKey])
+    expect(getDerivedInvalidationKeys([repo, otherRepo])).toEqual([inventoryKey, ordersKey])
+    expect(getDerivedInvalidationKeys([])).toEqual([])
+  } finally {
+    clearQueryReadDependencies(inventoryKey)
+    clearQueryReadDependencies(ordersKey)
+  }
+})
+
+it("clearing read dependencies drops the query from derivation", () => {
+  const inventoryKey = ["$Inventory", "List", undefined]
+  setQueryReadDependencies(inventoryKey, [repo])
+  clearQueryReadDependencies(inventoryKey)
+  expect(getDerivedInvalidationKeys([repo])).toEqual([])
+})
+
+it("derivation matches on both dependency type and name (repo vs signal)", () => {
+  const key = ["$Live", "Feed", undefined]
+  setQueryReadDependencies(key, [DataDependencies.signal("Feed")])
+  try {
+    // Same name but different type (repo "Feed") must NOT intersect a signal read.
+    expect(getDerivedInvalidationKeys([DataDependencies.repo("Feed")])).toEqual([])
+    // Same type and name does intersect.
+    expect(getDerivedInvalidationKeys([DataDependencies.signal("Feed")])).toEqual([key])
+  } finally {
+    clearQueryReadDependencies(key)
+  }
+})
+
+it("derivation intersects when any one of multiple reads matches a write", () => {
+  const key = ["$Mixed", "List", undefined]
+  setQueryReadDependencies(key, [DataDependencies.repo("A"), DataDependencies.repo("B")])
+  try {
+    expect(getDerivedInvalidationKeys([DataDependencies.repo("B")])).toEqual([key])
+    expect(getDerivedInvalidationKeys([DataDependencies.repo("C")])).toEqual([])
+  } finally {
+    clearQueryReadDependencies(key)
+  }
+})
+
+it.effect("a command's write deps invalidate active queries whose recorded reads intersect", () =>
+  Effect.gen(function*() {
+    const inventoryKey = ["$Inventory", "List", undefined]
+    setQueryReadDependencies(inventoryKey, [repo])
+
+    const recorded: Array<ReadonlyArray<unknown>> = []
+    const queryInvalidator = {
+      invalidateAndAwait: (keys: ReadonlyArray<ReadonlyArray<unknown>>) =>
+        Effect.sync(() => keys.forEach((key) => recorded.push(key)))
+    }
+
+    // The command handler records a write to the same repo the query read from.
+    const mutate = invalidateQueries({ id: "Admin.Save" }, undefined, queryInvalidator)
+    const command = DataDependencies.write(repo).pipe(Effect.as(123))
+
+    const fiber = yield* Effect.forkChild(mutate(command, { id: "abc" }))
+    yield* TestClock.adjust("1 millis")
+    const result = yield* Fiber.join(fiber)
+
+    clearQueryReadDependencies(inventoryKey)
+
+    expect(result).toBe(123)
+    expect(recorded).toContainEqual(inventoryKey)
+  }))
+
+// --- atom engine: recording wires through buildQueryFamily ---------------------------------------
+
+it("atom engine: a query records its read deps so a command's writes derive it", async () => {
+  const atomRepo = DataDependencies.repo("AtomRepo")
+  const mrt = ManagedRuntime.make(Layer.empty)
+  const baseContext = mrt.runSync(Effect.context<never>())
+  const rt = makeAtomClientRuntime(
+    () => Layer.succeedContext(baseContext) as Layer.Layer<any, never, never>,
+    mrt.memoMap
+  )
+
+  let runs = 0
+  const self = {
+    id: "AtomInv.List",
+    handler: () => DataDependencies.read(atomRepo).pipe(Effect.as(++runs))
+  }
+  const family = buildQueryFamily(rt as any, self as any)
+  const atom = family(undefined)
+
+  const unmount = defaultRegistry.mount(atom)
+  try {
+    await Effect.runPromise(awaitAtomResult(defaultRegistry, atom) as any)
+    expect(runs).toBe(1)
+
+    const fullKey = [...makeQueryKey(self), undefined]
+    expect(getDerivedInvalidationKeys([atomRepo])).toContainEqual(fullKey)
+    expect(getDerivedInvalidationKeys([repo])).not.toContainEqual(fullKey)
+  } finally {
+    unmount()
+    clearQueryReadDependencies([...makeQueryKey(self), undefined])
+  }
+})
+
+// --- legacy tanstack engine: recording + cache-removal cleanup -----------------------------------
+
+const makeTanstackContext = (queryClient: QueryClient) => {
+  const app = createApp({ render: () => null })
+  app.use(VueQueryPlugin, { queryClient })
+  const scope = effectScope(true)
+  const run = <T>(fn: () => T): T => {
+    let out!: T
+    app.runWithContext(() => {
+      scope.run(() => {
+        out = fn()
+      })
+    })
+    return out
+  }
+  return { run, dispose: () => scope.stop() }
+}
+
+it("tanstack engine: a query records reads, and a command's writes refetch it", async () => {
+  const tsRepo = DataDependencies.repo("TanstackRepo")
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: Infinity, staleTime: 0 } }
+  })
+  const useQuery = makeTanstackQuery(() => Context.empty(), queryClient)
+
+  let runs = 0
+  const self = { id: "TanstackInv.List", handler: () => DataDependencies.read(tsRepo).pipe(Effect.as(++runs)) }
+  const ctx = makeTanstackContext(queryClient)
+  const [, , , handle] = ctx.run(() => useQuery(self as any)(ref(undefined) as any, {} as any)) as any
+
+  try {
+    await Effect.runPromise(handle.refetch())
+    expect(runs).toBe(1)
+
+    const fullKey = [...makeQueryKey(self), undefined]
+    const derived = getDerivedInvalidationKeys([tsRepo])
+    expect(derived).toContainEqual(fullKey)
+
+    // Invalidating those derived keys via the tanstack invalidator refetches the active query.
+    await Effect.runPromise(makeTanstackQueryInvalidator(queryClient).invalidateAndAwait(derived))
+    expect(runs).toBe(2)
+  } finally {
+    ctx.dispose()
+  }
+})
+
+it("tanstack engine: evicting a query from the cache clears its recorded reads", () => {
+  const tsRepo = DataDependencies.repo("TanstackEvictRepo")
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  // Installs the cache-removal subscription that clears the registry on eviction.
+  makeTanstackQuery(() => Context.empty(), queryClient)
+
+  const key = ["$TanstackEvict", "List", undefined]
+  const cache = queryClient.getQueryCache()
+  cache.build(queryClient, { queryKey: key, queryFn: () => Promise.resolve(1) })
+  setQueryReadDependencies(key, [tsRepo])
+  expect(getDerivedInvalidationKeys([tsRepo])).toContainEqual(key)
+
+  cache.clear()
+  expect(getDerivedInvalidationKeys([tsRepo])).not.toContainEqual(key)
+})
+
+// --- atom engine: GC finalizer clears recorded reads --------------------------------------------
+
+it("atom engine: disposing the query atom clears its recorded reads", async () => {
+  const atomRepo = DataDependencies.repo("AtomGcRepo")
+  const mrt = ManagedRuntime.make(Layer.empty)
+  const baseContext = mrt.runSync(Effect.context<never>())
+  const rt = makeAtomClientRuntime(
+    () => Layer.succeedContext(baseContext) as Layer.Layer<any, never, never>,
+    mrt.memoMap
+  )
+  const self = { id: "AtomGc.List", handler: () => DataDependencies.read(atomRepo).pipe(Effect.as(1)) }
+  const atom = buildQueryFamily(rt as any, self as any)(undefined)
+  const fullKey = [...makeQueryKey(self), undefined]
+
+  const unmount = defaultRegistry.mount(atom)
+  await Effect.runPromise(awaitAtomResult(defaultRegistry, atom) as any)
+  expect(getDerivedInvalidationKeys([atomRepo])).toContainEqual(fullKey)
+
+  // Disposing the registry runs the atom's finalizers, including `trackReadDependencies`.
+  unmount()
+  defaultRegistry.reset()
+  expect(getDerivedInvalidationKeys([atomRepo])).not.toContainEqual(fullKey)
+})
+
+// --- full engine e2e matrix: every invalidation source, on each engine ---------------------------
+//
+// For each engine, a live query records a repo read; then commands sharing the query's namespace are
+// run through the real mutate path, covering every invalidation source. The command namespace matches
+// the query's, so the "no refetch" cases also confirm there is NO implicit namespace invalidation.
+
+interface EngineHarness {
+  readonly queryFullKey: ReadonlyArray<unknown>
+  readonly fetchInitial: () => Promise<unknown>
+  readonly runs: () => number
+  readonly runCommand: (options: any, command: Effect.Effect<unknown, never, any>) => Promise<unknown>
+  readonly dispose: () => void
+}
+
+const makeTanstackHarness = (queryRepo: DataDependencies.DataDependency): EngineHarness => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: Infinity, staleTime: 0 } }
+  })
+  const useQuery = makeTanstackQuery(() => Context.empty(), queryClient)
+  const invalidator = makeTanstackQueryInvalidator(queryClient)
+  let runs = 0
+  const self = { id: "MatrixTs.List", handler: () => DataDependencies.read(queryRepo).pipe(Effect.as(++runs)) }
+  const ctx = makeTanstackContext(queryClient)
+  const [, , , handle] = ctx.run(() => useQuery(self as any)(ref(undefined) as any, {} as any)) as any
+  return {
+    queryFullKey: [...makeQueryKey(self), undefined],
+    fetchInitial: () => Effect.runPromise(handle.refetch()),
+    runs: () => runs,
+    runCommand: (options, command) =>
+      Effect.runPromise(invalidateQueries({ id: "MatrixTs.Save" }, options, invalidator)(command, { id: "x" })),
+    dispose: () => ctx.dispose()
+  }
+}
+
+const makeAtomHarness = (queryRepo: DataDependencies.DataDependency): EngineHarness => {
+  const mrt = ManagedRuntime.make(Reactivity.layer)
+  const baseContext = mrt.runSync(Effect.context<Reactivity.Reactivity>())
+  const reactivity = Context.get(baseContext, Reactivity.Reactivity)
+  const rt = makeAtomClientRuntime(
+    () => Layer.succeedContext(baseContext) as Layer.Layer<any, never, never>,
+    mrt.memoMap
+  )
+  const invalidator = {
+    invalidateAndAwait: (keys: ReadonlyArray<ReadonlyArray<unknown>>) =>
+      invalidateAndAwait(keys).pipe(Effect.provideService(Reactivity.Reactivity, reactivity))
+  }
+  let runs = 0
+  const self = { id: "MatrixAtom.List", handler: () => DataDependencies.read(queryRepo).pipe(Effect.as(++runs)) }
+  const atom = buildQueryFamily(rt as any, self as any)(undefined)
+  const unmount = defaultRegistry.mount(atom)
+  return {
+    queryFullKey: [...makeQueryKey(self), undefined],
+    fetchInitial: () => Effect.runPromise(awaitAtomResult(defaultRegistry, atom) as any),
+    runs: () => runs,
+    runCommand: (options, command) =>
+      Effect.runPromise(
+        invalidateQueries({ id: "MatrixAtom.Save" }, options, invalidator)(command, { id: "x" })
+          .pipe(Effect.andThen(awaitAtomResult(defaultRegistry, atom).pipe(Effect.exit))) as any
+      ),
+    dispose: () => {
+      unmount()
+      clearQueryReadDependencies([...makeQueryKey(self), undefined])
+    }
+  }
+}
+
+const runInvalidationMatrix = (engine: string, makeHarness: (repo: DataDependencies.DataDependency) => EngineHarness) =>
+  it(`${engine} engine e2e: invalidation source matrix`, async () => {
+    const queryRepo = DataDependencies.repo(`${engine}MatrixRepo`)
+    const otherRepo = DataDependencies.repo(`${engine}MatrixOther`)
+    const h = makeHarness(queryRepo)
+    const noop = Effect.succeed(undefined)
+
+    const expectRefetch = async (label: string, options: any, command: Effect.Effect<unknown, never, any>) => {
+      const before = h.runs()
+      await h.runCommand(options, command)
+      expect(h.runs(), `${label} should refetch`).toBeGreaterThan(before)
+    }
+    const expectNoRefetch = async (label: string, options: any, command: Effect.Effect<unknown, never, any>) => {
+      const before = h.runs()
+      await h.runCommand(options, command)
+      expect(h.runs(), `${label} must not refetch`).toBe(before)
+    }
+
+    try {
+      await h.fetchInitial()
+      expect(h.runs()).toBeGreaterThanOrEqual(1)
+
+      // 1. write-dependency derivation: command writes the repo the query read.
+      await expectRefetch("intersecting write dep", undefined, DataDependencies.write(queryRepo).pipe(Effect.as(undefined)))
+
+      // 2. write-dependency derivation: command writes an UNRELATED repo (same namespace).
+      await expectNoRefetch("unrelated write dep", undefined, DataDependencies.write(otherRepo).pipe(Effect.as(undefined)))
+
+      // 3. explicit `queryInvalidation` config targeting the query.
+      await expectRefetch("explicit config", { queryInvalidation: () => [h.queryFullKey] }, noop)
+
+      // 4. explicit config targeting an UNRELATED key.
+      await expectNoRefetch("unrelated explicit config", { queryInvalidation: () => [["$NotAQuery"]] }, noop)
+
+      // 5. server-sent invalidation key targeting the query.
+      await expectRefetch(
+        "server key",
+        undefined,
+        Effect.flatMap(InvalidationKeysFromServer, (svc) => svc.add(h.queryFullKey)).pipe(Effect.as(undefined))
+      )
+
+      // 6. nothing — no config, no deps, no server keys, same namespace (no implicit invalidation).
+      await expectNoRefetch("empty command", undefined, noop)
+    } finally {
+      h.dispose()
+    }
+  })
+
+runInvalidationMatrix("tanstack", makeTanstackHarness)
+runInvalidationMatrix("atom", makeAtomHarness)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,6 +142,49 @@ importers:
         version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(jsdom@29.1.1)(vite@8.0.15(@types/node@25.9.1)(esbuild@0.28.0)(sass@1.100.0)(terser@5.45.0)(tsx@4.22.4)(yaml@2.9.0))
     publishDirectory: .publish
 
+  packages/e2e:
+    dependencies:
+      '@effect-app/infra':
+        specifier: workspace:*
+        version: link:../infra
+      '@effect-app/vue':
+        specifier: workspace:*
+        version: link:../vue
+      effect-app:
+        specifier: workspace:*
+        version: link:../effect-app
+    devDependencies:
+      '@effect/atom-vue':
+        specifier: ^4.0.0-beta.88
+        version: 4.0.0-beta.88(effect@4.0.0-beta.88)(vue@3.5.35(typescript@6.0.3(patch_hash=6a20b8df080eb8a9c34008e1802ecfd839f4e90e07f1ee97f78694dbd95a520e)))
+      '@effect/platform-node':
+        specifier: 4.0.0-beta.88
+        version: 4.0.0-beta.88(effect@4.0.0-beta.88)(ioredis@5.9.3)
+      '@effect/vitest':
+        specifier: 4.0.0-beta.88
+        version: 4.0.0-beta.88(effect@4.0.0-beta.88)(vitest@4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(jsdom@29.1.1)(vite@8.0.15(@types/node@25.9.1)(esbuild@0.28.0)(sass@1.100.0)(terser@5.45.0)(tsx@4.22.4)(yaml@2.9.0)))
+      '@tanstack/vue-query':
+        specifier: 5.96.2
+        version: 5.96.2(vue@3.5.35(typescript@6.0.3(patch_hash=6a20b8df080eb8a9c34008e1802ecfd839f4e90e07f1ee97f78694dbd95a520e)))
+      '@types/node':
+        specifier: 25.9.1
+        version: 25.9.1
+      '@vitejs/plugin-vue':
+        specifier: ^6.0.7
+        version: 6.0.7(vite@8.0.15(@types/node@25.9.1)(esbuild@0.28.0)(sass@1.100.0)(terser@5.45.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3(patch_hash=6a20b8df080eb8a9c34008e1802ecfd839f4e90e07f1ee97f78694dbd95a520e)))
+      effect:
+        specifier: ^4.0.0-beta.88
+        version: 4.0.0-beta.88
+      typescript:
+        specifier: ~6.0.3
+        version: 6.0.3(patch_hash=6a20b8df080eb8a9c34008e1802ecfd839f4e90e07f1ee97f78694dbd95a520e)
+      vitest:
+        specifier: ^4.1.7
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(jsdom@29.1.1)(vite@8.0.15(@types/node@25.9.1)(esbuild@0.28.0)(sass@1.100.0)(terser@5.45.0)(tsx@4.22.4)(yaml@2.9.0))
+      vue:
+        specifier: ^3.5.35
+        version: 3.5.35(typescript@6.0.3(patch_hash=6a20b8df080eb8a9c34008e1802ecfd839f4e90e07f1ee97f78694dbd95a520e))
+
   packages/effect-app:
     dependencies:
       '@tsconfig/strictest':

--- a/wiki/ResourceClients.md
+++ b/wiki/ResourceClients.md
@@ -12,6 +12,8 @@ Queries are for reading data from the api. No writing/mutating allowed. Queries 
 Mutations are for writing data to the api, return values should at most include identifiers, and often `void`.
 Mutations auto invalidate Queries in their namespace, so that a Users.Index Query will be invalidated upon a Users.Delete or Update mutation.
 This only occurs within the same namespace, like "Users".
+Queries can also be invalidated automatically from data dependencies recorded at runtime: repository reads by queries are matched with repository writes by commands.
+See [Repository-derived query invalidation](./repository-derived-query-invalidation.md) for the full architecture and trade-offs.
 If you need to invalidate queries in another namespace, you can pass the following option to the Mutation constructor:
 
 ```ts

--- a/wiki/repository-derived-query-invalidation.md
+++ b/wiki/repository-derived-query-invalidation.md
@@ -1,0 +1,288 @@
+# Repository-derived query invalidation
+
+Historically, resource clients relied on manual invalidation lists:
+
+```ts
+const options = {
+  queryInvalidation: (queryKey) => [
+    { filters: { queryKey } },
+    SomeOtherQuery
+  ]
+}
+```
+
+That works, but it is easy to forget a query when a command starts touching
+another repository. The derived invalidation path records what data a query
+read and what data a command wrote, then invalidates cached queries whose
+recorded reads intersect the command writes.
+
+Manual invalidation still exists. Derived invalidation is an additional safety
+net for data dependencies that can be observed at runtime.
+
+## Mental model
+
+The unit of dependency is a `DataDependency`:
+
+```ts
+type DataDependency =
+  | { readonly type: "repo"; readonly name: string }
+  | { readonly type: "signal"; readonly name: string }
+```
+
+- `repo(name)` represents a repository namespace, usually the name passed to
+  `makeRepo(name, ...)`.
+- `signal(name)` is available for non-repository data that still needs a stable
+  invalidation topic.
+
+Each request has a `DataDependencyRecorder` in context. Code can record:
+
+```ts
+yield* DataDependencies.read(DataDependencies.repo("PickList"))
+yield* DataDependencies.write(DataDependencies.repo("PickList"))
+```
+
+Repository operations do this automatically, so most resource handlers do not
+need to call `DataDependencies.read` or `DataDependencies.write` directly.
+
+## End-to-end flow
+
+1. A query runs through the Vue query helper or RPC client.
+2. The request receives a fresh `DataDependencyRecorder`.
+3. Repository reads record `repo(<repository name>)` as a read dependency.
+4. The query result is returned with dependency metadata.
+5. The client stores the query's read dependencies next to the TanStack Query
+   cache entry.
+6. A command runs through the mutation helper or RPC client.
+7. Repository writes record `repo(<repository name>)` as a write dependency.
+8. The command response metadata carries the write dependencies back to the
+   client.
+9. Vue mutation invalidation scans the query cache and invalidates every query
+   whose recorded reads intersect the command writes.
+
+In short:
+
+```txt
+query reads RepoA       -> query cache remembers RepoA
+command writes RepoA    -> cached RepoA readers are invalidated
+command writes RepoB    -> cached RepoA readers are left alone
+```
+
+## What repositories record automatically
+
+`makeRepo` records dependencies at the repository boundary:
+
+| Repository operation | Dependency recorded |
+| -------------------- | ------------------- |
+| `all`                | read                |
+| `find`               | read                |
+| `query`              | read                |
+| `queryRaw`           | read                |
+| mapped `all`         | read                |
+| mapped `find`        | read                |
+| `saveAndPublish`     | write               |
+| `removeAndPublish`   | write               |
+| `removeById`         | write               |
+| mapped `save`        | write               |
+
+The dependency name is the repository name:
+
+```ts
+const Products = makeRepo("Product", Product, {})
+```
+
+Any query that reads `Products` records:
+
+```ts
+{ type: "repo", name: "Product" }
+```
+
+Any command that writes `Products` records the same dependency as a write.
+
+## RPC wire format
+
+The RPC layer wraps payloads internally so dependency metadata can cross the
+network without changing handler APIs.
+
+Commands still return their plain success value to callers, but the transport
+envelope includes:
+
+```ts
+{
+  invalidateQueries: InvalidationKey[],
+  dataDependencies: {
+    reads: DataDependency[],
+    writes: DataDependency[]
+  }
+}
+```
+
+Queries similarly return their plain payload to callers, while the RPC success
+schema carries:
+
+```ts
+{
+  payload: A,
+  metadata: {
+    dataDependencies: {
+      reads: DataDependency[],
+      writes: DataDependency[]
+    }
+  }
+}
+```
+
+The client unwraps these envelopes and forwards the dependency metadata into
+the local `DataDependencyRecorder`. This makes dependency propagation work for
+both direct RPC clients and the Vue query/mutation helpers.
+
+Stream commands emit dependency metadata in the same metadata chunks already
+used for server-driven invalidation keys. Writes can therefore invalidate
+queries mid-stream or when the stream completes.
+
+## Vue cache integration
+
+`makeQuery` runs each query under a fresh dependency recorder. After the handler
+returns, it stores the query's read dependencies next to matching TanStack Query
+cache entries.
+
+The implementation uses a `WeakMap<Query, DataDependencies>` rather than
+`query.meta`. TanStack Vue Query clones and reapplies observer options during
+fetching, so runtime-learned metadata written into `query.meta` can be
+overwritten by the observer's original options. The `WeakMap` is keyed by the
+actual cache entry, disappears when the query is garbage-collected, and does
+not affect TanStack's public options.
+
+`makeMutation` records command writes and combines three invalidation sources:
+
+1. client-side `queryInvalidation` options,
+2. server-provided invalidation keys,
+3. derived dependency invalidation.
+
+All targets are grouped into predicate-based `invalidateQueries` calls so the
+cache is not invalidated once per target when the options are equivalent.
+
+## Manual invalidation still matters
+
+Derived invalidation only sees what is recorded. Keep manual invalidation when:
+
+- a command changes data outside a repository,
+- a command affects an external service,
+- a query reads data that is not represented by a repository operation,
+- the relationship is semantic rather than data-access based,
+- a command should invalidate a broader UI namespace than the actual writes.
+
+Example:
+
+```ts
+const save = useMutation(SaveProduct, {
+  queryInvalidation: (queryKey) => [
+    { filters: { queryKey } },
+    DashboardSummary
+  ]
+})
+```
+
+The command will still derive repository-based invalidation. The manual
+`DashboardSummary` entry is added on top.
+
+## Recording non-repository dependencies
+
+Use `signal(name)` for data that has no repository boundary:
+
+```ts
+const ExchangeRates = DataDependencies.signal("ExchangeRates")
+
+const getPrices = Effect.fnUntraced(function*() {
+  yield* DataDependencies.read(ExchangeRates)
+  return yield* fetchPrices
+})
+
+const refreshRates = Effect.fnUntraced(function*() {
+  yield* updateRates
+  yield* DataDependencies.write(ExchangeRates)
+})
+```
+
+Any cached query that read `ExchangeRates` will be invalidated after a command
+writes `ExchangeRates`.
+
+Prefer repository dependencies when data is stored in a repository. Use signals
+for external APIs, computed projections, caches, feature flags, or other shared
+state that does not naturally pass through `makeRepo`.
+
+## Resource and operation subscriptions
+
+The important subscription is between a query cache entry and the dependencies
+it read at runtime. In practice, resources do not need a separate static
+"subscribe to repository" configuration if they actually access repositories
+through `makeRepo`.
+
+Static configuration can still be useful for virtual resources:
+
+- A query composes several external sources.
+- A command writes via a service that cannot record dependencies internally.
+- A resource's dependency is known but not visible from its implementation.
+
+In those cases, call `DataDependencies.read(signalOrRepo)` or
+`DataDependencies.write(signalOrRepo)` in the handler or service method. That
+keeps the dependency close to the real boundary instead of maintaining a
+separate invalidation list beside the resource declaration.
+
+## Precision and trade-offs
+
+Repository dependencies are intentionally repository-level, not row-level.
+
+If a query reads one `Product`, and a command writes a different `Product`, the
+query is invalidated because both depend on `repo("Product")`. This is less
+precise than row-level invalidation, but it is:
+
+- easy to derive reliably,
+- stable across query shapes,
+- hard to forget,
+- compatible with existing manual invalidation for broader or special cases.
+
+Row-level dependencies can be introduced later by adding another dependency
+shape, for example `{ type: "repo-item", name, id }`, but repository-level
+tracking gives most of the maintainability win without making every query key
+encode storage details.
+
+## Where the pieces live
+
+- `packages/effect-app/src/DataDependencies.ts`
+  - dependency schemas,
+  - recorder service,
+  - helpers for `repo`, `signal`, `read`, `write`, and `intersects`.
+- `packages/effect-app/src/Model/Repository/internal/internal.ts`
+  - automatic repository read/write recording.
+- `packages/effect-app/src/rpc/Invalidation.ts`
+  - metadata schemas for command/query/stream envelopes.
+- `packages/infra/src/routing.ts`
+  - per-request recorder wiring on the server.
+- `packages/effect-app/src/client/apiClientFactory.ts`
+  - client unwrapping and metadata forwarding.
+- `packages/vue/src/query.ts`
+  - query read dependency capture.
+- `packages/vue/src/dependencyMetadata.ts`
+  - WeakMap storage for TanStack Query cache entries.
+- `packages/vue/src/mutate.ts`
+  - derived invalidation from command writes.
+
+## Test coverage
+
+The main coverage is:
+
+- `packages/infra/test/repository-ext.test.ts`
+  - repository operations record expected reads and writes.
+- `packages/infra/test/rpc-e2e-invalidation.test.ts`
+  - dependency metadata survives the real HTTP/RPC client and server path.
+- `packages/vue/test/dependencyInvalidation.test.ts`
+  - Vue queries that recorded reads are invalidated when a mutation writes an
+    intersecting dependency.
+
+Useful focused commands:
+
+```sh
+pnpm --filter @effect-app/infra test -- rpc-e2e-invalidation.test.ts repository-ext.test.ts --runInBand
+pnpm --filter @effect-app/vue test -- dependencyInvalidation.test.ts --runInBand
+pnpm check
+```


### PR DESCRIPTION
## Summary

Forks #779 (derive Vue Query invalidation from repository read/write dependencies) and **rebases it onto current `main`**, adapting the Vue-side changes to the **new effect-atom query engine** that replaced `@tanstack/vue-query` since #779 was branched — while keeping the feature working on the **legacy tanstack engine**, which is still the default (`legacyQueryEngine: "tanstack"`).

Supersedes #779 (which targets an older `main`).

### Carried over from #779 (rebased)
- `effect-app/DataDependencies` — request-scoped read/write dependency recorder + `intersects` helper
- Repository internal records reads (`all`/`find`/`query`/`queryRaw`/mapped) and writes (`save`/`remove*`)
- RPC: query & command responses carry `dataDependencies` metadata (`routing.ts`, `apiClientFactory.ts`, `rpc/Invalidation.ts`)

### Adapted for the dual query engine
- `dependencyMetadata.ts`: the former `WeakMap<tanstack Query, reads>` is replaced by an engine-agnostic reactivity-key registry — `setQueryReadDependencies(fullKey, reads)` / `clearQueryReadDependencies(fullKey)` / `getDerivedInvalidationKeys(writes)`. Both engines register reads under the same structural `[...queryKey, input]` key, so derivation and `combineQueryInvalidators` dispatch to both.
- **Atom engine** (`atomQuery.ts` `buildQueryFamily`): provides the recorder around the query handler, stores recorded reads under the atom's full reactivity key, and a `trackReadDependencies` finalizer clears them on atom GC (mirrors `trackByKeys`).
- **Legacy tanstack engine** (`internal/tanstackQuery.ts` `makeTanstackQuery`): provides the recorder in the `queryFn`, stores reads under the tanstack `queryKey`, and a one-time `QueryCache` `removed` subscription clears them on eviction.
- `mutate.ts`: derived invalidation contributes **reactivity keys** to `queryInvalidator.invalidateAndAwait(...)` (via `getDerivedInvalidationKeys`) instead of building tanstack `QueryFilters`.
- Infra e2e test handlers `Effect.orDie` the repo error channel to satisfy the current `Req.Query` default error type.

### Tests (`packages/vue/test/dependencyInvalidation.test.ts`)
- Shared registry + derivation unit tests, and a command→query derivation test through `invalidateQueries`.
- **Atom engine**: a query built via `buildQueryFamily` records its reads → a command's writes derive its key.
- **Tanstack engine**: a query records reads → invalidating the derived keys via `makeTanstackQueryInvalidator` refetches it (runs 1→2); cache eviction clears the recorded reads.

## Validation
- `pnpm --filter @effect-app/vue --filter effect-app --filter @effect-app/infra check`
- `pnpm --filter @effect-app/vue exec vitest run` (all vue suites)
- `pnpm --filter @effect-app/infra exec vitest run rpc-e2e-invalidation repository-ext`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
