### PR TITLE
Tighten computed projection typing

### DIFF
--- a/.changeset/project-computed-type-safety.md
+++ b/.changeset/project-computed-type-safety.md
@@ -1,0 +1,5 @@
+---
+"effect-app": patch
+---
+
+Tighten projectComputed projection schema typing against encoded repo fields and computed output types.

--- a/packages/effect-app/src/Model/query/dsl.ts
+++ b/packages/effect-app/src/Model/query/dsl.ts
@@ -55,10 +55,14 @@ type ExtractExclusiveness<T> = T extends QueryTogether<any, any, infer Exclusive
 type ExtractFieldValuesRefined<T> = T extends QueryTogether<any, infer TFieldValuesRefined, any, any, any, any, any>
   ? TFieldValuesRefined
   : never
+type ProjectableField<I, From, K extends PropertyKey> = K extends keyof From ? From[K] extends I ? I
+  : I extends From[K] ? I
+  : never
+  : never
 type ProjectableEncoded<I, From> = I extends FieldValues ? {
     [K in keyof I]: K extends keyof (
       I extends { readonly _tag: infer Tag } ? Extract<From, { readonly _tag: Tag }> : From
-    ) ? I[K]
+    ) ? ProjectableField<I[K], I extends { readonly _tag: infer Tag } ? Extract<From, { readonly _tag: Tag }> : From, K>
       : never
   }
   : never
@@ -122,74 +126,105 @@ export type ComputedProjectionMathExpression =
     readonly right: ComputedProjectionMathExpression
   }
 
-export type ComputedProjectionExpression =
-  | {
-    readonly _tag: "relation-count"
-    readonly path: string
-    readonly operation?: ComputedProjectionOperation
+declare const ComputedProjectionExpressionTypeId: unique symbol
+
+type ComputedProjectionOutput<A> = {
+  readonly [ComputedProjectionExpressionTypeId]?: Covariant<A>
+}
+
+export type ComputedProjectionExpression<A = unknown> =
+  & ComputedProjectionOutput<A>
+  & (
+    | {
+      readonly _tag: "relation-count"
+      readonly path: string
+      readonly operation?: ComputedProjectionOperation
+    }
+    | {
+      readonly _tag: "relation-any"
+      readonly path: string
+      readonly operation?: ComputedProjectionOperation
+    }
+    | {
+      readonly _tag: "relation-every"
+      readonly path: string
+      readonly operation: ComputedProjectionOperation
+    }
+    | {
+      readonly _tag: "relation-distinct-count"
+      readonly path: string
+      readonly field: string
+      readonly operation?: ComputedProjectionOperation
+    }
+    | {
+      readonly _tag: "relation-sum"
+      readonly path: string
+      readonly field: string
+      readonly operation?: ComputedProjectionOperation
+    }
+    | {
+      readonly _tag: "relation-sum-expr"
+      readonly path: string
+      readonly expression: ComputedProjectionMathExpression
+      readonly operation?: ComputedProjectionOperation
+    }
+    | {
+      readonly _tag: "relation-sum-expr-by"
+      readonly path: string
+      readonly expression: ComputedProjectionMathExpression
+      readonly unit: string
+      readonly operation?: ComputedProjectionOperation
+    }
+    | {
+      readonly _tag: "relation-sum-expr-normalized"
+      readonly path: string
+      readonly expression: ComputedProjectionMathExpression
+      readonly unit: string
+      readonly toBase: string
+      readonly factors: Readonly<Record<string, number>>
+      readonly operation?: ComputedProjectionOperation
+    }
+    | {
+      readonly _tag: "relation-collect"
+      readonly path: string
+      readonly field: string
+      readonly distinct: boolean
+      readonly operation?: ComputedProjectionOperation
+    }
+    | {
+      readonly _tag: "relation-collect-fields"
+      readonly path: string
+      readonly fields: readonly string[]
+      readonly distinct: boolean
+      readonly operation?: ComputedProjectionOperation
+    }
+    | {
+      readonly _tag: "relation-length"
+      readonly path: string
+    }
+  )
+
+type ComputedProjectionOutputOf<T> = T extends ComputedProjectionExpression<infer A> ? A : never
+
+type ComputedProjectionShape<M extends ComputedProjectionMap> = {
+  readonly [K in keyof M]: ComputedProjectionOutputOf<M[K]>
+}
+
+type ProjectableComputedEncoded<I, From, M extends ComputedProjectionMap> = I extends FieldValues ? {
+    [K in keyof I]: K extends keyof M ? ComputedProjectionShape<M>[K]
+      : K extends keyof (
+        I extends { readonly _tag: infer Tag } ? Extract<From, { readonly _tag: Tag }> : From
+      ) ? ProjectableField<
+          I[K],
+          I extends { readonly _tag: infer Tag } ? Extract<From, { readonly _tag: Tag }> : From,
+          K
+        >
+      : never
   }
-  | {
-    readonly _tag: "relation-any"
-    readonly path: string
-    readonly operation?: ComputedProjectionOperation
-  }
-  | {
-    readonly _tag: "relation-every"
-    readonly path: string
-    readonly operation: ComputedProjectionOperation
-  }
-  | {
-    readonly _tag: "relation-distinct-count"
-    readonly path: string
-    readonly field: string
-    readonly operation?: ComputedProjectionOperation
-  }
-  | {
-    readonly _tag: "relation-sum"
-    readonly path: string
-    readonly field: string
-    readonly operation?: ComputedProjectionOperation
-  }
-  | {
-    readonly _tag: "relation-sum-expr"
-    readonly path: string
-    readonly expression: ComputedProjectionMathExpression
-    readonly operation?: ComputedProjectionOperation
-  }
-  | {
-    readonly _tag: "relation-sum-expr-by"
-    readonly path: string
-    readonly expression: ComputedProjectionMathExpression
-    readonly unit: string
-    readonly operation?: ComputedProjectionOperation
-  }
-  | {
-    readonly _tag: "relation-sum-expr-normalized"
-    readonly path: string
-    readonly expression: ComputedProjectionMathExpression
-    readonly unit: string
-    readonly toBase: string
-    readonly factors: Readonly<Record<string, number>>
-    readonly operation?: ComputedProjectionOperation
-  }
-  | {
-    readonly _tag: "relation-collect"
-    readonly path: string
-    readonly field: string
-    readonly distinct: boolean
-    readonly operation?: ComputedProjectionOperation
-  }
-  | {
-    readonly _tag: "relation-collect-fields"
-    readonly path: string
-    readonly fields: readonly string[]
-    readonly distinct: boolean
-    readonly operation?: ComputedProjectionOperation
-  }
-  | {
-    readonly _tag: "relation-length"
-    readonly path: string
-  }
+  : never
+
+type NoExtraComputedKeys<M extends ComputedProjectionMap, I> = Exclude<keyof M, keyof I> extends never ? unknown
+  : never
 
 /**
  * An expression that aggregates values across documents (for use with {@link aggregate}).
@@ -629,11 +664,11 @@ export const relation = <
       right: ComputedProjectionMathExpression
     ): ComputedProjectionMathExpression => ({ _tag: "mul", left, right })
   },
-  length: (): ComputedProjectionExpression => ({
+  length: (): ComputedProjectionExpression<number> => ({
     _tag: "relation-length",
     path: path as string
   }),
-  count: (operation?: ComputedProjectionOperation): ComputedProjectionExpression =>
+  count: (operation?: ComputedProjectionOperation): ComputedProjectionExpression<number> =>
     operation
       ? {
         _tag: "relation-count",
@@ -644,7 +679,7 @@ export const relation = <
         _tag: "relation-count",
         path: path as string
       },
-  any: (operation?: ComputedProjectionOperation): ComputedProjectionExpression =>
+  any: (operation?: ComputedProjectionOperation): ComputedProjectionExpression<boolean> =>
     operation
       ? {
         _tag: "relation-any",
@@ -655,15 +690,15 @@ export const relation = <
         _tag: "relation-any",
         path: path as string
       },
-  every: (operation: ComputedProjectionOperation): ComputedProjectionExpression => ({
+  every: (operation: ComputedProjectionOperation): ComputedProjectionExpression<boolean> => ({
     _tag: "relation-every",
     path: path as string,
     operation
   }),
-  distinctCount: (
-    field: FieldPath<RelationElement<TFieldValues, P>>,
+  distinctCount: <const F extends FieldPath<RelationElement<TFieldValues, P>>>(
+    field: F,
     operation?: ComputedProjectionOperation
-  ): ComputedProjectionExpression =>
+  ): ComputedProjectionExpression<number> =>
     operation
       ? {
         _tag: "relation-distinct-count",
@@ -676,10 +711,10 @@ export const relation = <
         path: path as string,
         field: field as string
       },
-  sum: (
-    field: FieldPath<RelationElement<TFieldValues, P>>,
+  sum: <const F extends FieldPath<RelationElement<TFieldValues, P>>>(
+    field: F,
     operation?: ComputedProjectionOperation
-  ): ComputedProjectionExpression =>
+  ): ComputedProjectionExpression<number> =>
     operation
       ? {
         _tag: "relation-sum",
@@ -695,7 +730,7 @@ export const relation = <
   sumExpr: (
     expression: ComputedProjectionMathExpression,
     operation?: ComputedProjectionOperation
-  ): ComputedProjectionExpression =>
+  ): ComputedProjectionExpression<number> =>
     operation
       ? {
         _tag: "relation-sum-expr",
@@ -708,11 +743,13 @@ export const relation = <
         path: path as string,
         expression
       },
-  sumExprBy: (
+  sumExprBy: <const F extends FieldPath<RelationElement<TFieldValues, P>>>(
     expression: ComputedProjectionMathExpression,
-    options: { unit: FieldPath<RelationElement<TFieldValues, P>> },
+    options: { unit: F },
     operation?: ComputedProjectionOperation
-  ): ComputedProjectionExpression =>
+  ): ComputedProjectionExpression<
+    ReadonlyArray<{ readonly unit: FieldPathValue<RelationElement<TFieldValues, P>, F>; readonly total: number }>
+  > =>
     operation
       ? {
         _tag: "relation-sum-expr-by",
@@ -735,7 +772,7 @@ export const relation = <
       factors: Readonly<Record<string, number>>
     },
     operation?: ComputedProjectionOperation
-  ): ComputedProjectionExpression =>
+  ): ComputedProjectionExpression<number> =>
     operation
       ? {
         _tag: "relation-sum-expr-normalized",
@@ -754,10 +791,10 @@ export const relation = <
         toBase: options.toBase,
         factors: options.factors
       },
-  collect: (
-    field: FieldPath<RelationElement<TFieldValues, P>>,
+  collect: <const F extends FieldPath<RelationElement<TFieldValues, P>>>(
+    field: F,
     operation?: ComputedProjectionOperation
-  ): ComputedProjectionExpression =>
+  ): ComputedProjectionExpression<ReadonlyArray<FieldPathValue<RelationElement<TFieldValues, P>, F>>> =>
     operation
       ? {
         _tag: "relation-collect",
@@ -772,10 +809,10 @@ export const relation = <
         field: field as string,
         distinct: false
       },
-  collectDistinct: (
-    field: FieldPath<RelationElement<TFieldValues, P>>,
+  collectDistinct: <const F extends FieldPath<RelationElement<TFieldValues, P>>>(
+    field: F,
     operation?: ComputedProjectionOperation
-  ): ComputedProjectionExpression =>
+  ): ComputedProjectionExpression<ReadonlyArray<FieldPathValue<RelationElement<TFieldValues, P>, F>>> =>
     operation
       ? {
         _tag: "relation-collect",
@@ -790,10 +827,12 @@ export const relation = <
         field: field as string,
         distinct: true
       },
-  collectFields: (
-    fields: readonly FieldPath<RelationElement<TFieldValues, P>>[],
+  collectFields: <const F extends readonly FieldPath<RelationElement<TFieldValues, P>>[]>(
+    fields: F,
     operation?: ComputedProjectionOperation
-  ): ComputedProjectionExpression =>
+  ): ComputedProjectionExpression<
+    ReadonlyArray<FieldPathValue<RelationElement<TFieldValues, P>, F[number]>>
+  > =>
     operation
       ? {
         _tag: "relation-collect-fields",
@@ -808,10 +847,12 @@ export const relation = <
         fields: fields as readonly string[],
         distinct: false
       },
-  collectDistinctFields: (
-    fields: readonly FieldPath<RelationElement<TFieldValues, P>>[],
+  collectDistinctFields: <const F extends readonly FieldPath<RelationElement<TFieldValues, P>>[]>(
+    fields: F,
     operation?: ComputedProjectionOperation
-  ): ComputedProjectionExpression =>
+  ): ComputedProjectionExpression<
+    ReadonlyArray<FieldPathValue<RelationElement<TFieldValues, P>, F[number]>>
+  > =>
     operation
       ? {
         _tag: "relation-collect-fields",
@@ -865,13 +906,16 @@ const makeComputedHelpers = <TFieldValues extends FieldValues>(): ComputedHelper
 export const projectComputed: {
   <
     Q extends Query<any> | QueryWhere<any, any, any> | QueryEnd<any, "one" | "many", any>,
-    I extends Record<string, unknown>,
+    I extends FieldValues,
+    M extends ComputedProjectionMap,
     A = ExtractFieldValuesRefined<Q>,
     R = never,
     E extends boolean = ExtractExclusiveness<Q>
   >(
-    schema: S.Codec<Option.Option<A>, I, R>,
-    build: (helpers: ComputedHelpers<ExtractFieldValuesRefined<Q>>) => ComputedProjectionMap,
+    schema:
+      & S.Codec<Option.Option<A>, I, R>
+      & S.Codec<Option.Option<A>, ProjectableComputedEncoded<I, ExtractFieldValuesRefined<Q>, M>, R>,
+    build: (helpers: ComputedHelpers<ExtractFieldValuesRefined<Q>>) => M & NoExtraComputedKeys<M, I>,
     mode: "collect"
   ): (
     current: Q
@@ -879,13 +923,16 @@ export const projectComputed: {
 
   <
     Q extends Query<any> | QueryWhere<any, any, any> | QueryEnd<any, "one" | "many", any>,
-    I extends Record<string, unknown>,
+    I extends FieldValues,
+    M extends ComputedProjectionMap,
     A = ExtractFieldValuesRefined<Q>,
     R = never,
     E extends boolean = ExtractExclusiveness<Q>
   >(
-    schema: S.Codec<A, I, R>,
-    build: (helpers: ComputedHelpers<ExtractFieldValuesRefined<Q>>) => ComputedProjectionMap,
+    schema:
+      & S.Codec<A, I, R>
+      & S.Codec<A, ProjectableComputedEncoded<I, ExtractFieldValuesRefined<Q>, M>, R>,
+    build: (helpers: ComputedHelpers<ExtractFieldValuesRefined<Q>>) => M & NoExtraComputedKeys<M, I>,
     mode?: "project"
   ): (
     current: Q
@@ -893,13 +940,16 @@ export const projectComputed: {
 
   <
     Q extends Query<any> | QueryWhere<any, any, any> | QueryEnd<any, "one" | "many", any>,
-    I extends Record<string, unknown>,
+    I extends FieldValues,
+    M extends ComputedProjectionMap,
     A = ExtractFieldValuesRefined<Q>,
     R = never,
     E extends boolean = ExtractExclusiveness<Q>
   >(
-    schema: S.Codec<Option.Option<A>, I, R>,
-    computedProjection: ComputedProjectionMap,
+    schema:
+      & S.Codec<Option.Option<A>, I, R>
+      & S.Codec<Option.Option<A>, ProjectableComputedEncoded<I, ExtractFieldValuesRefined<Q>, M>, R>,
+    computedProjection: M & NoExtraComputedKeys<M, I>,
     mode: "collect"
   ): (
     current: Q
@@ -907,13 +957,16 @@ export const projectComputed: {
 
   <
     Q extends Query<any> | QueryWhere<any, any, any> | QueryEnd<any, "one" | "many", any>,
-    I extends Record<string, unknown>,
+    I extends FieldValues,
+    M extends ComputedProjectionMap,
     A = ExtractFieldValuesRefined<Q>,
     R = never,
     E extends boolean = ExtractExclusiveness<Q>
   >(
-    schema: S.Codec<A, I, R>,
-    computedProjection: ComputedProjectionMap,
+    schema:
+      & S.Codec<A, I, R>
+      & S.Codec<A, ProjectableComputedEncoded<I, ExtractFieldValuesRefined<Q>, M>, R>,
+    computedProjection: M & NoExtraComputedKeys<M, I>,
     mode?: "project"
   ): (
     current: Q

--- a/packages/effect-app/src/Model/query/dsl.ts
+++ b/packages/effect-app/src/Model/query/dsl.ts
@@ -223,7 +223,9 @@ type ProjectableComputedEncoded<I, From, M extends ComputedProjectionMap> = I ex
   }
   : never
 
-type NoExtraComputedKeys<M extends ComputedProjectionMap, I> = Exclude<keyof M, keyof I> extends never ? unknown
+type KeysOfUnion<T> = T extends T ? keyof T : never
+
+type NoExtraComputedKeys<M extends ComputedProjectionMap, I> = Exclude<keyof M, KeysOfUnion<I>> extends never ? unknown
   : never
 
 /**

--- a/packages/effect-app/src/Model/query/new-kid-interpreter.ts
+++ b/packages/effect-app/src/Model/query/new-kid-interpreter.ts
@@ -357,6 +357,21 @@ const walkTransformation = (t: S.AST.AST): S.AST.AST => {
   return t
 }
 
+const objectAsts = (ast: S.AST.AST): readonly S.AST.Objects[] => {
+  const t = walkTransformation(ast)
+  if (S.AST.isObjects(t)) {
+    return [t]
+  }
+  if (S.AST.isUnion(t)) {
+    return t.types.flatMap(objectAsts)
+  }
+  return []
+}
+
+const objectKeys = (ast: S.AST.AST): readonly string[] => [
+  ...new Set(objectAsts(ast).flatMap((object) => object.propertySignatures.map((_) => _.name as string)))
+]
+
 export const toFilter = <
   TFieldValues extends FieldValues,
   A,
@@ -399,9 +414,10 @@ export const toFilter = <
   // TODO: support more complex (nested) schemas?
   if (schema) {
     const t = walkTransformation(SchemaAST.toEncoded(schema.ast))
-    if (S.AST.isObjects(t)) {
-      select = t.propertySignatures.map((_) => _.name as string)
-      for (const prop of t.propertySignatures) {
+    const objects = [...objectAsts(t)]
+    if (Array.isArrayNonEmpty(objects)) {
+      select = [...objectKeys(t)]
+      for (const prop of objects.flatMap((_) => _.propertySignatures)) {
         if (S.AST.isArrays(prop.type)) {
           // make sure we only select when there are actually type literals in the tuple...
           // otherwise we might be dealing with strings etc.
@@ -411,8 +427,7 @@ export const toFilter = <
             subKeys: Array.flatMap(
               prop.type.rest,
               (x) => {
-                const t = walkTransformation(x)
-                return S.AST.isObjects(t) ? t.propertySignatures.map((y) => y.name as string) : []
+                return objectKeys(x)
               }
             )
           }
@@ -443,10 +458,7 @@ export const toFilter = <
       return [] as string[]
     }
     const encoded = walkTransformation(SchemaAST.toEncoded(baseSchema.ast))
-    if (!S.AST.isObjects(encoded)) {
-      return [] as string[]
-    }
-    const encodedKeys = encoded.propertySignatures.map((_) => _.name as string)
+    const encodedKeys = objectKeys(encoded)
     return schemaKeys.filter((key) => !encodedKeys.includes(key))
   })()
   const missingComputedKeys = nonEncodedSchemaKeys.filter((key) => !(computed && key in computed))

--- a/packages/infra/test/query.test.ts
+++ b/packages/infra/test/query.test.ts
@@ -695,6 +695,52 @@ it("projectComputed constrains projection schema to encoded repo fields and comp
   )
 })
 
+it("projectComputed supports union projection schemas", () => {
+  const baseSchema = S.Union([
+    S.Struct({
+      _tag: S.Literal("open"),
+      id: S.String,
+      items: S.Array(S.Struct({ articleId: S.String, weight: S.Number }))
+    }),
+    S.Struct({
+      _tag: S.Literal("closed"),
+      id: S.String,
+      closedAt: S.String
+    })
+  ])
+  type Encoded = S.Codec.Encoded<typeof baseSchema>
+  const query = make<Encoded>().pipe(
+    projectComputed(
+      S.Union([
+        S.Struct({
+          _tag: S.Literal("open"),
+          id: S.String,
+          articleCount: S.Number,
+          weight: S.Number,
+          articleIds: S.Array(S.String)
+        }),
+        S.Struct({
+          _tag: S.Literal("closed"),
+          id: S.String,
+          closedAt: S.String
+        })
+      ]),
+      computed({
+        articleCount: relation<Encoded>("items").count(),
+        weight: relation<Encoded>("items").sum("weight"),
+        articleIds: relation<Encoded>("items").collect("articleId")
+      })
+    )
+  )
+
+  const interpreted = toFilter(query, baseSchema)
+  expect(interpreted.computed && Object.keys(interpreted.computed).toSorted()).toEqual([
+    "articleCount",
+    "articleIds",
+    "weight"
+  ])
+})
+
 it("projection schema with computed fields fails without computed map", () => {
   const baseSchema = S.Struct({
     id: S.String,

--- a/packages/infra/test/query.test.ts
+++ b/packages/infra/test/query.test.ts
@@ -629,6 +629,7 @@ it("projectComputed validates extra computed keys", () => {
   const query = make<S.Codec.Encoded<typeof baseSchema>>().pipe(
     projectComputed(
       S.Struct({ id: S.String }),
+      // @ts-expect-error extra computed keys are rejected statically; keep runtime guard covered
       computed({
         pickedCount: relation<S.Codec.Encoded<typeof baseSchema>>("items").count()
       })
@@ -637,12 +638,70 @@ it("projectComputed validates extra computed keys", () => {
   expect(() => toFilter(query, baseSchema)).toThrowError("Computed projection keys must exist in projection schema")
 })
 
+it("projectComputed constrains projection schema to encoded repo fields and computed outputs", () => {
+  const baseSchema = S.Struct({
+    id: S.String,
+    name: S.String,
+    items: S.Array(S.Struct({ articleId: S.String, weight: S.Number }))
+  })
+  type Encoded = S.Codec.Encoded<typeof baseSchema>
+
+  make<Encoded>().pipe(
+    projectComputed(
+      S.Struct({
+        id: S.String,
+        itemCount: S.Number,
+        hasItems: S.Boolean,
+        articleIds: S.Array(S.String)
+      }),
+      ({ relation }) => ({
+        itemCount: relation("items").count(),
+        hasItems: relation("items").any(),
+        articleIds: relation("items").collect("articleId")
+      })
+    )
+  )
+
+  make<Encoded>().pipe(
+    // @ts-expect-error missingField is neither an encoded repo field nor a computed projection
+    projectComputed(S.Struct({ missingField: S.String }), computed({}))
+  )
+
+  make<Encoded>().pipe(
+    projectComputed(
+      // @ts-expect-error repo field name is encoded as string
+      S.Struct({ name: S.Number }),
+      computed({})
+    )
+  )
+
+  make<Encoded>().pipe(
+    projectComputed(
+      // @ts-expect-error itemCount computes a number
+      S.Struct({ itemCount: S.String }),
+      computed({ itemCount: relation<Encoded>("items").count() })
+    )
+  )
+
+  make<Encoded>().pipe(
+    projectComputed(
+      S.Struct({ itemCount: S.Number }),
+      // @ts-expect-error extra computed keys must exist in the projection schema
+      computed({
+        itemCount: relation<Encoded>("items").count(),
+        extraCount: relation<Encoded>("items").count()
+      })
+    )
+  )
+})
+
 it("projection schema with computed fields fails without computed map", () => {
   const baseSchema = S.Struct({
     id: S.String,
     items: S.Array(S.Struct({ value: S.Number }))
   })
   const query = make<S.Codec.Encoded<typeof baseSchema>>().pipe(
+    // @ts-expect-error missing computed keys are rejected statically; keep runtime guard covered
     projectComputed(S.Struct({ pickedCount: S.NonNegativeInt }), computed({}))
   )
   expect(() => toFilter(query, baseSchema)).toThrowError("Missing computed projections for schema keys")
@@ -1764,6 +1823,7 @@ it("memFilter: rejects extra computed keys not in projection schema", () => {
   const q = make<ComputedBase>().pipe(
     projectComputed(
       S.Struct({ id: S.String }),
+      // @ts-expect-error extra computed keys are rejected statically; keep runtime guard covered
       computed({
         bogus: relation<ComputedBase>("items").count(where("tag", "a"))
       })


### PR DESCRIPTION
## Summary
- Tighten `projectComputed` typing so projection schemas must match encoded repo fields and computed output types.
- Add typed computed projection outputs for relation helpers like `count`, `any`, `collect`, and `collectFields`.
- Support union projection schemas by collecting keys from every encoded object variant, including computed keys present on only one variant.
- Keep runtime validation for missing or extra computed keys, with invalid construction sites now locked by `@ts-expect-error`.

## Testing
- `pnpm lint-fix`
- `pnpm check`