### PR TITLE
fix(client): remove automatic Request.make usage

### DIFF
--- a/packages/effect-app/src/client/apiClientFactory.ts
+++ b/packages/effect-app/src/client/apiClientFactory.ts
@@ -301,7 +301,7 @@ const makeApiClientFactory = Effect
               mr.contextEffect.pipe(
                 Effect.flatMap((svcs) => {
                   const rpcEffect = TheClient
-                    .use((client) => (client as any)[requestAttr]!(Request.make(input)) as Effect.Effect<any, any>)
+                    .use((client) => (client as any)[requestAttr]!(input) as Effect.Effect<any, any>)
                     .pipe(
                       // local: true → isolate to this RPC call. `layers` is pure today
                       // (RequestName + caller-supplied requestLevelLayers), but the
@@ -324,7 +324,7 @@ const makeApiClientFactory = Effect
                     TheClient
                       .useSync((client) => {
                         const rpcStream = (client as any)[requestAttr]!(
-                          Request.make(input)
+                          input
                         ) as Stream.Stream<any, any, any>
                         return rpcStream.pipe(
                           // Collect server invalidation keys from the "done" chunk, then discard it.

--- a/packages/effect-app/src/client/clientFor.ts
+++ b/packages/effect-app/src/client/clientFor.ts
@@ -133,8 +133,8 @@ export type RequestStreamHandler<A, E, R, Request extends Req, Id extends string
   RequestStreamHandlerWithInput<void, A, E, R, Request, Id, Final>
 
 // make sure this is exported or d.ts of apiClientFactory breaks?!
-export type RequestInputFromMake<I extends { readonly make: (...args: any[]) => any }> = Parameters<I["make"]> extends
-  [] ? void : Parameters<I["make"]>[0]
+export type RequestInputFromMake<I extends { readonly "~type.make.in": unknown; readonly fields: S.Struct.Fields }> =
+  I["~type.make.in"]
 
 // Has no input only when the request schema declares no payload fields (the auto-added
 // `_tag` field is ignored). Any payload fields (even all-optional) produce a function handler.
@@ -142,13 +142,14 @@ type HasNoFields<I> = I extends { readonly fields: infer F extends S.Struct.Fiel
   ? [Exclude<keyof F, "_tag">] extends [never] ? true : false
   : false
 
-type RequestInput<I extends { readonly make: (...args: any[]) => any }> = Parameters<I["make"]>[0]
+type RequestInput<I extends { readonly "~type.make.in": unknown; readonly fields: S.Struct.Fields }> =
+  I["~type.make.in"]
 
 /**
  * Caller-facing input type for a request. `void` when the request schema has no fields;
  * otherwise `make`'s first param type.
  */
-export type HandlerInput<I extends { readonly make: (...args: any[]) => any }> = HasNoFields<I> extends true ? void
+export type HandlerInput<I extends { readonly fields: S.Struct.Fields }> = HasNoFields<I> extends true ? void
   : RequestInput<I>
 
 /** Extracts the final-value type from a stream request. Defaults to the success type when no `final` schema is set. */

--- a/packages/vue/src/makeClient.ts
+++ b/packages/vue/src/makeClient.ts
@@ -1268,6 +1268,6 @@ export interface CommandBase<I = void, A = void, RA = unknown, RE = unknown> {
 
 export interface EffectCommand<I = void, A = unknown, E = unknown> extends CommandBase<I, Fiber<A, E>, A, E> {}
 
-export interface CommandFromRequest<I extends { readonly make: (...args: any[]) => any }, A = unknown, E = unknown>
+export interface CommandFromRequest<I extends { readonly fields: S.Struct.Fields }, A = unknown, E = unknown>
   extends EffectCommand<HandlerInput<I>, A, E>
 {}


### PR DESCRIPTION
## Why
Remove implicit use of request constructors at the client boundary.

## What changed
- Stop invoking `Request.make(...)` in API client runtime calls for both effect and stream requests.
- Derive handler input types from request schema metadata instead of the `make` function signature.
- Keep no-input handling based on request fields (`_tag`-free)
  while making command-type utilities consume schema-based input typing.

## Validation
- Not run (not requested): checks were not executed for this PR creation flow.
