### PR TITLE
feat(repository): replace codec spans with phase timings

### DIFF
--- a/.changeset/calm-clocks-observe.md
+++ b/.changeset/calm-clocks-observe.md
@@ -1,0 +1,6 @@
+---
+"effect-app": patch
+"@effect-app/infra": patch
+---
+
+Replace repository codec child spans with parent-span timing attributes and bounded metrics, and record database operation timing for instrumented stores.

--- a/packages/effect-app/src/Model/Repository/internal/internal.ts
+++ b/packages/effect-app/src/Model/Repository/internal/internal.ts
@@ -4,6 +4,7 @@ import * as Equivalence from "effect/Equivalence"
 import { flow, pipe } from "effect/Function"
 import * as HashMap from "effect/HashMap"
 import * as HashSet from "effect/HashSet"
+import * as Metric from "effect/Metric"
 import * as Pipeable from "effect/Pipeable"
 import * as Ref from "effect/Ref"
 import * as Result from "effect/Result"
@@ -30,6 +31,47 @@ import type { ChangeFeed, ChangeFeedEvent, Repository } from "../service.ts"
 import { ValidationError, ValidationResult } from "../validation.ts"
 
 const dedupe = Array.dedupeWith(Equivalence.String)
+
+const schemaDurationBoundaries = [0.1, 0.5, 1, 2, 5, 10, 25, 50, 100, 250, 500, 1_000]
+const schemaDecodeDuration = Metric.histogram("app.schema.decode.duration", { boundaries: schemaDurationBoundaries })
+const schemaEncodeDuration = Metric.histogram("app.schema.encode.duration", { boundaries: schemaDurationBoundaries })
+const schemaItemCount = Metric.histogram("app.schema.item_count", {
+  boundaries: [0, 1, 2, 5, 10, 25, 50, 100, 250, 500, 1_000, 5_000]
+})
+
+const timeSchema = (
+  operation: "decode" | "encode",
+  entity: string,
+  queryMode: "aggregate" | "collect" | "project" | "transform" | undefined,
+  itemCount: number
+) =>
+<A, E, R>(self: Effect.Effect<A, E, R>): Effect.Effect<A, E, R> =>
+  Effect.clockWith((clock) => {
+    const startedAt = clock.currentTimeNanosUnsafe()
+    const attributes = {
+      "app.entity": entity,
+      "app.schema.operation": operation,
+      ...(queryMode !== undefined && { "app.query.mode": queryMode })
+    }
+    return Effect.onExit(self, () => {
+      const durationMs = Number(clock.currentTimeNanosUnsafe() - startedAt) / 1_000_000
+      return Effect.all([
+        Effect.annotateCurrentSpan({
+          [`app.schema.${operation}.duration_ms`]: durationMs,
+          "app.schema.item_count": itemCount,
+          ...(queryMode !== undefined && { "app.query.mode": queryMode })
+        }),
+        Metric.update(
+          Metric.withAttributes(
+            operation === "decode" ? schemaDecodeDuration : schemaEncodeDuration,
+            attributes
+          ),
+          durationMs
+        ),
+        Metric.update(Metric.withAttributes(schemaItemCount, attributes), itemCount)
+      ], { discard: true })
+    })
+  })
 
 /**
  * A base implementation to create a repository.
@@ -89,11 +131,11 @@ export function makeRepoInternal<
         .gen(function*() {
           const rctx: Context.Context<RCtx> = args.schemaContext ?? Context.empty() as any
           const provideRctx = Effect.provide(rctx)
-          const encodeMany = flow(
-            S.encodeEffect(S.Array(schema)),
-            provideRctx,
-            Effect.withSpan("encodeMany", { attributes: { "app.entity": name } }, { captureStackTrace: false })
-          )
+          const encodeMany = (items: readonly T[]) =>
+            S.encodeEffect(S.Array(schema))(items).pipe(
+              provideRctx,
+              timeSchema("encode", name, undefined, items.length)
+            )
           const decode = flow(S.decodeEffectConcurrently(schema), provideRctx)
           const decodeMany = flow(
             S.decodeEffectConcurrently(S.Array(schema)),
@@ -163,7 +205,11 @@ export function makeRepoInternal<
           const all = Effect
             .flatMap(
               allE,
-              (_) => decodeMany(_).pipe(Effect.orDie)
+              (items) =>
+                decodeMany(items).pipe(
+                  Effect.orDie,
+                  timeSchema("decode", name, undefined, items.length)
+                )
             )
             .pipe(
               Effect.tap(() => recordRead),
@@ -331,12 +377,13 @@ export function makeRepoInternal<
             }
           )
 
-          const parseMany = Effect.fn("parseMany", {
-            attributes: { "app.entity": name, "app.query.mode": "transform" }
-          })(
+          const parseMany = Effect.fnUntraced(
             function*(items: readonly PM[]) {
               const cm = yield* cms
-              return yield* decodeMany(items.map((_) => mapReverse(_, cm.set))).pipe(Effect.orDie)
+              return yield* decodeMany(items.map((_) => mapReverse(_, cm.set))).pipe(
+                Effect.orDie,
+                timeSchema("decode", name, "transform", items.length)
+              )
             }
           )
           const decodeManyCache = new WeakMap<
@@ -351,12 +398,13 @@ export function makeRepoInternal<
             }
             return dec
           }
-          const parseMany2 = Effect.fn("parseMany", {
-            attributes: { "app.entity": name, "app.query.mode": "transform" }
-          })(
+          const parseMany2 = Effect.fnUntraced(
             function*<A, R>(items: readonly PM[], schema: S.Codec<A, Encoded, R>) {
               const cm = yield* cms
-              return yield* getDecodeMany(schema)(items.map((_) => mapReverse(_, cm.set))).pipe(Effect.orDie)
+              return yield* getDecodeMany(schema)(items.map((_) => mapReverse(_, cm.set))).pipe(
+                Effect.orDie,
+                timeSchema("decode", name, "transform", items.length)
+              )
             }
           )
           const filter = <U extends keyof Encoded = keyof Encoded>(args: FilterArgs<Encoded, U>) =>
@@ -399,13 +447,11 @@ export function makeRepoInternal<
                 // Decode raw aggregate rows directly — no PM reverse-mapping, no id/_etag needed.
                 .pipe(
                   Effect.andThen(
-                    flow(
-                      S.decodeEffectConcurrently(S.Array(a.schema ?? schema)),
-                      provideRctx,
-                      Effect.withSpan("parseMany", {
-                        attributes: { "app.entity": name, "app.query.mode": "aggregate" }
-                      })
-                    )
+                    (items) =>
+                      S.decodeEffectConcurrently(S.Array(a.schema ?? schema))(items).pipe(
+                        provideRctx,
+                        timeSchema("decode", name, "aggregate", items.length)
+                      )
                   )
                 )
               : a.mode === "project"
@@ -413,27 +459,24 @@ export function makeRepoInternal<
                 // TODO: mapFrom but need to support per field and dependencies
                 .pipe(
                   Effect.andThen(
-                    flow(
-                      S.decodeEffectConcurrently(S.Array(a.schema ?? schema)),
-                      provideRctx,
-                      Effect.withSpan("parseMany", {
-                        attributes: { "app.entity": name, "app.query.mode": "project" }
-                      })
-                    )
+                    (items) =>
+                      S.decodeEffectConcurrently(S.Array(a.schema ?? schema))(items).pipe(
+                        provideRctx,
+                        timeSchema("decode", name, "project", items.length)
+                      )
                   )
                 )
               : a.mode === "collect"
               ? filter(a)
                 // TODO: mapFrom but need to support per field and dependencies
                 .pipe(
-                  Effect.flatMap(flow(
-                    S.decodeEffectConcurrently(S.Array(a.schema)),
-                    Effect.map(Array.getSomes),
-                    provideRctx,
-                    Effect.withSpan("parseMany", {
-                      attributes: { "app.entity": name, "app.query.mode": "collect" }
-                    })
-                  ))
+                  Effect.flatMap((items) =>
+                    S.decodeEffectConcurrently(S.Array(a.schema))(items).pipe(
+                      Effect.map(Array.getSomes),
+                      provideRctx,
+                      timeSchema("decode", name, "collect", items.length)
+                    )
+                  )
                 )
               : Effect.flatMap(
                 filter(a),
@@ -559,9 +602,12 @@ export function makeRepoInternal<
             seedNamespace: (namespace: string) => store.seedNamespace(namespace),
             validateSample,
             queryRaw<A, Out, QR>(schema: S.Codec<A, Out, QR>, q: Q.RawQuery<Encoded, Out>) {
-              const dec = S.decodeEffectConcurrently(S.Array(schema))
               return store.queryRaw(q).pipe(
-                Effect.flatMap(dec),
+                Effect.flatMap((items) =>
+                  S.decodeEffectConcurrently(S.Array(schema))(items).pipe(
+                    timeSchema("decode", name, undefined, items.length)
+                  )
+                ),
                 Effect.tap(() => recordRead),
                 Effect.withSpan("Repository.queryRaw", {
                   kind: "client",
@@ -583,7 +629,11 @@ export function makeRepoInternal<
               const spanAttrs = { kind: "client" as const, attributes: { "app.entity": name } }
               return {
                 all: allE.pipe(
-                  Effect.flatMap(decMany),
+                  Effect.flatMap((items) =>
+                    decMany(items).pipe(
+                      timeSchema("decode", name, undefined, items.length)
+                    )
+                  ),
                   Effect.tap(() => recordRead),
                   Effect.map((_) => _ as any[]),
                   Effect.withSpan("Repository.mapped.all", spanAttrs, { captureStackTrace: false })
@@ -613,10 +663,15 @@ export function makeRepoInternal<
                 //     )
                 // },
                 save: (...xes: any[]) =>
-                  Effect.flatMap(encMany(xes), (_) => saveAllE(_)).pipe(
-                    Effect.tap(() => recordWrite),
-                    Effect.withSpan("Repository.mapped.save", spanAttrs, { captureStackTrace: false })
-                  )
+                  Effect
+                    .flatMap(
+                      encMany(xes).pipe(timeSchema("encode", name, undefined, xes.length)),
+                      (_) => saveAllE(_)
+                    )
+                    .pipe(
+                      Effect.tap(() => recordWrite),
+                      Effect.withSpan("Repository.mapped.save", spanAttrs, { captureStackTrace: false })
+                    )
               }
             }
           }

--- a/packages/infra/src/otel.ts
+++ b/packages/infra/src/otel.ts
@@ -10,6 +10,7 @@
  */
 
 import * as Effect from "effect-app/Effect"
+import * as Metric from "effect/Metric"
 
 export type DbSystem =
   | "postgresql"
@@ -47,6 +48,30 @@ const dbAttributes = (a: DbSpanOptions): Record<string, unknown> => ({
   ...a.extra
 })
 
+const dbOperationDuration = Metric.histogram("db.client.operation.duration", {
+  boundaries: [0.1, 0.5, 1, 2, 5, 10, 25, 50, 100, 250, 500, 1_000, 2_500, 5_000, 10_000],
+  description: "Caller-observed database operation duration in milliseconds"
+})
+
+const timeDbOperation = (a: DbSpanOptions) => <A, E, R>(self: Effect.Effect<A, E, R>): Effect.Effect<A, E, R> =>
+  Effect.clockWith((clock) => {
+    const startedAt = clock.currentTimeNanosUnsafe()
+    return Effect.onExit(self, () => {
+      const durationMs = Number(clock.currentTimeNanosUnsafe() - startedAt) / 1_000_000
+      return Effect.all([
+        Effect.annotateCurrentSpan({ "db.operation.duration_ms": durationMs }),
+        Metric.update(
+          Metric.withAttributes(dbOperationDuration, {
+            "db.system.name": a.system,
+            "db.operation.name": a.operation,
+            ...(a.entity !== undefined && { "app.entity": a.entity })
+          }),
+          durationMs
+        )
+      ], { discard: true })
+    })
+  })
+
 /**
  * Wrap an effect with an OTel-semconv database span.
  *
@@ -68,7 +93,7 @@ export const withDbSpan = (a: DbSpanOptions) =>
  * No-op if there is no current span.
  */
 export const annotateDb = (a: DbSpanOptions) => <A, E, R>(self: Effect.Effect<A, E, R>): Effect.Effect<A, E, R> =>
-  Effect.flatMap(Effect.annotateCurrentSpan(dbAttributes(a)), () => self)
+  Effect.flatMap(Effect.annotateCurrentSpan(dbAttributes(a)), () => self.pipe(timeDbOperation(a)))
 
 /** Annotate the current span with response metrics from a DB call. */
 export const annotateDbResponse = (m: {

--- a/packages/infra/test/repository-ext.test.ts
+++ b/packages/infra/test/repository-ext.test.ts
@@ -8,6 +8,7 @@ import { RepositoryRegistryLive } from "effect-app/Model/Repository/Registry"
 import * as S from "effect-app/Schema"
 import { setupRequestContextFromCurrent } from "effect-app/setupRequest"
 import * as Ref from "effect/Ref"
+import * as Tracer from "effect/Tracer"
 import { MemoryStoreLive } from "../src/Store/Memory.js"
 
 class BatchItem extends S.Class<BatchItem>("BatchItem")({
@@ -170,6 +171,43 @@ describe("repository ext save/remove batching", () => {
 
         expect(yield* Ref.get(readsRef)).toEqual(new Set([DataDependencies.repo("DependencyItem")]))
         expect(yield* Ref.get(writesRef)).toEqual(new Set([DataDependencies.repo("DependencyItem")]))
+      })
+      .pipe(
+        setupRequestContextFromCurrent(),
+        Effect.provide(TestStoreLive)
+      ))
+
+  it.effect("records schema timing on repository spans without codec child spans", () =>
+    Effect
+      .gen(function*() {
+        const spans: Tracer.NativeSpan[] = []
+        const tracer = Tracer.make({
+          span(options) {
+            const span = new Tracer.NativeSpan(options)
+            spans.push(span)
+            return span
+          }
+        })
+
+        yield* Effect
+          .gen(function*() {
+            const repo = yield* makeRepo("TelemetryItem", BatchItem, {})
+            yield* repo.save(new BatchItem({ id: "1", label: "one" }))
+            yield* repo.all
+          })
+          .pipe(Effect.provideService(Tracer.Tracer, tracer))
+
+        expect(spans.map((_) => _.name)).not.toContain("parseMany")
+        expect(spans.map((_) => _.name)).not.toContain("encodeMany")
+
+        const saveSpan = spans.find((_) => _.name === "Repository.saveAndPublish")
+        const allSpan = spans.find((_) => _.name === "Repository.all")
+        expect(saveSpan?.attributes.get("app.schema.encode.duration_ms")).toEqual(expect.any(Number))
+        expect(saveSpan?.attributes.get("app.schema.item_count")).toBe(1)
+        expect(saveSpan?.attributes.get("db.operation.duration_ms")).toEqual(expect.any(Number))
+        expect(allSpan?.attributes.get("app.schema.decode.duration_ms")).toEqual(expect.any(Number))
+        expect(allSpan?.attributes.get("app.schema.item_count")).toBe(1)
+        expect(allSpan?.attributes.get("db.operation.duration_ms")).toEqual(expect.any(Number))
       })
       .pipe(
         setupRequestContextFromCurrent(),


### PR DESCRIPTION
## Summary

- replace `parseMany` and `encodeMany` child spans with monotonic parent-span schema timing attributes
- record bounded schema duration/item-count and database operation duration histograms
- time database adapter operations at the existing `annotateDb` boundary, preserving DB semantic-convention attributes
- cover all, query modes, raw queries, and mapped repository array codecs

## Validation

- `pnpm lint-fix`
- `pnpm check`
- `pnpm --filter effect-app test:run` (183 passed)
- `pnpm --filter @effect-app/infra test:run` (228 passed, 26 Cosmos environment-gated tests skipped)

## Notes

- Shipping path: shared `effect-app` / `@effect-app/infra` release via included changeset.
- Flow doc updated: ❌ (internal observability only)
- E2E coverage: internal-only
- Design angles: preserve repository phase visibility while reducing spans; numeric phase fields are the pragmatic implementation and a structured complete phase breakdown remains the greenfield direction.

Jira: SA-401

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/effect-app/codesmith/libs/pr/831"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788344595&installation_model_id=428864&pr_number=831&repository=effect-app%2Flibs&return_to=https%3A%2F%2Fgithub.com%2Feffect-app%2Flibs%2Fpull%2F831&signature=1d3af8a41beb25d4626775df4950194631b54ce7613bfaad5be3c0dcdae6cba0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->